### PR TITLE
Refactor text measure to measure actual bounding box

### DIFF
--- a/SixLabors.Fonts.sln
+++ b/SixLabors.Fonts.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{C317F1B1-D75E-4C6D-83EB-80367343E0D7}"
 	ProjectSection(SolutionItems) = preProject
@@ -15,17 +15,18 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{9E574A07-F879-4811-9C41-5CBDC6BAFDB7}"
 	ProjectSection(SolutionItems) = preProject
 		src\Shared\AssemblyInfo.Common.cs = src\Shared\AssemblyInfo.Common.cs
+		stylecop.json = stylecop.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SixLabors.Fonts", "src\SixLabors.Fonts\SixLabors.Fonts.csproj", "{09E744EC-4852-4FC7-BE78-C1B399F17967}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SixLabors.Fonts", "src\SixLabors.Fonts\SixLabors.Fonts.csproj", "{09E744EC-4852-4FC7-BE78-C1B399F17967}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SixLabors.Fonts.Tests", "tests\SixLabors.Fonts.Tests\SixLabors.Fonts.Tests.csproj", "{F836E8E6-B4D9-4208-8346-140C74678B91}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SixLabors.Fonts.Tests", "tests\SixLabors.Fonts.Tests\SixLabors.Fonts.Tests.csproj", "{F836E8E6-B4D9-4208-8346-140C74678B91}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{71A3911C-D6B9-4EBE-9691-2FE28BDF462E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DrawWithImageSharp", "samples\DrawWithImageSharp\DrawWithImageSharp.csproj", "{999EDFB3-9FE4-4E09-B669-CB02E597EC20}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrawWithImageSharp", "samples\DrawWithImageSharp\DrawWithImageSharp.csproj", "{999EDFB3-9FE4-4E09-B669-CB02E597EC20}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ListFonts", "samples\ListFonts\ListFonts.csproj", "{6DF4C474-1FDF-4DE0-9CB2-9674D2CCE1BA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ListFonts", "samples\ListFonts\ListFonts.csproj", "{6DF4C474-1FDF-4DE0-9CB2-9674D2CCE1BA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/samples/DrawWithImageSharp/BoundingBoxes.cs
+++ b/samples/DrawWithImageSharp/BoundingBoxes.cs
@@ -1,0 +1,36 @@
+﻿using ImageSharp;
+using ImageSharp.Drawing;
+using SixLabors.Fonts;
+using SixLabors.Fonts.DrawWithImageSharp;
+using SixLabors.Primitives;
+using SixLabors.Shapes.Temp;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+
+namespace DrawWithImageSharp
+{
+    public static class BoundingBoxes
+    {
+
+        public static void Generate(string text, Font font)
+        {
+            using (var img = new Image<Rgba32>(1000, 1000))
+            {
+                img.Fill(Rgba32.White);
+
+                var box = TextMeasurer.Measure(text, new RendererOptions(font));
+                var data = TextBuilder.GenerateGlyphsWithBox(text, new RendererOptions(font));
+
+                var f = Rgba32.Fuchsia;
+                f.A = 128;
+                img.Fill(Rgba32.Black, data.paths);
+                img.Draw(f, 1, data.boxes);
+                img.Draw(Rgba32.Lime, 1, new SixLabors.Shapes.RectangularePolygon(box));
+
+                img.Save("Output/Boxed.png");
+            }
+        }
+    }
+}

--- a/samples/DrawWithImageSharp/BoundingBoxes.cs
+++ b/samples/DrawWithImageSharp/BoundingBoxes.cs
@@ -1,13 +1,6 @@
 ﻿using ImageSharp;
-using ImageSharp.Drawing;
 using SixLabors.Fonts;
-using SixLabors.Fonts.DrawWithImageSharp;
-using SixLabors.Primitives;
 using SixLabors.Shapes.Temp;
-using System;
-using System.Collections.Generic;
-using System.Numerics;
-using System.Text;
 
 namespace DrawWithImageSharp
 {

--- a/samples/DrawWithImageSharp/BoundingBoxes.cs
+++ b/samples/DrawWithImageSharp/BoundingBoxes.cs
@@ -20,7 +20,7 @@ namespace DrawWithImageSharp
             {
                 img.Fill(Rgba32.White);
 
-                var box = TextMeasurer.Measure(text, new RendererOptions(font));
+                var box = TextMeasurer.MeasureBounds(text, new RendererOptions(font));
                 var data = TextBuilder.GenerateGlyphsWithBox(text, new RendererOptions(font));
 
                 var f = Rgba32.Fuchsia;

--- a/samples/DrawWithImageSharp/BoundingBoxes.cs
+++ b/samples/DrawWithImageSharp/BoundingBoxes.cs
@@ -13,7 +13,6 @@ namespace DrawWithImageSharp
 {
     public static class BoundingBoxes
     {
-
         public static void Generate(string text, Font font)
         {
             using (var img = new Image<Rgba32>(1000, 1000))

--- a/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
+++ b/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
@@ -15,8 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ImageSharp" Version="1.0.0-alpha9-00139" />
-    <PackageReference Include="ImageSharp.Drawing" Version="1.0.0-alpha9-00134" />
+    <PackageReference Include="ImageSharp" Version="1.0.0-alpha9-00152" />
+    <PackageReference Include="ImageSharp.Drawing" Version="1.0.0-alpha9-00147" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0-preview2-25405-01" />
   </ItemGroup>
 
 </Project>

--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -23,61 +23,65 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             FontFamily carter = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Carter_One\CarterOne.ttf");
             FontFamily Wendy_One = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Wendy_One\WendyOne-Regular.ttf");
 
-            RenderText(font, "abc", 72);
-            RenderText(font, "ABd", 72);
-            RenderText(fontWoff, "abe", 72);
-            RenderText(fontWoff, "ABf", 72);
-            RenderText(font2, "ov", 72);
-            RenderText(font2, "a\ta", 72);
-            RenderText(font2, "aa\ta", 72);
-            RenderText(font2, "aaa\ta", 72);
-            RenderText(font2, "aaaa\ta", 72);
-            RenderText(font2, "aaaaa\ta", 72);
-            RenderText(font2, "aaaaaa\ta", 72);
-            RenderText(font2, "Hello\nWorld", 72);
-            RenderText(carter, "Hello\0World", 72);
-            RenderText(Wendy_One, "Hello\0World", 72);
+            //RenderText(font, "abc", 72);
+            //RenderText(font, "ABd", 72);
+            //RenderText(fontWoff, "abe", 72);
+            //RenderText(fontWoff, "ABf", 72);
+            //RenderText(font2, "ov", 72);
+            //RenderText(font2, "a\ta", 72);
+            //RenderText(font2, "aa\ta", 72);
+            //RenderText(font2, "aaa\ta", 72);
+            //RenderText(font2, "aaaa\ta", 72);
+            //RenderText(font2, "aaaaa\ta", 72);
+            //RenderText(font2, "aaaaaa\ta", 72);
+            //RenderText(font2, "Hello\nWorld", 72);
+            //RenderText(carter, "Hello\0World", 72);
+            //RenderText(Wendy_One, "Hello\0World", 72);
 
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\tx");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\tx");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\t\tx");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\t\t\tx");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\tx");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\tx");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\t\tx");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\t\t\tx");
 
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 0 }, "Zero\tTab");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 0 }, "Zero\tTab");
 
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 0 }, "Zero\tTab");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "One\tTab");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 6 }, "\tTab Then Words");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Tab Then Words");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Words Then Tab\t");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "                 Spaces Then Words");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Words Then Spaces                 ");
-            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 0 }, "Zero\tTab");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "One\tTab");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 6 }, "\tTab Then Words");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Tab Then Words");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Words Then Tab\t");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "                 Spaces Then Words");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Words Then Spaces                 ");
+            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs");
 
-            RenderText(new Font(SystemFonts.Find("Arial"), 20f, FontStyle.Regular), "á é í ó ú ç ã õ", 200, 50);
-            RenderText(new Font(SystemFonts.Find("Arial"), 10f, FontStyle.Regular), "PGEP0JK867", 200, 50);
+            //RenderText(new Font(SystemFonts.Find("Arial"), 20f, FontStyle.Regular), "á é í ó ú ç ã õ", 200, 50);
+            //RenderText(new Font(SystemFonts.Find("Arial"), 10f, FontStyle.Regular), "PGEP0JK867", 200, 50);
+
+            RenderText(new RendererOptions(SystemFonts.CreateFont("consolas", 72)) { TabWidth = 4 }, "xxxxxxxxxxxxxxxx\n\txxxx\txxxx\n\t\txxxxxxxx\n\t\t\txxxx");
+
+            BoundingBoxes.Generate("a b c y q G H T", SystemFonts.CreateFont("arial", 40f));
 
             TextAlignment.Generate(new Font(font2, 50));
 
-            StringBuilder sb = new StringBuilder();
-            for (char c = 'a'; c <= 'z'; c++)
-            {
-                sb.Append(c);
-            }
-            for (char c = 'A'; c <= 'Z'; c++)
-            {
-                sb.Append(c);
-            }
-            for (char c = '0'; c <= '9'; c++)
-            {
-                sb.Append(c);
-            }
-            string text = sb.ToString();
+            //StringBuilder sb = new StringBuilder();
+            //for (char c = 'a'; c <= 'z'; c++)
+            //{
+            //    sb.Append(c);
+            //}
+            //for (char c = 'A'; c <= 'Z'; c++)
+            //{
+            //    sb.Append(c);
+            //}
+            //for (char c = '0'; c <= '9'; c++)
+            //{
+            //    sb.Append(c);
+            //}
+            //string text = sb.ToString();
 
-            foreach (FontFamily f in fonts.Families)
-            {
-                RenderText(f, text, 72);
-            }
+            //foreach (FontFamily f in fonts.Families)
+            //{
+            //    RenderText(f, text, 72);
+            //}
         }
 
 
@@ -101,6 +105,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                 }
             }
         }
