### PR TITLE
Remove white space from wrapped text end

### DIFF
--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -31,6 +31,9 @@ namespace SixLabors.Fonts
             float originX = 0;
             if (options.WrappingWidth > 0)
             {
+                // trim trailing white spaces from the text
+                text = text.TrimEnd(null);
+
                 maxWidth = options.WrappingWidth / options.DpiX;
 
                 switch (options.HorizontalAlignment)

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -83,7 +83,7 @@ namespace SixLabors.Fonts
 
                 char c = text[i];
 
-                if (char.IsWhiteSpace(c))
+                if (options.WrappingWidth > 0 && char.IsWhiteSpace(c))
                 {
                     // keep a record of where to wrap text and ensure that no line starts with white space
                     for (int j = layout.Count - 1; j >= 0; j--)

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -183,9 +183,7 @@ namespace SixLabors.Fonts
                             {
                                 if (lastWrappableLocation < layout.Count)
                                 {
-                                    // remove the white space from the end of the line
                                     float wrappingOffset = layout[lastWrappableLocation].Location.X;
-
                                     startOfLine = true;
 
                                     // move the remaining characters to the next line

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -176,20 +176,15 @@ namespace SixLabors.Fonts
                             {
                                 if (lastWrappableLocation < layout.Count)
                                 {
-                                    float wrappingOffset = layout[lastWrappableLocation].Location.X;
+                                    // remove the white space from the end of the line
+                                    float wrappingOffset = layout[lastWrappableLocation].Location.X + layout[lastWrappableLocation].Width;
+                                    layout.RemoveAt(lastWrappableLocation);
+
                                     startOfLine = true;
 
-                                    // move the characters to the next line
+                                    // move the remaining characters to the next line
                                     for (int j = lastWrappableLocation; j < layout.Count; j++)
                                     {
-                                        if (layout[j].IsWhiteSpace)
-                                        {
-                                            wrappingOffset += layout[j].Width;
-                                            layout.RemoveAt(j);
-                                            j--;
-                                            continue;
-                                        }
-
                                         Vector2 current = layout[j].Location;
                                         layout[j] = new GlyphLayout(layout[j].Character, layout[j].Glyph, new Vector2(current.X - wrappingOffset, current.Y + lineHeight), layout[j].Width, layout[j].Height, layout[j].LineHeight, startOfLine, layout[j].IsWhiteSpace, layout[j].IsControlCharacter);
                                         startOfLine = false;

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -186,7 +186,7 @@ namespace SixLabors.Fonts
                                     float wrappingOffset = layout[lastWrappableLocation].Location.X;
                                     startOfLine = true;
 
-                                    // move the remaining characters to the next line
+                                    // move the characters to the next line
                                     for (int j = lastWrappableLocation; j < layout.Count; j++)
                                     {
                                         if (layout[j].IsWhiteSpace)

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -168,18 +168,28 @@ namespace SixLabors.Fonts
                             layout.Add(new GlyphLayout(c, new Glyph(glyph, spanStyle.PointSize), glyphLocation, glyphWidth, glyphHeight, lineHeight, startOfLine, false, false));
                             startOfLine = false;
 
-                            // move foraward the actual with of the glyph, we are retaining the baseline
+                            // move forward the actual width of the glyph, we are retaining the baseline
                             location.X += glyphWidth;
 
+                            // if the word extended pass the end of the box, wrap it
                             if (location.X >= maxWidth && lastWrappableLocation > 0)
                             {
                                 if (lastWrappableLocation < layout.Count)
                                 {
                                     float wrappingOffset = layout[lastWrappableLocation].Location.X;
                                     startOfLine = true;
-                                    // the word just extended passed the end of the box
+
+                                    // move the characters to the next line
                                     for (int j = lastWrappableLocation; j < layout.Count; j++)
                                     {
+                                        if (layout[j].IsWhiteSpace)
+                                        {
+                                            wrappingOffset += layout[j].Width;
+                                            layout.RemoveAt(j);
+                                            j--;
+                                            continue;
+                                        }
+
                                         Vector2 current = layout[j].Location;
                                         layout[j] = new GlyphLayout(layout[j].Character, layout[j].Glyph, new Vector2(current.X - wrappingOffset, current.Y + lineHeight), layout[j].Width, layout[j].Height, layout[j].LineHeight, startOfLine, layout[j].IsWhiteSpace, layout[j].IsControlCharacter);
                                         startOfLine = false;

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -79,6 +79,24 @@ namespace SixLabors.Fonts.Tests.Issues
             Assert.Equal(true, layout[2].IsWhiteSpace);
         }
 
+        [Fact]
+        public void WhiteSpaceAtTheEndOfTextShouldBeTrimmed()
+        {
+            var font = CreateFont("\t x");
+            var text = "hello world hello world hello world   ";
+
+            GlyphRenderer r = new GlyphRenderer();
+
+            ImmutableArray<GlyphLayout> layout = new TextLayout().GenerateLayout(text, new RendererOptions(new Font(font, 30), 72)
+            {
+                WrappingWidth = 350
+            });
+
+            Assert.Equal(false, layout[layout.Length - 1].IsWhiteSpace);
+            Assert.Equal(false, layout[layout.Length - 2].IsWhiteSpace);
+            Assert.Equal(false, layout[layout.Length - 3].IsWhiteSpace);
+        }
+
         public static Font CreateFont(string text)
         {
             FontCollection fc = new FontCollection();

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -35,7 +35,7 @@ namespace SixLabors.Fonts.Tests.Issues
         [InlineData(HorizontalAlignment.Left)]
         [InlineData(HorizontalAlignment.Right)]
         [InlineData(HorizontalAlignment.Center)]
-        public void NewWrappedLinesShouldNotEndOrStartWithWhiteSpace(HorizontalAlignment horiAlignment)
+        public void NewWrappedLinesShouldNotStartOrEndWithWhiteSpace(HorizontalAlignment horiAlignment)
         {
             var font = CreateFont("\t x");
             var text = "hello world hello world hello world hello world";

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -35,7 +35,7 @@ namespace SixLabors.Fonts.Tests.Issues
         [InlineData(HorizontalAlignment.Left)]
         [InlineData(HorizontalAlignment.Right)]
         [InlineData(HorizontalAlignment.Center)]
-        public void WrappedTextShouldNotEndOrStartWithWhiteSpace(HorizontalAlignment horiAlignment)
+        public void NewWrappedLinesShouldNotEndOrStartWithWhiteSpace(HorizontalAlignment horiAlignment)
         {
             var font = CreateFont("\t x");
             var text = "hello world hello world hello world hello world";

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -1,0 +1,41 @@
+using System.Collections.Immutable;
+using SixLabors.Fonts.Tests.Fakes;
+using Xunit;
+
+namespace SixLabors.Fonts.Tests.Issues
+{
+    public class Issues_47
+    {
+        [Theory]
+        [InlineData("hello world hello world hello world hello world")]
+        public void LeftAlignedTextNewLineShouldNotStartWithWhiteSpace(string text)
+        {
+            var font = CreateFont("\t x");
+
+            GlyphRenderer r = new GlyphRenderer();
+
+            ImmutableArray<GlyphLayout> layout = new TextLayout().GenerateLayout(text, new RendererOptions(new Font(font, 30), 72)
+            {
+                WrappingWidth = 350,
+                HorizontalAlignment = HorizontalAlignment.Left
+            });
+
+            float lineYPos = layout[0].Location.Y;
+            foreach (GlyphLayout glyph in layout)
+            {
+                if (lineYPos != glyph.Location.Y)
+                {
+                    Assert.Equal(false, glyph.IsWhiteSpace);
+                    lineYPos = glyph.Location.Y;
+                }
+            }
+        }
+
+        public static Font CreateFont(string text)
+        {
+            FontCollection fc = new FontCollection();
+            Font d = fc.Install(new FakeFontInstance(text)).CreateFont(12);
+            return new Font(d, 1);
+        }
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -61,6 +61,24 @@ namespace SixLabors.Fonts.Tests.Issues
             }
         }
 
+        [Fact]
+        public void WhiteSpaceAtStartOfTextShouldNotBeTrimmed()
+        {
+            var font = CreateFont("\t x");
+            var text = "   hello world hello world hello world";
+
+            GlyphRenderer r = new GlyphRenderer();
+
+            ImmutableArray<GlyphLayout> layout = new TextLayout().GenerateLayout(text, new RendererOptions(new Font(font, 30), 72)
+            {
+                WrappingWidth = 350
+            });
+
+            Assert.Equal(true, layout[0].IsWhiteSpace);
+            Assert.Equal(true, layout[1].IsWhiteSpace);
+            Assert.Equal(true, layout[2].IsWhiteSpace);
+        }
+
         public static Font CreateFont(string text)
         {
             FontCollection fc = new FontCollection();

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -31,6 +31,36 @@ namespace SixLabors.Fonts.Tests.Issues
             }
         }
 
+        [Theory]
+        [InlineData(HorizontalAlignment.Left)]
+        [InlineData(HorizontalAlignment.Right)]
+        [InlineData(HorizontalAlignment.Center)]
+        public void WrappedTextShouldNotEndOrStartWithWhiteSpace(HorizontalAlignment horiAlignment)
+        {
+            var font = CreateFont("\t x");
+            var text = "hello world hello world hello world hello world";
+
+            GlyphRenderer r = new GlyphRenderer();
+
+            ImmutableArray<GlyphLayout> layout = new TextLayout().GenerateLayout(text, new RendererOptions(new Font(font, 30), 72)
+            {
+                WrappingWidth = 350,
+                HorizontalAlignment = horiAlignment
+            });
+
+            float lineYPos = layout[0].Location.Y;
+            for (int i = 0; i < layout.Length; i++)
+            {
+                GlyphLayout glyph = layout[i];
+                if (lineYPos != glyph.Location.Y)
+                {
+                    Assert.Equal(false, glyph.IsWhiteSpace);
+                    Assert.Equal(false, layout[i - 1].IsWhiteSpace);
+                    lineYPos = glyph.Location.Y;
+                }
+            }
+        }
+
         public static Font CreateFont(string text)
         {
             FontCollection fc = new FontCollection();

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -32,13 +32,13 @@ namespace SixLabors.Fonts.Tests.Issues
         }
 
         [Theory]
-        [InlineData(HorizontalAlignment.Left)]
-        [InlineData(HorizontalAlignment.Right)]
-        [InlineData(HorizontalAlignment.Center)]
-        public void NewWrappedLinesShouldNotStartOrEndWithWhiteSpace(HorizontalAlignment horiAlignment)
+        [InlineData("hello world hello world hello world hello world", HorizontalAlignment.Left)]
+        [InlineData("hello world hello world hello world hello world", HorizontalAlignment.Right)]
+        [InlineData("hello world hello world hello world hello world", HorizontalAlignment.Center)]
+        [InlineData("hello   world   hello   world   hello   hello   world", HorizontalAlignment.Left)]
+        public void NewWrappedLinesShouldNotStartOrEndWithWhiteSpace(string text, HorizontalAlignment horiAlignment)
         {
             var font = CreateFont("\t x");
-            var text = "hello world hello world hello world hello world";
 
             GlyphRenderer r = new GlyphRenderer();
 

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -114,8 +114,8 @@ namespace SixLabors.Fonts.Tests
 
         [Theory]
         [InlineData("hello world", 10, 310)]
-        [InlineData("hello world hello world",
-            40, // 30 actual line height + 10 actual height
+        [InlineData("hello world hello world hello world",
+            70, // 30 actual line height * 2 + 10 actual height
             310)]
         public void MeasureTextWordWrapping(string text, float height, float width)
         {

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -115,7 +115,7 @@ namespace SixLabors.Fonts.Tests
         [Theory]
         [InlineData("hello world", 10, 310)]
         [InlineData("hello world hello world",
-            70, //30 actaul line height + 20 actual height
+            40, // 30 actual line height + 10 actual height
             310)]
         public void MeasureTextWordWrapping(string text, float height, float width)
         {


### PR DESCRIPTION
Removes whitespace from the end of wrapped text lines. Looks neater when rendered with all different alignments and provides more accurate TextMeasurer results.

Fixes #47 

