### PR TITLE
Expose glyph data

### DIFF
--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -142,7 +142,7 @@ namespace SixLabors.Fonts
         /// <value>
         /// The font instance.
         /// </value>
-        internal IFontInstance FontInstance => this.instance.Value;
+        public IFontInstance FontInstance => this.instance.Value;
 
         /// <summary>
         /// Gets the glyph.

--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -149,7 +149,7 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="codePoint">The code point of the character.</param>
         /// <returns>Returns the glyph</returns>
-        internal Glyph GetGlyph(int codePoint)
+        public Glyph GetGlyph(int codePoint)
         {
             return new Glyph(this.instance.Value.GetGlyph(codePoint), this.Size);
         }

--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -142,7 +142,7 @@ namespace SixLabors.Fonts
         /// <value>
         /// The font instance.
         /// </value>
-        public IFontInstance FontInstance => this.instance.Value;
+        public IFontInstance Instance => this.instance.Value;
 
         /// <summary>
         /// Gets the glyph.

--- a/src/SixLabors.Fonts/FontInstance.cs
+++ b/src/SixLabors.Fonts/FontInstance.cs
@@ -12,7 +12,7 @@ namespace SixLabors.Fonts
     /// <summary>
     /// provide metadata about a font.
     /// </summary>
-    internal class FontInstance : IFontInstance
+    public class FontInstance : IFontInstance
     {
         private readonly CMapTable cmap;
         private readonly GlyphTable glyphs;

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -20,7 +20,7 @@ namespace SixLabors.Fonts
         /// <value>
         /// The glyph instance.
         /// </value>
-        public GlyphInstance GlyphInstance => this.instance;
+        public GlyphInstance Instance => this.instance;
 
         internal Glyph(GlyphInstance instance, float pointSize)
         {

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -9,10 +9,18 @@ namespace SixLabors.Fonts
     /// <summary>
     /// A glyph from a particular font face.
     /// </summary>
-    internal readonly struct Glyph
+    public readonly struct Glyph
     {
         private readonly GlyphInstance instance;
         private readonly float pointSize;
+
+        /// <summary>
+        /// Gets the glyph instance.
+        /// </summary>
+        /// <value>
+        /// The glyph instance.
+        /// </value>
+        public GlyphInstance GlyphInstance => this.instance;
 
         internal Glyph(GlyphInstance instance, float pointSize)
         {

--- a/src/SixLabors.Fonts/GlyphInstance.cs
+++ b/src/SixLabors.Fonts/GlyphInstance.cs
@@ -11,7 +11,7 @@ namespace SixLabors.Fonts
     /// <summary>
     /// A glyph from a particular font face.
     /// </summary>
-    internal partial class GlyphInstance
+    public partial class GlyphInstance
     {
         private readonly ushort sizeOfEm;
         private readonly Vector2[] controlPoints;
@@ -259,5 +259,32 @@ namespace SixLabors.Fonts
                 this.Count = 0;
             }
         }
+
+        public ushort SizeOfEm => this.sizeOfEm;
+
+        /// <summary>
+        /// The points defining the shape of this glyph
+        /// </summary>
+        public Vector2[] ControlPoints => this.controlPoints;
+
+        /// <summary>
+        /// Wether or not the corresponding control point is on a curve
+        /// </summary>
+        public bool[] OnCurves => this.onCurves;
+
+        /// <summary>
+        /// The end points
+        /// </summary>
+        public ushort[] EndPoints => this.endPoints;
+
+        /// <summary>
+        /// The distance from the bounding box start
+        /// </summary>
+        public short LeftSideBearing => this.leftSideBearing;
+
+        /// <summary>
+        /// The scale factor that is applied to the glyph
+        /// </summary>
+        public float ScaleFactor => this.scaleFactor;
     }
 }

--- a/src/SixLabors.Fonts/IFontInstance.cs
+++ b/src/SixLabors.Fonts/IFontInstance.cs
@@ -5,7 +5,7 @@ using System.Numerics;
 
 namespace SixLabors.Fonts
 {
-    internal interface IFontInstance
+    public interface IFontInstance
     {
         FontDescription Description { get; }
 

--- a/src/SixLabors.Fonts/RendererOptions.cs
+++ b/src/SixLabors.Fonts/RendererOptions.cs
@@ -150,7 +150,7 @@ namespace SixLabors.Fonts
                 Start = 0,
                 End = length - 1,
                 PointSize = this.Font.Size,
-                Font = this.Font.FontInstance,
+                Font = this.Font.Instance,
                 TabWidth = this.TabWidth,
                 ApplyKerning = this.ApplyKerning
             };

--- a/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
@@ -11,7 +11,7 @@ namespace SixLabors.Fonts.Tests
         {
             Font font = new FontCollection().Install(TestFonts.CarterOneFileData()).CreateFont(12);
 
-            GlyphInstance g = font.FontInstance.GetGlyph('\0');
+            GlyphInstance g = font.Instance.GetGlyph('\0');
         }
 
         [Fact]

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -72,7 +72,7 @@ namespace SixLabors.Fonts.Tests
 
             // Get letter A
             Glyph g = font.GetGlyph(41);
-            var instance = g.GlyphInstance;
+            var instance = g.Instance;
 
             Assert.Equal(20, instance.ControlPoints.Length);
             Assert.Equal(20, instance.OnCurves.Length);

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -64,5 +64,18 @@ namespace SixLabors.Fonts.Tests
             Font d = fc.Install(new FakeFontInstance(text)).CreateFont(12);
             return new Font(d, 1);
         }
+
+        [Fact]
+        public void LoadGlyph()
+        {
+            Font font = new FontCollection().Install(TestFonts.SimpleFontFileData()).CreateFont(12);
+
+            // Get letter A
+            Glyph g = font.GetGlyph(41);
+            var instance = g.GlyphInstance;
+
+            Assert.Equal(20, instance.ControlPoints.Length);
+            Assert.Equal(20, instance.OnCurves.Length);
+        }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -14,7 +14,7 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void RenderToPointAndSingleDPI()
         {
-            var glyph = new Glyph(new GlyphInstance((FontInstance)CreateFont("A").FontInstance, new Vector2[0], new bool[0], new ushort[0], new Bounds(0, 1, 0, 1), 0, 0, 1, 0), 10);
+            var glyph = new Glyph(new GlyphInstance((FontInstance)CreateFont("A").Instance, new Vector2[0], new bool[0], new ushort[0], new Bounds(0, 1, 0, 1), 0, 0, 1, 0), 10);
 
             var locationInFontSpace = new PointF(99, 99) / 72; // glyp ends up 10px over due to offiset in fake glyph
             glyph.RenderTo(renderer, locationInFontSpace, 72, 0);

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -79,7 +79,7 @@ namespace SixLabors.Fonts.Tests
             };
 
             IReadOnlyList<GlyphLayout> glyphsToRender = new TextLayout().GenerateLayout(text, span);
-            IFontInstance fontInst = span.Font.FontInstance;
+            IFontInstance fontInst = span.Font.Instance;
             float lineHeight = (fontInst.LineHeight * span.Font.Size) / (fontInst.EmSize * 72);
             lineHeight *= scaleFactor;
             RectangleF bound = TextMeasurer.GetBounds(glyphsToRender, new Vector2(span.DpiX, span.DpiY));


### PR DESCRIPTION
I need this to rendering fonts myself with a GPU rasterizer. Since this library is not just about `rasterizing` fonts but also about `loading` them it seems useful to expose those informations. In the current version it's not possible to obtain any informations about glyphs apart from their dimensions.

Fixes #89 #65 #57 