+
         public static void RenderText(RendererOptions font, string text)
         {
             GlyphBuilder builder = new GlyphBuilder();
@@ -149,7 +154,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                     .Translate(new Vector2(10)); // move in from top left
 
             StringBuilder sb = new StringBuilder();
-            System.Collections.Immutable.ImmutableArray<ISimplePath> converted = shape.Flatten();
+            var converted = shape.Flatten();
             converted.Aggregate(sb, (s, p) =>
             {
                 foreach (Vector2 point in p.Points)

--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -16,46 +16,46 @@ namespace SixLabors.Fonts.DrawWithImageSharp
     {
         public static void Main(string[] args)
         {
-            //FontCollection fonts = new FontCollection();
-            //FontFamily font = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.ttf");
-            //FontFamily fontWoff = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.woff");
-            //FontFamily font2 = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\OpenSans-Regular.ttf");
-            //FontFamily carter = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Carter_One\CarterOne.ttf");
-            //FontFamily Wendy_One = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Wendy_One\WendyOne-Regular.ttf");
+            FontCollection fonts = new FontCollection();
+            FontFamily font = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.ttf");
+            FontFamily fontWoff = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.woff");
+            FontFamily font2 = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\OpenSans-Regular.ttf");
+            FontFamily carter = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Carter_One\CarterOne.ttf");
+            FontFamily Wendy_One = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Wendy_One\WendyOne-Regular.ttf");
 
-            //RenderText(font, "abc", 72);
-            //RenderText(font, "ABd", 72);
-            //RenderText(fontWoff, "abe", 72);
-            //RenderText(fontWoff, "ABf", 72);
-            //RenderText(font2, "ov", 72);
-            //RenderText(font2, "a\ta", 72);
-            //RenderText(font2, "aa\ta", 72);
-            //RenderText(font2, "aaa\ta", 72);
-            //RenderText(font2, "aaaa\ta", 72);
-            //RenderText(font2, "aaaaa\ta", 72);
-            //RenderText(font2, "aaaaaa\ta", 72);
-            //RenderText(font2, "Hello\nWorld", 72);
-            //RenderText(carter, "Hello\0World", 72);
-            //RenderText(Wendy_One, "Hello\0World", 72);
+            RenderText(font, "abc", 72);
+            RenderText(font, "ABd", 72);
+            RenderText(fontWoff, "abe", 72);
+            RenderText(fontWoff, "ABf", 72);
+            RenderText(font2, "ov", 72);
+            RenderText(font2, "a\ta", 72);
+            RenderText(font2, "aa\ta", 72);
+            RenderText(font2, "aaa\ta", 72);
+            RenderText(font2, "aaaa\ta", 72);
+            RenderText(font2, "aaaaa\ta", 72);
+            RenderText(font2, "aaaaaa\ta", 72);
+            RenderText(font2, "Hello\nWorld", 72);
+            RenderText(carter, "Hello\0World", 72);
+            RenderText(Wendy_One, "Hello\0World", 72);
 
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\tx");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\tx");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\t\tx");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\t\t\tx");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\tx");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\tx");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\t\tx");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\t\t\tx");
 
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 0 }, "Zero\tTab");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 0 }, "Zero\tTab");
 
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 0 }, "Zero\tTab");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "One\tTab");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 6 }, "\tTab Then Words");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Tab Then Words");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Words Then Tab\t");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "                 Spaces Then Words");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Words Then Spaces                 ");
-            //RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 0 }, "Zero\tTab");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "One\tTab");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 6 }, "\tTab Then Words");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Tab Then Words");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Words Then Tab\t");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "                 Spaces Then Words");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "Words Then Spaces                 ");
+            RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 1 }, "\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs");
 
-            //RenderText(new Font(SystemFonts.Find("Arial"), 20f, FontStyle.Regular), "á é í ó ú ç ã õ", 200, 50);
-            //RenderText(new Font(SystemFonts.Find("Arial"), 10f, FontStyle.Regular), "PGEP0JK867", 200, 50);
+            RenderText(new Font(SystemFonts.Find("Arial"), 20f, FontStyle.Regular), "á é í ó ú ç ã õ", 200, 50);
+            RenderText(new Font(SystemFonts.Find("Arial"), 10f, FontStyle.Regular), "PGEP0JK867", 200, 50);
 
             RenderText(new RendererOptions(SystemFonts.CreateFont("consolas", 72)) { TabWidth = 4 }, "xxxxxxxxxxxxxxxx\n\txxxx\txxxx\n\t\txxxxxxxx\n\t\t\txxxx");
 
@@ -63,25 +63,25 @@ namespace SixLabors.Fonts.DrawWithImageSharp
 
             TextAlignment.Generate(SystemFonts.CreateFont("arial", 50f));
 
-            //StringBuilder sb = new StringBuilder();
-            //for (char c = 'a'; c <= 'z'; c++)
-            //{
-            //    sb.Append(c);
-            //}
-            //for (char c = 'A'; c <= 'Z'; c++)
-            //{
-            //    sb.Append(c);
-            //}
-            //for (char c = '0'; c <= '9'; c++)
-            //{
-            //    sb.Append(c);
-            //}
-            //string text = sb.ToString();
+            StringBuilder sb = new StringBuilder();
+            for (char c = 'a'; c <= 'z'; c++)
+            {
+                sb.Append(c);
+            }
+            for (char c = 'A'; c <= 'Z'; c++)
+            {
+                sb.Append(c);
+            }
+            for (char c = '0'; c <= '9'; c++)
+            {
+                sb.Append(c);
+            }
+            string text = sb.ToString();
 
-            //foreach (FontFamily f in fonts.Families)
-            //{
-            //    RenderText(f, text, 72);
-            //}
+            foreach (FontFamily f in fonts.Families)
+            {
+                RenderText(f, text, 72);
+            }
         }
 
 

--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -1,5 +1,4 @@
 ﻿using ImageSharp;
-using System;
 using System.IO;
 
 namespace SixLabors.Fonts.DrawWithImageSharp

--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -16,12 +16,12 @@ namespace SixLabors.Fonts.DrawWithImageSharp
     {
         public static void Main(string[] args)
         {
-            FontCollection fonts = new FontCollection();
-            FontFamily font = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.ttf");
-            FontFamily fontWoff = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.woff");
-            FontFamily font2 = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\OpenSans-Regular.ttf");
-            FontFamily carter = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Carter_One\CarterOne.ttf");
-            FontFamily Wendy_One = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Wendy_One\WendyOne-Regular.ttf");
+            //FontCollection fonts = new FontCollection();
+            //FontFamily font = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.ttf");
+            //FontFamily fontWoff = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.woff");
+            //FontFamily font2 = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\OpenSans-Regular.ttf");
+            //FontFamily carter = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Carter_One\CarterOne.ttf");
+            //FontFamily Wendy_One = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Wendy_One\WendyOne-Regular.ttf");
 
             //RenderText(font, "abc", 72);
             //RenderText(font, "ABd", 72);
@@ -61,7 +61,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
 
             BoundingBoxes.Generate("a b c y q G H T", SystemFonts.CreateFont("arial", 40f));
 
-            TextAlignment.Generate(new Font(font2, 50));
+            TextAlignment.Generate(SystemFonts.CreateFont("arial", 50f));
 
             //StringBuilder sb = new StringBuilder();
             //for (char c = 'a'; c <= 'z'; c++)

--- a/samples/DrawWithImageSharp/TextAlignment.cs
+++ b/samples/DrawWithImageSharp/TextAlignment.cs
@@ -2,6 +2,7 @@
 using ImageSharp.Drawing;
 using SixLabors.Fonts;
 using SixLabors.Fonts.DrawWithImageSharp;
+using SixLabors.Primitives;
 using SixLabors.Shapes.Temp;
 using System;
 using System.Collections.Generic;
@@ -64,11 +65,11 @@ namespace DrawWithImageSharp
                     break;
             }
 
-            GlyphBuilder glyphBuilder = new GlyphBuilder(location);
+            GlyphBuilder glyphBuilder = new GlyphBuilder();
 
             TextRenderer renderer = new TextRenderer(glyphBuilder);
             
-            RendererOptions style = new RendererOptions(font, 72)
+            RendererOptions style = new RendererOptions(font, 72, location)
             {
                 ApplyKerning = true,
                 TabWidth = 4,
@@ -77,14 +78,18 @@ namespace DrawWithImageSharp
                 VerticalAlignment = vert
             };
 
-            string text = $"{horiz}\n{vert}";
+            string text = $"{horiz} x y z\n{vert} x y z";
             renderer.RenderText(text, style);
 
             System.Collections.Generic.IEnumerable<SixLabors.Shapes.IPath> shapesToDraw = glyphBuilder.Paths;
-            foreach (SixLabors.Shapes.IPath s in shapesToDraw)
-            {
-                img.Fill(Rgba32.Black, s);
-            }
+                img.Fill(Rgba32.Black, glyphBuilder.Paths);
+
+            var f = Rgba32.Fuchsia;
+            f.A = 128;
+            img.Fill(Rgba32.Black, glyphBuilder.Paths);
+            img.Draw(f, 1, glyphBuilder.Boxes);
+
+            img.Draw(Rgba32.Lime, 1, glyphBuilder.TextBox);
         }
     }
 }

--- a/samples/DrawWithImageSharp/TextAlignment.cs
+++ b/samples/DrawWithImageSharp/TextAlignment.cs
@@ -1,13 +1,8 @@
 ﻿using ImageSharp;
-using ImageSharp.Drawing;
 using SixLabors.Fonts;
-using SixLabors.Fonts.DrawWithImageSharp;
-using SixLabors.Primitives;
 using SixLabors.Shapes.Temp;
 using System;
