### PR TITLE
Expose glyph size

### DIFF
--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -145,13 +145,13 @@ namespace SixLabors.Fonts
         internal IFontInstance FontInstance => this.instance.Value;
 
         /// <summary>
-        /// Gets the glyph.
+        /// Gets the glyph that corresponds to the given character.
         /// </summary>
-        /// <param name="codePoint">The code point of the character.</param>
+        /// <param name="character">The UTF-32 encoded character.</param>
         /// <returns>Returns the glyph</returns>
-        internal Glyph GetGlyph(int codePoint)
+        public Glyph GetGlyph(int character)
         {
-            return new Glyph(this.instance.Value.GetGlyph(codePoint), this.Size);
+            return new Glyph(this.instance.Value.GetGlyph(character), this.Size);
         }
 
         private IFontInstance LoadInstanceInternal()

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -9,7 +9,7 @@ namespace SixLabors.Fonts
     /// <summary>
     /// A glyph from a particular font face.
     /// </summary>
-    internal struct Glyph
+    public struct Glyph
     {
         private readonly GlyphInstance instance;
         private readonly float pointSize;
@@ -20,6 +20,22 @@ namespace SixLabors.Fonts
             this.pointSize = pointSize;
         }
 
+        /// <summary>
+        /// Get the size of the glyph when rendered at the given dpi.
+        /// </summary>
+        /// <param name="dpi">Dots per inch.</param>
+        /// <returns>The size of the glyph.</returns>
+        public SizeF Size(Vector2 dpi)
+        {
+            return this.instance.Size(this.pointSize * dpi);
+        }
+
+        /// <summary>
+        /// Get the bounding box of the glyph when rendered at the given dpi.
+        /// </summary>
+        /// <param name="location">Bottom left position.</param>
+        /// <param name="dpi">Dots per inch.</param>
+        /// <returns>The bounding box of the glyph.</returns>
         public RectangleF BoundingBox(PointF location, Vector2 dpi)
         {
             return this.instance.BoundingBox(location, this.pointSize * dpi);

--- a/src/SixLabors.Fonts/GlyphInstance.cs
+++ b/src/SixLabors.Fonts/GlyphInstance.cs
@@ -78,14 +78,20 @@ namespace SixLabors.Fonts
 
         private static readonly Vector2 Scale = new Vector2(1, -1);
 
+        internal SizeF Size(Vector2 scaledPointSize)
+        {
+            var size = (this.Bounds.Size() * scaledPointSize) / this.scaleFactor;
+            return new SizeF(size.X, size.Y);
+        }
+
         internal RectangleF BoundingBox(Vector2 origin, Vector2 scaledPointSize)
         {
-            Vector2 size = (this.Bounds.Size() * scaledPointSize) / this.scaleFactor;
+            SizeF size = this.Size(scaledPointSize);
             Vector2 loc = ((new Vector2(this.Bounds.Min.X, this.Bounds.Max.Y) * scaledPointSize) / this.scaleFactor) * Scale;
 
             loc = origin + loc;
 
-            return new RectangleF(loc.X, loc.Y, size.X, size.Y);
+            return new RectangleF(loc.X, loc.Y, size.Width, size.Height);
         }
 
         /// <summary>


### PR DESCRIPTION
I'm working on a Font atlas implementation so I needed to get the glyph size. Hope it's alright to expose it like this :) 

Related to #57. I think it would be useful to expose some more glyph data through `Glyph` as mentioned in that issue (though this is all I needed for now).