### PR TITLE
Fix LanguageID check for Windows platform, they are specified as hexa…

### DIFF
--- a/src/SixLabors.Fonts/Tables/General/NameTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/NameTable.cs
@@ -114,7 +114,7 @@ namespace SixLabors.Fonts.Tables.General
         {
             foreach (NameRecord name in this.names)
             {
-                if (name.Platform == PlatformIDs.Windows && name.LanguageID == 0409)
+                if (name.Platform == PlatformIDs.Windows && name.LanguageID == 0x0409)
                 {
                     if (name.NameID == nameId)
                     {


### PR DESCRIPTION
…decimal in the spec.

Bad thing is I can't provide a test font due to licensing issues.