-using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 
 namespace DrawWithImageSharp
 {

--- a/samples/DrawWithImageSharp/TextBuilder/BaseGlyphBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/BaseGlyphBuilder.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using SixLabors.Fonts;
 using SixLabors.Shapes;
 using SixLabors.Primitives;
+using System.Linq;
 
 namespace SixLabors.Shapes.Temp
 {
@@ -14,6 +15,7 @@ namespace SixLabors.Shapes.Temp
     internal class BaseGlyphBuilder : IGlyphRenderer
     {
         protected readonly PathBuilder builder = new PathBuilder();
+        private readonly List<RectangleF> glyphBounds = new List<RectangleF>();
         private readonly List<IPath> paths = new List<IPath>();
         private Vector2 currentPoint = default(Vector2);
 
@@ -31,12 +33,23 @@ namespace SixLabors.Shapes.Temp
         /// </summary>
         public IPathCollection Paths => new PathCollection(this.paths);
 
+        /// <summary>
+        /// Gets the paths that have been rendered by this.
+        /// </summary>
+        public IPathCollection Boxes => new PathCollection(this.glyphBounds.Select(x => new SixLabors.Shapes.RectangularePolygon(x)));
+
+        /// <summary>
+        /// Gets the paths that have been rendered by this.
+        /// </summary>
+        public IPath TextBox { get; private set; }
+
         void IGlyphRenderer.EndText()
         {
         }
 
         void IGlyphRenderer.BeginText(RectangleF rect)
         {
+            this.TextBox = new SixLabors.Shapes.RectangularePolygon(rect);
             BeginText(rect);
         }
 
@@ -52,6 +65,7 @@ namespace SixLabors.Shapes.Temp
         bool IGlyphRenderer.BeginGlyph(RectangleF rect, int cachKey)
         {
             this.builder.Clear();
+            this.glyphBounds.Add(rect);
             return BeginGlyph(rect, cachKey);
         }
 

--- a/samples/DrawWithImageSharp/TextBuilder/BaseGlyphBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/BaseGlyphBuilder.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Numerics;
 
 using SixLabors.Fonts;
-using SixLabors.Shapes;
 using SixLabors.Primitives;
 using System.Linq;
 

--- a/samples/DrawWithImageSharp/TextBuilder/GlyphBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/GlyphBuilder.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Numerics;
-
-using SixLabors.Fonts;
-using SixLabors.Shapes;
+﻿using System.Numerics;
 
 namespace SixLabors.Shapes.Temp
 {

--- a/samples/DrawWithImageSharp/TextBuilder/PathGlyphBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/PathGlyphBuilder.cs
@@ -39,11 +39,11 @@ namespace SixLabors.Shapes.Temp
         {
             var point = this.path.PointAlongPath(rect.X);
 
-            var targetPoint = point.Point + new Vector2(0, rect.Y - this.offsetY);
+            var targetPoint = point.Point + new PointF(0, rect.Y - this.offsetY);
 
             // due to how matrix combining works you have to combine thins in the revers order of operation
             // this one rotates the glype then moves it.
-            var matrix = Matrix3x2.CreateTranslation(targetPoint - (Vector2)rect.Location) * Matrix3x2.CreateRotation(point.Angle - Pi, point.Point);
+            var matrix = Matrix3x2.CreateTranslation(targetPoint - rect.Location) * Matrix3x2.CreateRotation(point.Angle - Pi, point.Point);
             this.builder.SetTransform(matrix);
         }
     }

--- a/samples/DrawWithImageSharp/TextBuilder/PathGlyphBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/PathGlyphBuilder.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Numerics;
-
-using SixLabors.Fonts;
-using SixLabors.Shapes;
 using SixLabors.Primitives;
 
 namespace SixLabors.Shapes.Temp

--- a/samples/DrawWithImageSharp/TextBuilder/TextBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/TextBuilder.cs
@@ -20,7 +20,7 @@ namespace SixLabors.Shapes.Temp
         /// <param name="location">The location</param>
         /// <param name="style">The style and settings to use while rendering the glyphs</param>
         /// <returns></returns>
-        public static IPathCollection GenerateGlyphs(string text, PointF location, RendererOptions style)
+        public static (IPathCollection paths, IPathCollection boxes, IPath textBox) GenerateGlyphsWithBox(string text, PointF location, RendererOptions style)
         {
             var glyphBuilder = new GlyphBuilder(location);
 
@@ -28,7 +28,19 @@ namespace SixLabors.Shapes.Temp
 
             renderer.RenderText(text, style);
 
-            return glyphBuilder.Paths;
+            return (glyphBuilder.Paths, glyphBuilder.Boxes, glyphBuilder.TextBox);
+        }
+
+        /// <summary>
+        /// Generates the shapes corresponding the glyphs described by the font and with the setting ing withing the FontSpan
+        /// </summary>
+        /// <param name="text">The text to generate glyphs for</param>
+        /// <param name="location">The location</param>
+        /// <param name="style">The style and settings to use while rendering the glyphs</param>
+        /// <returns></returns>
+        public static IPathCollection GenerateGlyphs(string text, PointF location, RendererOptions style)
+        {
+            return GenerateGlyphsWithBox(text, location, style).paths;
         }
 
         /// <summary>
@@ -40,6 +52,17 @@ namespace SixLabors.Shapes.Temp
         public static IPathCollection GenerateGlyphs(string text, RendererOptions style)
         {
             return GenerateGlyphs(text, PointF.Empty, style);
+        }
+
+        /// <summary>
+        /// Generates the shapes corresponding the glyphs described by the font and with the setting ing withing the FontSpan
+        /// </summary>
+        /// <param name="text">The text to generate glyphs for</param>
+        /// <param name="style">The style and settings to use while rendering the glyphs</param>
+        /// <returns></returns>
+        public static (IPathCollection paths, IPathCollection boxes, IPath textBox) GenerateGlyphsWithBox(string text, RendererOptions style)
+        {
+            return GenerateGlyphsWithBox(text, PointF.Empty, style);
         }
 
         /// <summary>

--- a/samples/DrawWithImageSharp/TextBuilder/TextBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/TextBuilder.cs
@@ -1,10 +1,5 @@
 ﻿using SixLabors.Fonts;
 using SixLabors.Primitives;
-using SixLabors.Shapes.Temp;
-using System;
-using System.Collections.Generic;
-using System.Numerics;
-using System.Text;
 
 namespace SixLabors.Shapes.Temp
 {

--- a/src/Shared/AssemblyInfo.Common.cs
+++ b/src/Shared/AssemblyInfo.Common.cs
@@ -1,7 +1,6 @@
-﻿// <copyright file="AssemblyInfo.Common.cs" company="Scott Williams">
-// Copyright (c) Scott Williams and contributors.
+﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
-// </copyright>
+
 using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
@@ -11,9 +10,9 @@ using System.Runtime.CompilerServices;
 // associated with an assembly.
 [assembly: AssemblyDescription("A cross-platform library for loading and laying out for processing and measuring; written in C#")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Scott Williams")]
+[assembly: AssemblyCompany("Six Labors")]
 [assembly: AssemblyProduct("SixLabors.Fonts")]
-[assembly: AssemblyCopyright("Copyright (c) Scott Williams and contributors.")]
+[assembly: AssemblyCopyright("Copyright (c) Six Labors and contributors.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/src/SixLabors.Fonts/BigEndianBitConverter.cs
+++ b/src/SixLabors.Fonts/BigEndianBitConverter.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
-using SixLabors.Fonts.Tables;
+using System;
+using System.Runtime.InteropServices;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/BinaryReader.cs
+++ b/src/SixLabors.Fonts/BinaryReader.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.IO;
 using System.Text;
@@ -535,32 +538,32 @@ namespace SixLabors.Fonts
         }
 
         /// <summary>
-        /// Class to cast to type <typeparamref name="T"/>
+        /// Class to cast to type <typeparamref name="TTarget"/>
         /// </summary>
-        /// <typeparam name="T">Target type</typeparam>
-        private static class CastTo<T>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        private static class CastTo<TTarget>
         {
             /// <summary>
-            /// Casts <typeparamref name="S" /> to <typeparamref name="T" />.
+            /// Casts <typeparamref name="TSource" /> to <typeparamref name="TTarget" />.
             /// This does not cause boxing for value types.
             /// Useful in generic methods.
             /// </summary>
-            /// <typeparam name="S">Source type to cast from. Usually a generic type.</typeparam>
+            /// <typeparam name="TSource">Source type to cast from. Usually a generic type.</typeparam>
             /// <param name="s">The s.</param>
-            public static T From<S>(S s)
+            public static TTarget From<TSource>(TSource s)
             {
-                return Cache<S>.Caster(s);
+                return Cache<TSource>.Caster(s);
             }
 
-            private static class Cache<S>
+            private static class Cache<TSource>
             {
-                public static readonly Func<S, T> Caster = Get();
+                public static readonly Func<TSource, TTarget> Caster = Get();
 
-                private static Func<S, T> Get()
+                private static Func<TSource, TTarget> Get()
                 {
-                    System.Linq.Expressions.ParameterExpression p = System.Linq.Expressions.Expression.Parameter(typeof(S));
-                    System.Linq.Expressions.UnaryExpression c = System.Linq.Expressions.Expression.ConvertChecked(p, typeof(T));
-                    return System.Linq.Expressions.Expression.Lambda<Func<S, T>>(c, p).Compile();
+                    System.Linq.Expressions.ParameterExpression p = System.Linq.Expressions.Expression.Parameter(typeof(TSource));
+                    System.Linq.Expressions.UnaryExpression c = System.Linq.Expressions.Expression.ConvertChecked(p, typeof(TTarget));
+                    return System.Linq.Expressions.Expression.Lambda<Func<TSource, TTarget>>(c, p).Compile();
                 }
             }
         }

--- a/src/SixLabors.Fonts/BinaryReader.cs
+++ b/src/SixLabors.Fonts/BinaryReader.cs
@@ -245,10 +245,8 @@ namespace SixLabors.Fonts
         public byte[] ReadUInt8Array(int length)
         {
             byte[] data = new byte[length];
-            for (int i = 0; i < length; i++)
-            {
-                data[i] = this.ReadUInt8();
-            }
+
+            this.ReadInternal(data, length);
 
             return data;
         }

--- a/src/SixLabors.Fonts/Bounds.cs
+++ b/src/SixLabors.Fonts/Bounds.cs
@@ -1,9 +1,8 @@
-﻿using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Numerics;
-using System.Threading.Tasks;
+using SixLabors.Primitives;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/Exceptions/FontException.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontException.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 
 namespace SixLabors.Fonts.Exceptions

--- a/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
@@ -6,15 +6,18 @@ namespace SixLabors.Fonts.Exceptions
     /// Base class for exceptions thrown by this library.
     /// </summary>
     /// <seealso cref="System.Exception" />
-    public class FontFamilyNotFountException : FontException
+    public class FontFamilyNotFoundException : FontException
     {
+        /// <summary>
+        /// The name of the font familiy we failed to find.
+        /// </summary>
         public string FontFamily { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FontException"/> class.
         /// </summary>
-        /// <param name="message">The message that describes the error.</param>
-        public FontFamilyNotFountException(string family)
+        /// <param name="family">The name of the missing font family.</param>
+        public FontFamilyNotFoundException(string family)
             : base($"{family} could not be found")
         {
             this.FontFamily = family;

--- a/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
@@ -1,4 +1,5 @@
-using System;
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Exceptions
 {
@@ -9,12 +10,7 @@ namespace SixLabors.Fonts.Exceptions
     public class FontFamilyNotFoundException : FontException
     {
         /// <summary>
-        /// The name of the font familiy we failed to find.
-        /// </summary>
-        public string FontFamily { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FontException"/> class.
+        /// Initializes a new instance of the <see cref="FontFamilyNotFoundException"/> class.
         /// </summary>
         /// <param name="family">The name of the missing font family.</param>
         public FontFamilyNotFoundException(string family)
@@ -22,5 +18,10 @@ namespace SixLabors.Fonts.Exceptions
         {
             this.FontFamily = family;
         }
+
+        /// <summary>
+        /// Gets the name of the font familiy we failed to find.
+        /// </summary>
+        public string FontFamily { get; }
     }
 }

--- a/src/SixLabors.Fonts/Exceptions/InvalidFontFileException.cs
+++ b/src/SixLabors.Fonts/Exceptions/InvalidFontFileException.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 
 namespace SixLabors.Fonts.Exceptions

--- a/src/SixLabors.Fonts/Exceptions/InvalidFontTableException.cs
+++ b/src/SixLabors.Fonts/Exceptions/InvalidFontTableException.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Exceptions
 {
@@ -12,7 +10,7 @@ namespace SixLabors.Fonts.Exceptions
     public class InvalidFontTableException : InvalidFontFileException
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="InvalidFontFileException" /> class.
+        /// Initializes a new instance of the <see cref="InvalidFontTableException"/> class.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         /// <param name="table">The table.</param>

--- a/src/SixLabors.Fonts/FileFontInstance.cs
+++ b/src/SixLabors.Fonts/FileFontInstance.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.IO;
-using System.Numerics;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
-using SixLabors.Fonts.Tables;
-using SixLabors.Fonts.Tables.General;
+using System;
+using System.Numerics;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.IO;
-using System.Numerics;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
-using SixLabors.Fonts.Tables;
-using SixLabors.Fonts.Tables.General;
+using System;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -1,10 +1,12 @@
-﻿using SixLabors.Fonts.Exceptions;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
+using SixLabors.Fonts.Exceptions;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -62,7 +62,7 @@ namespace SixLabors.Fonts
         /// Finds the specified font family.
         /// </summary>
         /// <param name="fontFamily">The font family.</param>
-        /// <returns>The family if installed otherwise throws <see cref="FontFamilyNotFountException"/></returns>
+        /// <returns>The family if installed otherwise throws <see cref="FontFamilyNotFoundException"/></returns>
         public FontFamily Find(string fontFamily)
         {
             if (TryFind(fontFamily, out FontFamily result))
@@ -70,7 +70,7 @@ namespace SixLabors.Fonts
                 return result;
             }
 
-            throw new FontFamilyNotFountException(fontFamily);
+            throw new FontFamilyNotFoundException(fontFamily);
         }
 
         /// <summary>

--- a/src/SixLabors.Fonts/FontDescription.cs
+++ b/src/SixLabors.Fonts/FontDescription.cs
@@ -1,5 +1,7 @@
-﻿using System.IO;
-using SixLabors.Fonts.Tables;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.IO;
 using SixLabors.Fonts.Tables.General;
 
 namespace SixLabors.Fonts

--- a/src/SixLabors.Fonts/FontFamily.cs
+++ b/src/SixLabors.Fonts/FontFamily.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.IO;
-using System.Numerics;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
-using SixLabors.Fonts.Tables;
-using SixLabors.Fonts.Tables.General;
-using System.Linq;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/FontFamilyCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/FontFamilyCollectionExtensions.cs
@@ -14,7 +14,6 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Create a new instance of the <see cref="Font"/> for the named font family. 
         /// </summary>
-        /// <param name="collection">The the ont collection to retrieve the font family from.</param>
         /// <param name="fontFamily">The family.</param>
         /// <param name="size">The size.</param>
         /// <param name="style">The style.</param>
@@ -26,7 +25,6 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Create a new instance of the <see cref="Font"/> for the named font family with regular styling. 
         /// </summary>
-        /// <param name="collection">The the ont collection to retrieve the font family from.</param>
         /// <param name="fontFamily">The family.</param>
         /// <param name="size">The size.</param>
         public static Font CreateFont(this FontFamily fontFamily, float size)

--- a/src/SixLabors.Fonts/FontFamilyCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/FontFamilyCollectionExtensions.cs
@@ -1,8 +1,5 @@
-﻿using SixLabors.Fonts.Exceptions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/FontInstance.cs
+++ b/src/SixLabors.Fonts/FontInstance.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
 using System.Numerics;
-
-using SixLabors.Fonts.Tables;
 using SixLabors.Fonts.Tables.General;
 
 namespace SixLabors.Fonts
@@ -29,7 +29,7 @@ namespace SixLabors.Fonts
         public int LineHeight { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FontDescription" /> class.
+        /// Initializes a new instance of the <see cref="FontInstance"/> class.
         /// </summary>
         /// <param name="nameTable">The name table.</param>
         /// <param name="cmap">The cmap.</param>

--- a/src/SixLabors.Fonts/FontReader.cs
+++ b/src/SixLabors.Fonts/FontReader.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Collections.ObjectModel;
-using System.Globalization;
 using System.IO;
-using System.Linq;
 
 using SixLabors.Fonts.Tables;
 
@@ -122,7 +122,6 @@ namespace SixLabors.Fonts
 
             return null;
         }
-
 
         public virtual BinaryReader GetReaderAtTablePosition(string tableName)
         {

--- a/src/SixLabors.Fonts/FontStyle.cs
+++ b/src/SixLabors.Fonts/FontStyle.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -18,7 +18,7 @@ namespace SixLabors.Fonts
 
         public RectangleF BoundingBox(PointF location, Vector2 dpi)
         {
-            return instance.BoundingBox(location, pointSize, dpi);
+            return this.instance.BoundingBox(location, this.pointSize * dpi);
         }
 
         internal Glyph(GlyphInstance instance, float pointSize)

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -16,6 +16,11 @@ namespace SixLabors.Fonts
         private readonly GlyphInstance instance;
         private readonly float pointSize;
 
+        public RectangleF BoundingBox(PointF location, Vector2 dpi)
+        {
+            return instance.BoundingBox(location, pointSize, dpi);
+        }
+
         internal Glyph(GlyphInstance instance, float pointSize)
         {
             this.instance = instance;

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -1,10 +1,8 @@
-﻿using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Numerics;
-using System.Threading.Tasks;
+using SixLabors.Primitives;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -26,19 +26,19 @@ namespace SixLabors.Fonts
             this.instance = instance;
             this.pointSize = pointSize;
         }
-        
+
         /// <summary>
         /// Renders to.
         /// </summary>
         /// <param name="surface">The surface.</param>
         /// <param name="location">The location.</param>
         /// <param name="dpi">The dpi.</param>
-        /// <param name="offset">The offset.</param>
+        /// <param name="lineHeight">The line height.</param>
         internal void RenderTo(IGlyphRenderer surface, PointF location, float dpi, float lineHeight)
         {
             this.RenderTo(surface, location, dpi, dpi, lineHeight);
         }
-        
+
         /// <summary>
         /// Renders the glyph to the render surface in font units relative to a bottom left origin at (0,0)
         /// </summary>
@@ -46,7 +46,7 @@ namespace SixLabors.Fonts
         /// <param name="location">The location.</param>
         /// <param name="dpiX">The dpi.</param>
         /// <param name="dpiY">The dpi.</param>
-        /// <param name="offset">The offset.</param>
+        /// <param name="lineHeight">The line height.</param>
         /// <exception cref="System.NotSupportedException">Too many control points</exception>
         internal void RenderTo(IGlyphRenderer surface, PointF location, float dpiX, float dpiY, float lineHeight)
         {

--- a/src/SixLabors.Fonts/GlyphInstance.cs
+++ b/src/SixLabors.Fonts/GlyphInstance.cs
@@ -22,7 +22,7 @@ namespace SixLabors.Fonts
         private readonly float scaleFactor;
 
         internal GlyphInstance(Vector2[] controlPoints, bool[] onCurves, ushort[] endPoints, Bounds bounds, ushort advanceWidth, short leftSideBearing, ushort sizeOfEm, ushort index)
-         {
+        {
             this.sizeOfEm = sizeOfEm;
             this.controlPoints = controlPoints;
             this.onCurves = onCurves;
@@ -72,7 +72,7 @@ namespace SixLabors.Fonts
 
         internal RectangleF BoundingBox(Vector2 origin, Vector2 scaledPointSize)
         {
-            var size = ((this.Bounds.Size() * scaledPointSize) / this.scaleFactor) ;
+            var size = (this.Bounds.Size() * scaledPointSize) / this.scaleFactor;
             var loc = ((new Vector2(this.Bounds.Min.X, this.Bounds.Max.Y) * scaledPointSize) / this.scaleFactor) * scale;
 
             loc = origin + loc;

--- a/src/SixLabors.Fonts/GlyphInstance.cs
+++ b/src/SixLabors.Fonts/GlyphInstance.cs
@@ -1,11 +1,10 @@
-﻿using SixLabors.Primitives;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
+using SixLabors.Primitives;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/HashHelpers.cs
+++ b/src/SixLabors.Fonts/HashHelpers.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/HorizontalAlignment.cs
+++ b/src/SixLabors.Fonts/HorizontalAlignment.cs
@@ -1,4 +1,7 @@
-﻿namespace SixLabors.Fonts
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.Fonts
 {
     /// <summary>
     /// Horizontal alignment modes.

--- a/src/SixLabors.Fonts/IFontCollection.cs
+++ b/src/SixLabors.Fonts/IFontCollection.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/IFontInstance.cs
+++ b/src/SixLabors.Fonts/IFontInstance.cs
@@ -1,4 +1,7 @@
-﻿using System.Numerics;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Numerics;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/IGlyphRenderer.cs
+++ b/src/SixLabors.Fonts/IGlyphRenderer.cs
@@ -1,9 +1,7 @@
-﻿using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.Primitives;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/IGlyphRendererExtensions.cs
+++ b/src/SixLabors.Fonts/IGlyphRendererExtensions.cs
@@ -1,9 +1,5 @@
-﻿using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/IO/ZlibInflateStream.cs
+++ b/src/SixLabors.Fonts/IO/ZlibInflateStream.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts.IO
 {

--- a/src/SixLabors.Fonts/IReadonlyFontCollection.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontCollection.cs
@@ -1,8 +1,8 @@
-﻿using SixLabors.Fonts.Exceptions;
-using System;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using SixLabors.Fonts.Exceptions;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/IReadonlyFontCollection.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontCollection.cs
@@ -23,7 +23,7 @@ namespace SixLabors.Fonts
         /// Finds the specified font family.
         /// </summary>
         /// <param name="fontFamily">The font family.</param>
-        /// <returns>The family if installed otherwise throws <see cref="FontFamilyNotFountException"/></returns>
+        /// <returns>The family if installed otherwise throws <see cref="FontFamilyNotFoundException"/></returns>
         FontFamily Find(string fontFamily);
 
         /// <summary>

--- a/src/SixLabors.Fonts/IReadonlyFontCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontCollectionExtensions.cs
@@ -1,8 +1,5 @@
-﻿using SixLabors.Fonts.Exceptions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/Properties/AssemblyInfo.cs
+++ b/src/SixLabors.Fonts/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="Scott Williams">
-// Copyright (c) Scott Williams and contributors.
+﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
-// </copyright>
 
 // Common values read from `AssemblyInfo.Common.cs`

--- a/src/SixLabors.Fonts/RendererOptions.cs
+++ b/src/SixLabors.Fonts/RendererOptions.cs
@@ -1,10 +1,7 @@
-﻿using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Numerics;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.Primitives;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -32,8 +32,20 @@
   <ItemGroup>
     <Compile Include="..\Shared\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
+  
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\SixLabors.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" />
+    <Content Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="SixLabors.Core" Version="0.1.0-alpha0002" />
   </ItemGroup>

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>SixLabors.Fonts</AssemblyTitle>
     <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
     <VersionPrefix Condition="$(packageversion) == ''">0.1.0-alpha1</VersionPrefix>
-    <Authors>Scott Williams and contributors</Authors>
+    <Authors>Six Labors and contributors</Authors>
     <TargetFrameworks>netstandard1.3;netstandard1.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -1,10 +1,10 @@
-﻿using SixLabors.Fonts.Exceptions;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -49,7 +49,6 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Create a new instance of the <see cref="Font"/> for the named font family. 
         /// </summary>
-        /// <param name="collection">The the ont collection to retrieve the font family from.</param>
         /// <param name="fontFamily">The family.</param>
         /// <param name="size">The size.</param>
         /// <param name="style">The style.</param>
@@ -58,7 +57,6 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Create a new instance of the <see cref="Font"/> for the named font family with regular styling. 
         /// </summary>
-        /// <param name="collection">The the ont collection to retrieve the font family from.</param>
         /// <param name="fontFamily">The family.</param>
         /// <param name="size">The size.</param>
         public static Font CreateFont(string fontFamily, float size) => Collection.CreateFont(fontFamily, size);

--- a/src/SixLabors.Fonts/Tables/General/CMap/CMapSubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/CMapSubTable.cs
@@ -1,4 +1,7 @@
-﻿using SixLabors.Fonts.WellKnownIds;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Tables.General.CMap
 {

--- a/src/SixLabors.Fonts/Tables/General/CMap/EncodingRecord.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/EncodingRecord.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Tables.General.CMap

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format0SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format0SubTable.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Tables.General.CMap
@@ -40,7 +39,6 @@ namespace SixLabors.Fonts.Tables.General.CMap
 
             // char 'A' == 65 thus glyph = glyphIds[65];
             byte[] glyphIds = reader.ReadBytes(glyphsCount);
-
 
             foreach (EncodingRecord encoding in encodings)
             {

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format4SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format4SubTable.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Tables.General.CMap

--- a/src/SixLabors.Fonts/Tables/General/CMapTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMapTable.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using SixLabors.Fonts.Tables.General.CMap;
 using SixLabors.Fonts.WellKnownIds;
 
@@ -79,7 +80,6 @@ namespace SixLabors.Fonts.Tables.General
             {
                 encodings[i] = EncodingRecord.Read(reader);
             }
-
 
             // foreach encoding we move forward looking for th subtables
             List<CMapSubTable> tables = new List<CMapSubTable>(numTables);

--- a/src/SixLabors.Fonts/Tables/General/GlyphTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/GlyphTable.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using SixLabors.Fonts.Tables.General.CMap;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using SixLabors.Fonts.Tables.General.Glyphs;
-using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Tables.General
 {

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts.Tables.General.Glyphs
 {

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/EmptyGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/EmptyGlyphLoader.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Numerics;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts.Tables.General.Glyphs
 {

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/GlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/GlyphLoader.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Tables.General.Glyphs
 {

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/GlyphVector.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/GlyphVector.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Numerics;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts.Tables.General.Glyphs
 {

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/SimpleGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/SimpleGlyphLoader.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 using System.Numerics;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts.Tables.General.Glyphs
 {

--- a/src/SixLabors.Fonts/Tables/General/HeadTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/HeadTable.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 
 using SixLabors.Fonts.Exceptions;
-using SixLabors.Fonts.Tables.General.Name;
-using SixLabors.Fonts.Utilities;
-using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Tables.General
 {

--- a/src/SixLabors.Fonts/Tables/General/HoizontalHeadTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/HoizontalHeadTable.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Fonts.Exceptions;
-using SixLabors.Fonts.Tables.General.Name;
-using SixLabors.Fonts.Utilities;
-using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Tables.General
 {

--- a/src/SixLabors.Fonts/Tables/General/HorizontalMetricsTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/HorizontalMetricsTable.cs
@@ -1,13 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-
-using SixLabors.Fonts.Exceptions;
-using SixLabors.Fonts.Tables.General.Name;
-using SixLabors.Fonts.Utilities;
-using SixLabors.Fonts.WellKnownIds;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Tables.General
 {

--- a/src/SixLabors.Fonts/Tables/General/IndexLocationTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/IndexLocationTable.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Fonts.Exceptions;
-using SixLabors.Fonts.Tables.General.Name;
-using SixLabors.Fonts.Utilities;
-using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Tables.General
 {

--- a/src/SixLabors.Fonts/Tables/General/Kern/Format0SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/Kern/Format0SubTable.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 
 namespace SixLabors.Fonts.Tables.General.Kern
 {

--- a/src/SixLabors.Fonts/Tables/General/Kern/KearningPair.cs
+++ b/src/SixLabors.Fonts/Tables/General/Kern/KearningPair.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 
 namespace SixLabors.Fonts.Tables.General.Kern
 {

--- a/src/SixLabors.Fonts/Tables/General/Kern/KerningCoverage.cs
+++ b/src/SixLabors.Fonts/Tables/General/Kern/KerningCoverage.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Tables.General.Kern
 {

--- a/src/SixLabors.Fonts/Tables/General/Kern/KerningSubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/Kern/KerningSubTable.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Numerics;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts.Tables.General.Kern
 {

--- a/src/SixLabors.Fonts/Tables/General/KerningTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/KerningTable.cs
@@ -1,13 +1,10 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 
 using SixLabors.Fonts.Tables.General.Kern;
-using SixLabors.Fonts.Tables.General.Name;
-using SixLabors.Fonts.Utilities;
-using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Tables.General
 {

--- a/src/SixLabors.Fonts/Tables/General/MaximumProfileTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/MaximumProfileTable.cs
@@ -1,13 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-
-using SixLabors.Fonts.Exceptions;
-using SixLabors.Fonts.Tables.General.Name;
-using SixLabors.Fonts.Utilities;
-using SixLabors.Fonts.WellKnownIds;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Tables.General
 {

--- a/src/SixLabors.Fonts/Tables/General/Name/NameRecord.cs
+++ b/src/SixLabors.Fonts/Tables/General/Name/NameRecord.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Text;
-using System.Threading.Tasks;
 
 using SixLabors.Fonts.Utilities;
 using SixLabors.Fonts.WellKnownIds;

--- a/src/SixLabors.Fonts/Tables/General/NameTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/NameTable.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using SixLabors.Fonts.Tables.General.Name;
 using SixLabors.Fonts.Utilities;
 using SixLabors.Fonts.WellKnownIds;

--- a/src/SixLabors.Fonts/Tables/General/OS2Table.cs
+++ b/src/SixLabors.Fonts/Tables/General/OS2Table.cs
@@ -1,13 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-
-using SixLabors.Fonts.Exceptions;
-using SixLabors.Fonts.Tables.General.Name;
-using SixLabors.Fonts.Utilities;
-using SixLabors.Fonts.WellKnownIds;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Tables.General
 {

--- a/src/SixLabors.Fonts/Tables/Table.cs
+++ b/src/SixLabors.Fonts/Tables/Table.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 namespace SixLabors.Fonts.Tables
 {
     internal abstract class Table

--- a/src/SixLabors.Fonts/Tables/TableHeader.cs
+++ b/src/SixLabors.Fonts/Tables/TableHeader.cs
@@ -1,7 +1,7 @@
-using System;
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
-using System.IO.Compression;
-using System.Text;
 
 namespace SixLabors.Fonts.Tables
 {

--- a/src/SixLabors.Fonts/Tables/TableLoader.cs
+++ b/src/SixLabors.Fonts/Tables/TableLoader.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SixLabors.Fonts/Tables/TableNameAttribute.cs
+++ b/src/SixLabors.Fonts/Tables/TableNameAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 
 namespace SixLabors.Fonts.Tables

--- a/src/SixLabors.Fonts/Tables/UnknownTable.cs
+++ b/src/SixLabors.Fonts/Tables/UnknownTable.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Tables
 {
-    using System.IO;
-    using System.Text;
-
     internal class UnknownTable : Table
     {
         internal UnknownTable(string name)

--- a/src/SixLabors.Fonts/Tables/WoffTableHeader.cs
+++ b/src/SixLabors.Fonts/Tables/WoffTableHeader.cs
@@ -1,7 +1,7 @@
-using System;
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
-using System.IO.Compression;
-using System.Text;
 
 namespace SixLabors.Fonts.Tables
 {

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -1,11 +1,11 @@
-﻿using SixLabors.Primitives;
-using System;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Numerics;
 using System.Text;
-using System.Threading.Tasks;
+using SixLabors.Primitives;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -281,7 +281,7 @@ namespace SixLabors.Fonts
         internal RectangleF BoundingBox(Vector2 dpi)
         {
             var box = this.Glyph.BoundingBox(this.Location * dpi, dpi);
-            if(this.IsWhiteSpace)
+            if (this.IsWhiteSpace)
             {
                 box.Width = this.Width * dpi.X;
             }

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -21,7 +21,6 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The style.</param>
-        /// <param name="origin">The origin point in font space (real location divided by dpi).</param>
         /// <returns>A collection of layout that describe all thats needed to measure or render a series of glyphs.</returns>
         public ImmutableArray<GlyphLayout> GenerateLayout(string text, RendererOptions options)
         {

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -19,8 +19,38 @@ namespace SixLabors.Fonts
         /// <param name="text">The text.</param>
         /// <param name="options">The style.</param>
         /// <returns>The size of the text if it was to be rendered.</returns>
-        public static RectangleF Measure(string text, RendererOptions options)
+        public static SizeF Measure(string text, RendererOptions options)
             => TextMeasurerInt.Default.Measure(text, options);
+
+        /// <summary>
+        /// Measures the text.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="options">The style.</param>
+        /// <returns>The size of the text if it was to be rendered.</returns>
+        public static RectangleF MeasureBounds(string text, RendererOptions options)
+            => TextMeasurerInt.Default.MeasureBounds(text, options);
+
+        internal static SizeF GetSize(ImmutableArray<GlyphLayout> glyphLayouts, Vector2 dpi)
+        {
+            if (glyphLayouts.IsEmpty)
+            {
+                return Size.Empty;
+            }
+
+            float left = glyphLayouts.Min(x => x.Location.X);
+            float right = glyphLayouts.Max(x => x.Location.X + x.Width);
+
+            // location is bottom left of the line
+            float top = glyphLayouts.Min(x => x.Location.Y - x.LineHeight);
+            float bottom = glyphLayouts.Max(x => x.Location.Y - x.LineHeight + x.Height);
+
+            Vector2 topLeft = new Vector2(left, top) * dpi;
+            Vector2 bottomRight = new Vector2(right, bottom) * dpi;
+
+            var size = bottomRight - topLeft;
+            return new RectangleF(topLeft.X, topLeft.Y, size.X, size.Y).Size;
+        }
 
         internal static RectangleF GetBounds(ImmutableArray<GlyphLayout> glyphLayouts, Vector2 dpi)
         {
@@ -98,11 +128,24 @@ namespace SixLabors.Fonts
             /// <param name="text">The text.</param>
             /// <param name="options">The style.</param>
             /// <returns>The size of the text if it was to be rendered.</returns>
-            internal RectangleF Measure(string text, RendererOptions options)
+            internal RectangleF MeasureBounds(string text, RendererOptions options)
             {
                 ImmutableArray<GlyphLayout> glyphsToRender = this.layoutEngine.GenerateLayout(text, options);
 
                 return GetBounds(glyphsToRender, new Vector2(options.DpiX, options.DpiY));
+            }
+
+            /// <summary>
+            /// Measures the text.
+            /// </summary>
+            /// <param name="text">The text.</param>
+            /// <param name="options">The style.</param>
+            /// <returns>The size of the text if it was to be rendered.</returns>
+            internal SizeF Measure(string text, RendererOptions options)
+            {
+                ImmutableArray<GlyphLayout> glyphsToRender = this.layoutEngine.GenerateLayout(text, options);
+
+                return GetSize(glyphsToRender, new Vector2(options.DpiX, options.DpiY));
             }
         }
     }

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -1,10 +1,10 @@
-﻿using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
-using System.Threading.Tasks;
+using SixLabors.Primitives;
 
 namespace SixLabors.Fonts
 {
@@ -115,7 +115,7 @@ namespace SixLabors.Fonts
             }
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="TextMeasurer"/> class.
+            /// Initializes a new instance of the <see cref="TextMeasurerInt"/> class.
             /// </summary>
             internal TextMeasurerInt()
             : this(TextLayout.Default)

--- a/src/SixLabors.Fonts/TextRenderer.cs
+++ b/src/SixLabors.Fonts/TextRenderer.cs
@@ -1,10 +1,10 @@
-﻿using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
-using System.Threading.Tasks;
+using SixLabors.Primitives;
 
 namespace SixLabors.Fonts
 {

--- a/src/SixLabors.Fonts/TextRenderer.cs
+++ b/src/SixLabors.Fonts/TextRenderer.cs
@@ -57,9 +57,10 @@ namespace SixLabors.Fonts
 
             this.renderer.BeginText(rect);
 
-            foreach (GlyphLayout g in glyphsToRender.Where(x => x.Glyph.HasValue))
+            foreach (GlyphLayout g in glyphsToRender.Where(x => !x.IsWhiteSpace))
             {
-                g.Glyph.Value.RenderTo(this.renderer, g.Location, options.DpiX, options.DpiY, g.LineHeight);
+
+                g.Glyph.RenderTo(this.renderer, g.Location, options.DpiX, options.DpiY, g.LineHeight);
             }
 
             this.renderer.EndText();

--- a/src/SixLabors.Fonts/TextRenderer.cs
+++ b/src/SixLabors.Fonts/TextRenderer.cs
@@ -59,7 +59,6 @@ namespace SixLabors.Fonts
 
             foreach (GlyphLayout g in glyphsToRender.Where(x => !x.IsWhiteSpace))
             {
-
                 g.Glyph.RenderTo(this.renderer, g.Location, options.DpiX, options.DpiY, g.LineHeight);
             }
 

--- a/src/SixLabors.Fonts/Utilities/EncodingIDExtensions.cs
+++ b/src/SixLabors.Fonts/Utilities/EncodingIDExtensions.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Text;
-using System.Threading.Tasks;
 using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts.Utilities

--- a/src/SixLabors.Fonts/Utilities/StringLoader.cs
+++ b/src/SixLabors.Fonts/Utilities/StringLoader.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Text;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts.Utilities
 {

--- a/src/SixLabors.Fonts/VerticalAlignment.cs
+++ b/src/SixLabors.Fonts/VerticalAlignment.cs
@@ -1,4 +1,7 @@
-﻿namespace SixLabors.Fonts
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.Fonts
 {
     /// <summary>
     /// Vertial alignment modes.

--- a/src/SixLabors.Fonts/WellKnownIds/EncodingIDs.cs
+++ b/src/SixLabors.Fonts/WellKnownIds/EncodingIDs.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.WellKnownIds
 {

--- a/src/SixLabors.Fonts/WellKnownIds/NameIds.cs
+++ b/src/SixLabors.Fonts/WellKnownIds/NameIds.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.WellKnownIds
 {

--- a/src/SixLabors.Fonts/WellKnownIds/PlatformIDs.cs
+++ b/src/SixLabors.Fonts/WellKnownIds/PlatformIDs.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.WellKnownIds
 {

--- a/src/SixLabors.ruleset
+++ b/src/SixLabors.ruleset
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Shaper2D" ToolsVersion="14.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1413" Action="None" />
+  </Rules>
+</RuleSet>

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace",
+      "elementOrder": [
+        "kind"
+      ]
+    },
+    "documentationRules": {
+      "xmlHeader": false,
+      "documentInternalElements": false,
+      "copyrightText": "Copyright (c) Six Labors and contributors.\nLicensed under the Apache License, Version 2.0."
+    }
+  }
+}

--- a/tests/SixLabors.Fonts.Tests/Accents.cs
+++ b/tests/SixLabors.Fonts.Tests/Accents.cs
@@ -22,7 +22,7 @@ namespace SixLabors.Fonts.Tests
             FontFamily arial = SystemFonts.Find("Arial");
             Font font = new Font(arial, 1f, FontStyle.Regular);
 
-            SizeF size = TextMeasurer.Measure(c.ToString(), font, 72);
+            SizeF size = TextMeasurer.Measure(c.ToString(), new RendererOptions(font, 72)).Size;
         }
 
         [Theory]
@@ -39,7 +39,7 @@ namespace SixLabors.Fonts.Tests
             FontFamily arial = SystemFonts.Find("Arial");
             Font font = new Font(arial, 1f, FontStyle.Regular);
 
-            SizeF size = TextMeasurer.Measure($"abc{c}def", font, 72);
+            SizeF size = TextMeasurer.Measure($"abc{c}def", new RendererOptions(font, 72)).Size;
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Accents.cs
+++ b/tests/SixLabors.Fonts.Tests/Accents.cs
@@ -22,7 +22,7 @@ namespace SixLabors.Fonts.Tests
             FontFamily arial = SystemFonts.Find("Arial");
             Font font = new Font(arial, 1f, FontStyle.Regular);
 
-            SizeF size = TextMeasurer.Measure(c.ToString(), new RendererOptions(font, 72)).Size;
+            SizeF size = TextMeasurer.Measure(c.ToString(), new RendererOptions(font, 72));
         }
 
         [Theory]
@@ -39,7 +39,7 @@ namespace SixLabors.Fonts.Tests
             FontFamily arial = SystemFonts.Find("Arial");
             Font font = new Font(arial, 1f, FontStyle.Regular);
 
-            SizeF size = TextMeasurer.Measure($"abc{c}def", new RendererOptions(font, 72)).Size;
+            SizeF size = TextMeasurer.Measure($"abc{c}def", new RendererOptions(font, 72));
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Accents.cs
+++ b/tests/SixLabors.Fonts.Tests/Accents.cs
@@ -1,7 +1,4 @@
 ﻿using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests

--- a/tests/SixLabors.Fonts.Tests/BinaryWriter.cs
+++ b/tests/SixLabors.Fonts.Tests/BinaryWriter.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts.Tests
 {

--- a/tests/SixLabors.Fonts.Tests/ConstructorGuards.cs
+++ b/tests/SixLabors.Fonts.Tests/ConstructorGuards.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests

--- a/tests/SixLabors.Fonts.Tests/FakeFont.cs
+++ b/tests/SixLabors.Fonts.Tests/FakeFont.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace SixLabors.Fonts.Tests
+﻿namespace SixLabors.Fonts.Tests
 {
-    
+
 }

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeCmapSubtable.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeCmapSubtable.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using SixLabors.Fonts.Tables.General.CMap;
 
 namespace SixLabors.Fonts.Tests.Fakes

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using SixLabors.Fonts.Tables.General;
 
 namespace SixLabors.Fonts.Tests.Fakes

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeGlyphSource.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeGlyphSource.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Threading.Tasks;
+﻿using System.Numerics;
 using SixLabors.Fonts.Tables.General.Glyphs;
 
 namespace SixLabors.Fonts.Tests.Fakes

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeGlyphTable.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeGlyphTable.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.Tables.General.Glyphs;
 

--- a/tests/SixLabors.Fonts.Tests/FontDescriptionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontDescriptionTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-using SixLabors.Fonts.Tables;
-using SixLabors.Fonts.Tables.General;
+﻿using System.Collections.Generic;
 
 using Xunit;
 

--- a/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
 namespace SixLabors.Fonts.Tests
 {

--- a/tests/SixLabors.Fonts.Tests/FontReaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontReaderTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
+﻿
 using SixLabors.Fonts.Tables;
 using SixLabors.Fonts.Tables.General;
 

--- a/tests/SixLabors.Fonts.Tests/GlyphRenderer.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphRenderer.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace SixLabors.Fonts.Tests
 {
     using SixLabors.Primitives;
-    using System.Numerics;
-    using Xunit;
 
     public class GlyphRenderer : IGlyphRenderer
     {

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -18,10 +18,10 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void RenderToPointAndSingleDPI()
         {
-            var locationInFontSpace = new PointF(99, 99) / 72;
+            var locationInFontSpace = new PointF(99, 99) / 72; // glyp ends up 10px over due to offiset in fake glyph
             glyph.RenderTo(renderer, locationInFontSpace, 72, 0);
 
-            Assert.Equal(new RectangleF(99, 99, 0, 0), renderer.GlyphRects.Single());
+            Assert.Equal(new RectangleF(99, 89, 0, 0), renderer.GlyphRects.Single());
         }
 
         [Fact]

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
 namespace SixLabors.Fonts.Tests
 {

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_23.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_23.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Xunit;
+﻿using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues
 {

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
@@ -15,7 +15,7 @@ namespace SixLabors.Fonts.Tests.Issues
 
             GlyphRenderer r = new GlyphRenderer();
 
-            var size = TextMeasurer.Measure("          ", new RendererOptions(new Font(font, 30), 72)).Size;
+            var size = TextMeasurer.MeasureBounds("          ", new RendererOptions(new Font(font, 30), 72)).Size;
 
             Assert.Equal(60, size.Width, 1);
             Assert.Equal(31.6, size.Height, 1);

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Xunit;
+﻿using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues
 {

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
@@ -15,10 +15,10 @@ namespace SixLabors.Fonts.Tests.Issues
 
             GlyphRenderer r = new GlyphRenderer();
 
-            var size = TextMeasurer.Measure("          ", new RendererOptions(new Font(font, 30), 72));
+            var size = TextMeasurer.Measure("          ", new RendererOptions(new Font(font, 30), 72)).Size;
 
             Assert.Equal(60, size.Width, 1);
-            Assert.Equal(31.6, size.Height, 1);
+            Assert.Equal(31.7, size.Height, 1);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
@@ -18,7 +18,7 @@ namespace SixLabors.Fonts.Tests.Issues
             var size = TextMeasurer.Measure("          ", new RendererOptions(new Font(font, 30), 72)).Size;
 
             Assert.Equal(60, size.Width, 1);
-            Assert.Equal(31.7, size.Height, 1);
+            Assert.Equal(31.6, size.Height, 1);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
@@ -17,11 +17,11 @@ namespace SixLabors.Fonts.Tests.Issues
             SizeF size = TextMeasurer.Measure(text, new RendererOptions(font, (72 * font.EmSize))
             {
                 TabWidth = 0
-            });
+            }).Size;
 
             // tab width of 0 should make tabs not render at all
-            Assert.Equal(30, size.Height, 4);
-            Assert.Equal(300, size.Width, 4);
+            Assert.Equal(10, size.Height, 4);
+            Assert.Equal(280, size.Width, 4);
         }
 
         public static Font CreateFont(string text)

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
@@ -1,8 +1,5 @@
 ﻿using SixLabors.Fonts.Tests.Fakes;
 using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
@@ -14,7 +14,7 @@ namespace SixLabors.Fonts.Tests.Issues
         {
             var text = "Hello\tworld";
             var font  = CreateFont(text);
-            SizeF size = TextMeasurer.Measure(text, new RendererOptions(font, (72 * font.EmSize))
+            SizeF size = TextMeasurer.MeasureBounds(text, new RendererOptions(font, (72 * font.EmSize))
             {
                 TabWidth = 0
             }).Size;

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
@@ -10,18 +10,18 @@ namespace SixLabors.Fonts.Tests.Issues
     public class Issues_33
     {
         [Theory]
-        [InlineData("\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs", 780, 120)]
-        [InlineData("\n\tHelloworld", 420, 60)]
-        [InlineData("\tHelloworld", 420, 30)]
-        [InlineData("  Helloworld", 360, 30)]
-        [InlineData("Hell owor ld\t", 480, 30)]
-        [InlineData("Helloworld  ", 360, 30)]
+        [InlineData("\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs", 760, 70)] // newlines arn't directly measured but it is used for offseting
+        [InlineData("\n\tHelloworld", 400, 10)]
+        [InlineData("\tHelloworld", 400, 10)]
+        [InlineData("  Helloworld", 340, 10)]
+        [InlineData("Hell owor ld\t", 480, 10)]
+        [InlineData("Helloworld  ", 360, 10)]
         public void WhiteSpaceAtStartOfLineNotMeasured(string text, float width, float height )
         {
             var font  = CreateFont(text);
             SizeF size = TextMeasurer.Measure(text, new RendererOptions(font, (72 * font.EmSize))
             {
-            });
+            }).Size;
 
             Assert.Equal(height, size.Height, 2);
             Assert.Equal(width, size.Width, 2);

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
@@ -19,7 +19,7 @@ namespace SixLabors.Fonts.Tests.Issues
         public void WhiteSpaceAtStartOfLineNotMeasured(string text, float width, float height )
         {
             var font  = CreateFont(text);
-            SizeF size = TextMeasurer.Measure(text, new RendererOptions(font, (72 * font.EmSize))
+            SizeF size = TextMeasurer.MeasureBounds(text, new RendererOptions(font, (72 * font.EmSize))
             {
             }).Size;
 

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
@@ -1,8 +1,5 @@
 ﻿using SixLabors.Fonts.Tests.Fakes;
 using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
@@ -13,10 +13,10 @@ namespace SixLabors.Fonts.Tests.Issues
         public void RenderingTabAtStartOrLineTooShort()
         {
             var font = CreateFont("\t x");
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF tabWidth = TextMeasurer.Measure("\t", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF doublTabWidth = TextMeasurer.Measure("\t\t", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF tabWithXWidth = TextMeasurer.Measure("\tx", new RendererOptions(font, (72 * font.EmSize)));
+            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.Measure("\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF doublTabWidth = TextMeasurer.Measure("\t\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWithXWidth = TextMeasurer.Measure("\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(tabWidth.Width + xWidth.Width, tabWithXWidth.Width, 2);
         }
@@ -26,9 +26,9 @@ namespace SixLabors.Fonts.Tests.Issues
         public void Rendering2TabsAtStartOfLineTooShort()
         {
             var font = CreateFont("\t x");
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF tabWidth = TextMeasurer.Measure("\t\t", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF tabWithXWidth = TextMeasurer.Measure("\t\tx", new RendererOptions(font, (72 * font.EmSize)));
+            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.Measure("\t\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWithXWidth = TextMeasurer.Measure("\t\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(tabWidth.Width + xWidth.Width, tabWithXWidth.Width, 2);
         }
@@ -37,9 +37,9 @@ namespace SixLabors.Fonts.Tests.Issues
         public void TwoTabsAreDoubleWidthOfOneTab()
         {
             var font = CreateFont("\t x");
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF tabWidth = TextMeasurer.Measure("\t", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF twoTabWidth = TextMeasurer.Measure("\t\t", new RendererOptions(font, (72 * font.EmSize)));
+            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.Measure("\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF twoTabWidth = TextMeasurer.Measure("\t\t", new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(twoTabWidth.Width, tabWidth.Width * 2, 2);
         }
@@ -49,9 +49,9 @@ namespace SixLabors.Fonts.Tests.Issues
         public void TwoTabsAreDoubleWidthOfOneTabMinusXWidth()
         {
             var font = CreateFont("\t x");
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF tabWidth = TextMeasurer.Measure("\tx", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF twoTabWidth = TextMeasurer.Measure("\t\tx", new RendererOptions(font, (72 * font.EmSize)));
+            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.Measure("\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF twoTabWidth = TextMeasurer.Measure("\t\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(twoTabWidth.Width - xWidth.Width, (tabWidth.Width - xWidth.Width) * 2, 2);
         }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
@@ -13,10 +13,10 @@ namespace SixLabors.Fonts.Tests.Issues
         public void RenderingTabAtStartOrLineTooShort()
         {
             var font = CreateFont("\t x");
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF tabWidth = TextMeasurer.Measure("\t", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF doublTabWidth = TextMeasurer.Measure("\t\t", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF tabWithXWidth = TextMeasurer.Measure("\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF doublTabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWithXWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(tabWidth.Width + xWidth.Width, tabWithXWidth.Width, 2);
         }
@@ -26,9 +26,9 @@ namespace SixLabors.Fonts.Tests.Issues
         public void Rendering2TabsAtStartOfLineTooShort()
         {
             var font = CreateFont("\t x");
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF tabWidth = TextMeasurer.Measure("\t\t", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF tabWithXWidth = TextMeasurer.Measure("\t\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWithXWidth = TextMeasurer.MeasureBounds("\t\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(tabWidth.Width + xWidth.Width, tabWithXWidth.Width, 2);
         }
@@ -37,9 +37,9 @@ namespace SixLabors.Fonts.Tests.Issues
         public void TwoTabsAreDoubleWidthOfOneTab()
         {
             var font = CreateFont("\t x");
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF tabWidth = TextMeasurer.Measure("\t", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF twoTabWidth = TextMeasurer.Measure("\t\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF twoTabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(twoTabWidth.Width, tabWidth.Width * 2, 2);
         }
@@ -49,9 +49,9 @@ namespace SixLabors.Fonts.Tests.Issues
         public void TwoTabsAreDoubleWidthOfOneTabMinusXWidth()
         {
             var font = CreateFont("\t x");
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF tabWidth = TextMeasurer.Measure("\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF twoTabWidth = TextMeasurer.Measure("\t\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF twoTabWidth = TextMeasurer.MeasureBounds("\t\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(twoTabWidth.Width - xWidth.Width, (tabWidth.Width - xWidth.Width) * 2, 2);
         }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
@@ -1,8 +1,5 @@
 ﻿using SixLabors.Fonts.Tests.Fakes;
 using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
@@ -21,9 +21,9 @@ namespace SixLabors.Fonts.Tests.Issues
         {
             var font = CreateFont("\t x");
 
-            SizeF tabWidth = TextMeasurer.Measure("\t", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, (72 * font.EmSize))).Size;
             var tabString = "".PadRight(tabCount, '\t');
-            SizeF tabCountWidth = TextMeasurer.Measure(tabString, new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabCountWidth = TextMeasurer.MeasureBounds(tabString, new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(tabWidth.Width * tabCount, tabCountWidth.Width, 2);
         }
@@ -40,10 +40,10 @@ namespace SixLabors.Fonts.Tests.Issues
         {
             var font = CreateFont("\t x");
 
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
-            SizeF tabWidth = TextMeasurer.Measure("\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
             var tabString = "x".PadLeft(tabCount+1, '\t');
-            SizeF tabCountWidth = TextMeasurer.Measure(tabString, new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabCountWidth = TextMeasurer.MeasureBounds(tabString, new RendererOptions(font, (72 * font.EmSize))).Size;
 
             var singleTabWidth = tabWidth.Width - xWidth.Width;
             var finalTabWidth = tabCountWidth.Width - xWidth.Width;

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
@@ -1,8 +1,5 @@
 ﻿using SixLabors.Fonts.Tests.Fakes;
 using SixLabors.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
@@ -21,9 +21,9 @@ namespace SixLabors.Fonts.Tests.Issues
         {
             var font = CreateFont("\t x");
 
-            SizeF tabWidth = TextMeasurer.Measure("\t", new RendererOptions(font, (72 * font.EmSize)));
+            SizeF tabWidth = TextMeasurer.Measure("\t", new RendererOptions(font, (72 * font.EmSize))).Size;
             var tabString = "".PadRight(tabCount, '\t');
-            SizeF tabCountWidth = TextMeasurer.Measure(tabString, new RendererOptions(font, (72 * font.EmSize)));
+            SizeF tabCountWidth = TextMeasurer.Measure(tabString, new RendererOptions(font, (72 * font.EmSize))).Size;
 
             Assert.Equal(tabWidth.Width * tabCount, tabCountWidth.Width, 2);
         }
@@ -40,10 +40,10 @@ namespace SixLabors.Fonts.Tests.Issues
         {
             var font = CreateFont("\t x");
 
-            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize)));
-            SizeF tabWidth = TextMeasurer.Measure("\tx", new RendererOptions(font, (72 * font.EmSize)));
+            SizeF xWidth = TextMeasurer.Measure("x", new RendererOptions(font, (72 * font.EmSize))).Size;
+            SizeF tabWidth = TextMeasurer.Measure("\tx", new RendererOptions(font, (72 * font.EmSize))).Size;
             var tabString = "x".PadLeft(tabCount+1, '\t');
-            SizeF tabCountWidth = TextMeasurer.Measure(tabString, new RendererOptions(font, (72 * font.EmSize)));
+            SizeF tabCountWidth = TextMeasurer.Measure(tabString, new RendererOptions(font, (72 * font.EmSize))).Size;
 
             var singleTabWidth = tabWidth.Width - xWidth.Width;
             var finalTabWidth = tabCountWidth.Width - xWidth.Width;

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_39.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_39.cs
@@ -1,0 +1,28 @@
+﻿using SixLabors.Fonts.Tests.Fakes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace SixLabors.Fonts.Tests.Issues
+{
+    public class Issues_39
+    {
+        [Fact]
+        public void RenderingEmptyString_DoesNotThrow()
+        {
+            var font = CreateFont("\t x");
+         
+            GlyphRenderer r = new GlyphRenderer();
+
+            new TextRenderer(r).RenderText("", new RendererOptions(new Font(font, 30), 72));
+        }
+
+        public static Font CreateFont(string text)
+        {
+            FontCollection fc = new FontCollection();
+            Font d = fc.Install(new FakeFontInstance(text)).CreateFont(12);
+            return new Font(d, 1);
+        }
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_39.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_39.cs
@@ -1,7 +1,4 @@
 ﻿using SixLabors.Fonts.Tests.Fakes;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues

--- a/tests/SixLabors.Fonts.Tests/Properties/AssemblyInfo.cs
+++ b/tests/SixLabors.Fonts.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format0SubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format0SubTableTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-using SixLabors.Fonts.Tables.General;
+﻿using System.Linq;
 using SixLabors.Fonts.Tables.General.CMap;
 using SixLabors.Fonts.WellKnownIds;
 

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format4SubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format4SubTableTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-using SixLabors.Fonts.Tables.General;
+﻿using System.Linq;
 using SixLabors.Fonts.Tables.General.CMap;
 using SixLabors.Fonts.WellKnownIds;
 

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMapTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMapTableTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.Tables.General.CMap;

--- a/tests/SixLabors.Fonts.Tests/Tables/General/HeadTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/HeadTableTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 using SixLabors.Fonts.Tables.General;
-using SixLabors.Fonts.WellKnownIds;
 
 using Xunit;
 

--- a/tests/SixLabors.Fonts.Tests/Tables/General/HoizontalHeadTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/HoizontalHeadTableTests.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
+﻿
 using SixLabors.Fonts.Tables.General;
-using SixLabors.Fonts.WellKnownIds;
 
 using Xunit;
 

--- a/tests/SixLabors.Fonts.Tests/Tables/General/NameTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/NameTableTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.WellKnownIds;

--- a/tests/SixLabors.Fonts.Tests/TestFonts.cs
+++ b/tests/SixLabors.Fonts.Tests/TestFonts.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace SixLabors.Fonts.Tests
 {

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -16,8 +16,6 @@ namespace SixLabors.Fonts.Tests
 {
     public class TextLayoutTests
     {
-        private float expectedY;
-
         [Fact]
         public void FakeFontGetGlyph()
         {
@@ -30,48 +28,48 @@ namespace SixLabors.Fonts.Tests
         [InlineData(
             VerticalAlignment.Top,
             HorizontalAlignment.Left,
-            0,
-            0)]
+            10,
+            10)]
         [InlineData(
             VerticalAlignment.Top,
             HorizontalAlignment.Right,
-            0,
-            -330)]
+            10,
+            -320)]
         [InlineData(
             VerticalAlignment.Top,
             HorizontalAlignment.Center,
-            0,
-            -165)]
+            10,
+            -155)]
         [InlineData(
             VerticalAlignment.Bottom,
             HorizontalAlignment.Left,
-            -60,
-            0)]
+            -50,
+            10)]
         [InlineData(
             VerticalAlignment.Bottom,
             HorizontalAlignment.Right,
-            -60,
-            -330)]
+            -50,
+            -320)]
         [InlineData(
             VerticalAlignment.Bottom,
             HorizontalAlignment.Center,
-            -60,
-            -165)]
+            -50,
+            -155)]
         [InlineData(
             VerticalAlignment.Center,
             HorizontalAlignment.Left,
-            -30,
-            0)]
+            -20,
+            10)]
         [InlineData(
             VerticalAlignment.Center,
             HorizontalAlignment.Right,
-            -30,
-            -330)]
+            -20,
+            -320)]
         [InlineData(
             VerticalAlignment.Center,
             HorizontalAlignment.Center,
-            -30,
-            -165)]
+            -20,
+            -155)]
         public void VerticalAlignmentTests(
             VerticalAlignment vertical,
             HorizontalAlignment horizental,
@@ -93,18 +91,21 @@ namespace SixLabors.Fonts.Tests
             lineHeight *= scaleFactor;
             RectangleF bound = TextMeasurer.GetBounds(glyphsToRender, new Vector2(span.DpiX, span.DpiY));
 
-            Assert.Equal(330, bound.Width, 3);
-            Assert.Equal(60, bound.Height, 3);
+            Assert.Equal(310, bound.Width, 3);
+            Assert.Equal(40, bound.Height, 3);
             Assert.Equal(left, bound.Left, 3);
             Assert.Equal(top, bound.Top, 3);
         }
 
 
         [Theory]
-        [InlineData("hello", 30, 150)]
-        [InlineData("hello world", 30, 330)]
-        [InlineData("hello world\nhello world", 60, 330)]
-        [InlineData("hello\nworld", 60, 150)]
+        [InlineData("h", 10, 10)]
+        [InlineData("he", 10, 40)]
+        [InlineData("hel", 10, 70)]
+        [InlineData("hello", 10, 130)]
+        [InlineData("hello world", 10, 310)]
+        [InlineData("hello world\nhello world", 40, 310)]
+        [InlineData("hello\nworld", 40, 130)]
         public void MeasureText(string text, float height, float width)
         {
             Font font = CreateFont(text);
@@ -113,17 +114,17 @@ namespace SixLabors.Fonts.Tests
             SizeF size = TextMeasurer.Measure(text, new RendererOptions(font, 72 * font.EmSize)
             {
 
-            });
+            }).Size;
 
             Assert.Equal(height, size.Height, 4);
             Assert.Equal(width, size.Width, 4);
         }
 
         [Theory]
-        [InlineData("hello world", 30, 330)]
+        [InlineData("hello world", 10, 310)]
         [InlineData("hello world hello world",
-            90, //30 actaul line height + 20 actual height
-            330)]
+            70, //30 actaul line height + 20 actual height
+            310)]
         public void MeasureTextWordWrapping(string text, float height, float width)
         {
             Font font = CreateFont(text);
@@ -132,31 +133,31 @@ namespace SixLabors.Fonts.Tests
             SizeF size = TextMeasurer.Measure(text, new RendererOptions(font, 72 * font.EmSize)
             {
                 WrappingWidth = 350
-            });
+            }).Size;
 
             Assert.Equal(width, size.Width, 4);
             Assert.Equal(height, size.Height, 4);
         }
 
         [Theory]
-        [InlineData("ab", 1236, 1148, false)] // no kerning rules defined for lowercase ab so widths should stay the same
-        [InlineData("ab", 1236, 1148, true)]
-        [InlineData("AB", 1236, 1148, false)] // width changes between kerning enabled or not
-        [InlineData("AB", 1236, 769, true)]
+        [InlineData("ab", 477, 1081, false)] // no kerning rules defined for lowercase ab so widths should stay the same
+        [InlineData("ab", 477, 1081, true)]
+        [InlineData("AB", 465, 1033, false)] // width changes between kerning enabled or not
+        [InlineData("AB", 465, 654, true)]
         public void MeasureTextWithKerning(string text, float height, float width, bool enableKerning)
         {
             FontCollection c = new FontCollection();
             Font font = c.Install(TestFonts.SimpleFontFileData()).CreateFont(12);
 
             int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
-            SizeF size = TextMeasurer.Measure(text, new RendererOptions(new Font(font, 1), 72 * font.EmSize) { ApplyKerning = enableKerning });
+            SizeF size = TextMeasurer.Measure(text, new RendererOptions(new Font(font, 1), 72 * font.EmSize) { ApplyKerning = enableKerning }).Size;
 
             Assert.Equal(height, size.Height, 4);
             Assert.Equal(width, size.Width, 4);
         }
 
         [Theory]
-        [InlineData("a", 100, 100, 100, 100)] 
+        [InlineData("a", 100, 100, 125, 828)] 
         public void LayoutWithLocation(string text, float x, float y, float expectedX, float expectedY)
         {
             FontCollection c = new FontCollection();

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -111,7 +111,7 @@ namespace SixLabors.Fonts.Tests
             Font font = CreateFont(text);
 
             int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
-            SizeF size = TextMeasurer.Measure(text, new RendererOptions(font, 72 * font.EmSize)
+            SizeF size = TextMeasurer.MeasureBounds(text, new RendererOptions(font, 72 * font.EmSize)
             {
 
             }).Size;
@@ -130,7 +130,7 @@ namespace SixLabors.Fonts.Tests
             Font font = CreateFont(text);
 
             int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
-            SizeF size = TextMeasurer.Measure(text, new RendererOptions(font, 72 * font.EmSize)
+            SizeF size = TextMeasurer.MeasureBounds(text, new RendererOptions(font, 72 * font.EmSize)
             {
                 WrappingWidth = 350
             }).Size;
@@ -150,7 +150,7 @@ namespace SixLabors.Fonts.Tests
             Font font = c.Install(TestFonts.SimpleFontFileData()).CreateFont(12);
 
             int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
-            SizeF size = TextMeasurer.Measure(text, new RendererOptions(new Font(font, 1), 72 * font.EmSize) { ApplyKerning = enableKerning }).Size;
+            SizeF size = TextMeasurer.MeasureBounds(text, new RendererOptions(new Font(font, 1), 72 * font.EmSize) { ApplyKerning = enableKerning }).Size;
 
             Assert.Equal(height, size.Height, 4);
             Assert.Equal(width, size.Width, 4);

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -1,12 +1,4 @@
-﻿using Moq;
-using SixLabors.Fonts.Tables.General;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Numerics;
-using SixLabors.Fonts.Tables.General.CMap;
-using SixLabors.Fonts.Tables.General.Glyphs;
+﻿using System.Numerics;
 using Xunit;
 using SixLabors.Fonts.Tests.Fakes;
 using System.Collections.Immutable;

--- a/tests/SixLabors.Fonts.Tests/WriterExtensions.cs
+++ b/tests/SixLabors.Fonts.Tests/WriterExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 using SixLabors.Fonts.Tables;
 using SixLabors.Fonts.Tables.General;


### PR DESCRIPTION
changes the way we measure the text making it more accurate but potentially less intuitive as the location of the box doesn't equate to the location the text should be drawn. 

That is why `TextMeasurer` now returns a `RectangleF` instead of a `SizeF`. 