### PR TITLE
Allowing retrieving fontnames in any culture

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,36 +30,36 @@
 
   <!--
     https://apisof.net/
-    +===================+=======+==========+=====================+=============+=================+====================+==============+
-    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+
-    | netcoreapp3.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |
-    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |
-    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |
-    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |
-    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |
-    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |
-    | net472            |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+
+    +===================+=======+==========+=====================+=============+=================+====================+==============+==================+
+    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE | CULTUREINFO_LCID |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+==================+
+    | netcoreapp3.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |         Y        |
+    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |         Y        |
+    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |         Y        |
+    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |         Y        |
+    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |         Y        |
+    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |         N        |
+    | net472            |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |         Y        |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+==================+
     -->
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_RUNTIME_INTRINSICS;SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_RUNTIME_INTRINSICS;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
 
   <!-- Default settings that explicitly differ from the Sdk.targets defaults-->

--- a/src/SixLabors.Fonts/FileFontInstance.cs
+++ b/src/SixLabors.Fonts/FileFontInstance.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Numerics;
 using SixLabors.Fonts.Tables;
@@ -16,21 +17,21 @@ namespace SixLabors.Fonts
     {
         private readonly Lazy<IFontInstance> font;
 
-        public FileFontInstance(string path)
-            : this(path, 0)
+        public FileFontInstance(string path, CultureInfo culture)
+            : this(path, 0, culture)
         {
         }
 
-        public FileFontInstance(string path, long offset)
-            : this(FontDescription.LoadDescription(path), path, offset)
+        public FileFontInstance(string path, long offset, CultureInfo culture)
+            : this(FontDescription.LoadDescription(path, culture), path, offset, culture)
         {
         }
 
-        internal FileFontInstance(FontDescription description, string path, long offset)
+        internal FileFontInstance(FontDescription description, string path, long offset, CultureInfo culture)
         {
             this.Description = description;
             this.Path = path;
-            this.font = new Lazy<Fonts.IFontInstance>(() => FontInstance.LoadFont(path, offset));
+            this.font = new Lazy<Fonts.IFontInstance>(() => FontInstance.LoadFont(path, offset, culture));
         }
 
         public FontDescription Description { get; }
@@ -57,8 +58,9 @@ namespace SixLabors.Fonts
         /// Reads a <see cref="FontInstance"/> from the specified stream.
         /// </summary>
         /// <param name="path">The file path.</param>
+        /// <param name="culture">The Culture used while reading font metadata.</param>
         /// <returns>a <see cref="FontInstance"/>.</returns>
-        public static FileFontInstance[] LoadFontCollection(string path)
+        public static FileFontInstance[] LoadFontCollection(string path, CultureInfo culture)
         {
             using (FileStream fs = File.OpenRead(path))
             {
@@ -70,8 +72,8 @@ namespace SixLabors.Fonts
                 for (int i = 0; i < ttcHeader.NumFonts; ++i)
                 {
                     fs.Position = startPos + ttcHeader.OffsetTable[i];
-                    var description = FontDescription.LoadDescription(fs);
-                    fonts[i] = new FileFontInstance(description, path, (long)ttcHeader.OffsetTable[i]);
+                    var description = FontDescription.LoadDescription(fs, culture);
+                    fonts[i] = new FileFontInstance(description, path, (long)ttcHeader.OffsetTable[i], culture);
                 }
 
                 return fonts;

--- a/src/SixLabors.Fonts/FontDescription.cs
+++ b/src/SixLabors.Fonts/FontDescription.cs
@@ -163,7 +163,7 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Reads all the <see cref="FontDescription"/>s from the specified stream (typically a .ttc file like simsun.ttc).
         /// </summary>
-        /// <param name="stream">The stream to read the font collection from.</param>             
+        /// <param name="stream">The stream to read the font collection from.</param>
         /// <param name="culture">The culture to load metadata in.</param>
         /// <returns>a <see cref="FontDescription"/>.</returns>
         public static FontDescription[] LoadFontCollectionDescriptions(Stream stream, CultureInfo culture)

--- a/src/SixLabors.Fonts/FontDescription.cs
+++ b/src/SixLabors.Fonts/FontDescription.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.IO;
 using SixLabors.Fonts.Tables;
 using SixLabors.Fonts.Tables.General;
+using SixLabors.Fonts.Tables.General.Name;
+using SixLabors.Fonts.WellKnownIds;
 
 namespace SixLabors.Fonts
 {
@@ -14,14 +16,6 @@ namespace SixLabors.Fonts
     /// </summary>
     public class FontDescription
     {
-        internal FontDescription(string fontName, string fontFamily, string fontSubFamilyName, FontStyle style)
-        {
-            this.FontName = fontName;
-            this.FontFamily = fontFamily;
-            this.FontSubFamilyName = fontSubFamilyName;
-            this.Style = style;
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="FontDescription" /> class.
         /// </summary>
@@ -30,8 +24,14 @@ namespace SixLabors.Fonts
         /// <param name="head">The head.</param>
         /// <param name="culture">The culture to load metadata in.</param>
         internal FontDescription(NameTable nameTable, OS2Table? os2, HeadTable? head, CultureInfo culture)
-            : this(nameTable.FontName(culture), nameTable.FontFamilyName(culture), nameTable.FontSubFamilyName(culture), ConvertStyle(os2, head))
         {
+            this.FontName = nameTable.FontName(culture);
+            this.FontFamily = nameTable.FontFamilyName(culture);
+            this.FontSubFamilyName = nameTable.FontSubFamilyName(culture);
+            this.Style = ConvertStyle(os2, head);
+            this.FontNames = nameTable.GetNameRecordsById(NameIds.FullFontName);
+            this.FontFamilyNames = nameTable.GetNameRecordsById(NameIds.FontFamilyName);
+            this.FontSubFamilyNames = nameTable.GetNameRecordsById(NameIds.FontSubfamilyName);
         }
 
         /// <summary>
@@ -56,6 +56,21 @@ namespace SixLabors.Fonts
         /// Gets the font sub family.
         /// </summary>
         public string FontSubFamilyName { get; }
+
+        /// <summary>
+        /// Gets the font names in every platform and language.
+        /// </summary>
+        internal IEnumerable<NameRecord> FontNames { get; }
+
+        /// <summary>
+        /// Gets the font family names in every platform and language.
+        /// </summary>
+        internal IEnumerable<NameRecord> FontFamilyNames { get; }
+
+        /// <summary>
+        /// Gets the font sub family names in every platform and language.
+        /// </summary>
+        internal IEnumerable<NameRecord> FontSubFamilyNames { get; }
 
         /// <summary>
         /// Reads a <see cref="FontDescription"/> from the specified stream.

--- a/src/SixLabors.Fonts/IReadonlyFontCollection.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontCollection.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
+using System.Globalization;
 using SixLabors.Fonts.Exceptions;
 
 namespace SixLabors.Fonts
@@ -33,5 +34,26 @@ namespace SixLabors.Fonts
         /// <param name="family">The found family.</param>
         /// <returns>true if a font of that family has been installed into the font collection.</returns>
         bool TryFind(string fontFamily, out FontFamily family);
+
+        /// <summary>
+        /// Finds the specified font family, also by looking into locale specific names.<br/>
+        /// <b>Note</b>: On targets where <see cref="CultureInfo"/>.LCID is not supported,
+        /// such as .NET Standard 1.0,  it's same as <see cref="Find(string)"/>
+        /// </summary>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="preferredCulture">Preferred culture, can be null.</param>
+        /// <returns>The family if installed otherwise throws <see cref="FontFamilyNotFoundException"/></returns>
+        FontFamily Find(string fontFamily, CultureInfo? preferredCulture);
+
+        /// <summary>
+        /// Finds the specified font family, also by looking into locale specific names.
+        /// <b>Note</b>: On targets where <see cref="CultureInfo"/>.LCID is not supported,
+        /// such as .NET Standard 1.0,  it's same as <see cref="TryFind(string, out FontFamily)"/>
+        /// </summary>
+        /// <param name="fontFamily">The font family to find.</param>
+        /// <param name="preferredCulture">Preferred culture, can be null.</param>
+        /// <param name="family">The found family.</param>
+        /// <returns>true if a font of that family has been installed into the font collection.</returns>
+        bool TryFind(string fontFamily, CultureInfo? preferredCulture, out FontFamily family);
     }
 }

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -90,5 +90,11 @@ namespace SixLabors.Fonts
 
         /// <inheritdocs />
         public bool TryFind(string fontFamily, out FontFamily family) => this.collection.TryFind(fontFamily, out family);
+
+        /// <inheritdocs />
+        public FontFamily Find(string fontFamily, CultureInfo? preferredCulture) => this.collection.Find(fontFamily, preferredCulture);
+
+        /// <inheritdocs />
+        public bool TryFind(string fontFamily, CultureInfo? preferredCulture, out FontFamily family) => this.collection.TryFind(fontFamily, preferredCulture, out family);
     }
 }

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -35,7 +35,7 @@ namespace SixLabors.Fonts
         /// Finds the specified font family from the system font store.
         /// </summary>
         /// <param name="fontFamily">The font family.</param>
-        /// <returns>The family if installed otherwise null</returns>
+        /// <returns>The family if installed otherwise throws <see cref="FontFamilyNotFoundException"/></returns>
         public static FontFamily Find(string fontFamily) => Collection.Find(fontFamily);
 
         /// <summary>

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using SixLabors.Fonts.Exceptions;
 
 namespace SixLabors.Fonts
 {
@@ -44,6 +45,23 @@ namespace SixLabors.Fonts
         /// <param name="family">The found family.</param>
         /// <returns>true if a font of that family has been installed into the font collection.</returns>
         public static bool TryFind(string fontFamily, out FontFamily family) => Collection.TryFind(fontFamily, out family);
+
+        /// <summary>
+        /// Finds the specified font family from the system font store, also by looking into locale specific names.
+        /// </summary>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="preferredCulture">Preferred culture, can be null.</param>
+        /// <returns>The family if installed otherwise throws <see cref="FontFamilyNotFoundException"/></returns>
+        public static FontFamily Find(string fontFamily, CultureInfo? preferredCulture) => Collection.Find(fontFamily, preferredCulture);
+
+        /// <summary>
+        /// Finds the specified font family from the system font store, also by looking into locale specific names.
+        /// </summary>
+        /// <param name="fontFamily">The font family to find.</param>
+        /// <param name="preferredCulture">Preferred culture, can be null.</param>
+        /// <param name="family">The found family.</param>
+        /// <returns>true if a font of that family has been installed into the font collection.</returns>
+        public static bool TryFind(string fontFamily, CultureInfo? preferredCulture, out FontFamily family) => Collection.TryFind(fontFamily, preferredCulture, out family);
 
         /// <summary>
         /// Create a new instance of the <see cref="Font"/> for the named font family.

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace SixLabors.Fonts
 {
@@ -11,10 +12,10 @@ namespace SixLabors.Fonts
     /// </summary>
     public static class SystemFonts
     {
-        private static Lazy<SystemFontCollection> lazySystemFonts = new Lazy<SystemFontCollection>(() => new SystemFontCollection());
+        private static Lazy<IReadOnlyFontCollection> lazySystemFonts = new Lazy<IReadOnlyFontCollection>(() => LoadCollection(CultureInfo.InvariantCulture));
 
         /// <summary>
-        /// Gets the collection hosting the globably installled system fonts.
+        /// Gets the collection containing the globaly installled system fonts.
         /// </summary>
         /// <value>
         /// The system fonts.
@@ -60,5 +61,12 @@ namespace SixLabors.Fonts
         /// <param name="size">The size.</param>
         /// <returns>Returns instance of the <see cref="Font"/> from the current collection.</returns>
         public static Font CreateFont(string fontFamily, float size) => Collection.CreateFont(fontFamily, size);
+
+        /// <summary>
+        /// Creates the collection of system fonts hosted the globably installed system fonts with metadata stored in a particular culture.
+        /// </summary>
+        /// <param name="culture">The culture to load the fonts metadata in.</param>
+        /// <returns>the newly created collection containg the loaded system fonts with metadata in the desired culture (where availible).</returns>
+        public static IReadOnlyFontCollection LoadCollection(CultureInfo culture) => new SystemFontCollection(culture);
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using SixLabors.Fonts.Tables.General;
 
@@ -19,12 +20,13 @@ namespace SixLabors.Fonts.Tests.Fakes
                   GenerateOS2Table(), 
                   GenerateHorizontalMetricsTable(glyphs), 
                   GenerateHeadTable(glyphs), 
-                  new KerningTable(new Fonts.Tables.General.Kern.KerningSubTable[0]))
+                  new KerningTable(new Fonts.Tables.General.Kern.KerningSubTable[0]),
+                  CultureInfo.InvariantCulture)
         {
         }
 
         internal FakeFontInstance(NameTable nameTable, CMapTable cmap, GlyphTable glyphs, OS2Table os2, HorizontalMetricsTable horizontalMetrics, HeadTable head, KerningTable kern) 
-            : base(nameTable, cmap, glyphs, os2, horizontalMetrics, head, kern) 
+            : base(nameTable, cmap, glyphs, os2, horizontalMetrics, head, kern, CultureInfo.InvariantCulture) 
         {
         }
 

--- a/tests/SixLabors.Fonts.Tests/FontDescriptionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontDescriptionTests.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-
+using System.Collections.Generic;
+using System.Globalization;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests
@@ -24,6 +24,93 @@ namespace SixLabors.Fonts.Tests
             Assert.Equal("name", description.FontName);
             Assert.Equal("sub", description.FontSubFamilyName);
             Assert.Equal("fam", description.FontFamily);
+        }
+
+        [Fact]
+        public void LoadFontDescription_CultureNamePriority_FirstWindows()
+        {
+            var usCulture = new CultureInfo(0x0409);
+            var c1 = new CultureInfo(1034); // spanish - international
+            var c2 = new CultureInfo(3082); // spanish - traditional
+
+            var writer = new BinaryWriter();
+            writer.WriteTrueTypeFileHeader(1, 0, 0, 0);
+            writer.WriteTableHeader("name", 0, 28, 999);
+            writer.WriteNameTable(
+                (WellKnownIds.NameIds.FullFontName, "name_c1", c1),
+                (WellKnownIds.NameIds.FontSubfamilyName, "sub_c1", c1),
+                (WellKnownIds.NameIds.FontFamilyName, "fam_c1", c1),
+                (WellKnownIds.NameIds.FullFontName, "name_c2", c2),
+                (WellKnownIds.NameIds.FontSubfamilyName, "sub_c2", c2),
+                (WellKnownIds.NameIds.FontFamilyName, "fam_c2", c2)
+                );
+
+            var description = FontDescription.LoadDescription(writer.GetStream(), CultureInfo.InvariantCulture);
+
+            // unknown culture shoudl prioritise US, but missing so will return first
+            Assert.Equal("name_c1", description.FontName);
+            Assert.Equal("sub_c1", description.FontSubFamilyName);
+            Assert.Equal("fam_c1", description.FontFamily);
+        }
+
+        [Fact]
+        public void LoadFontDescription_CultureNamePriority_US()
+        {
+            var usCulture = new CultureInfo(0x0409);
+            var c1 = new CultureInfo(1034); // spanish - international
+            var c2 = new CultureInfo(3082); // spanish - traditional
+
+            var writer = new BinaryWriter();
+            writer.WriteTrueTypeFileHeader(1, 0, 0, 0);
+            writer.WriteTableHeader("name", 0, 28, 999);
+            writer.WriteNameTable(
+                (WellKnownIds.NameIds.FullFontName, "name_c1", c1),
+                (WellKnownIds.NameIds.FontSubfamilyName, "sub_c1", c1),
+                (WellKnownIds.NameIds.FontFamilyName, "fam_c1", c1),
+                (WellKnownIds.NameIds.FullFontName, "name_c2", c2),
+                (WellKnownIds.NameIds.FontSubfamilyName, "sub_c2", c2),
+                (WellKnownIds.NameIds.FontFamilyName, "fam_c2", c2),
+                (WellKnownIds.NameIds.FullFontName, "name_us", usCulture),
+                (WellKnownIds.NameIds.FontSubfamilyName, "sub_us", usCulture),
+                (WellKnownIds.NameIds.FontFamilyName, "fam_us", usCulture)
+                );
+
+            var description = FontDescription.LoadDescription(writer.GetStream(), CultureInfo.InvariantCulture);
+
+            // unknown culture shoudl prioritise US, but missing so will return first
+            Assert.Equal("name_us", description.FontName);
+            Assert.Equal("sub_us", description.FontSubFamilyName);
+            Assert.Equal("fam_us", description.FontFamily);
+        }
+
+        [Fact]
+        public void LoadFontDescription_CultureNamePriority_Exactmatch()
+        {
+            var usCulture = new CultureInfo(0x0409);
+            var c1 = new CultureInfo(1034); // spanish - international
+            var c2 = new CultureInfo(3082); // spanish - traditional
+
+            var writer = new BinaryWriter();
+            writer.WriteTrueTypeFileHeader(1, 0, 0, 0);
+            writer.WriteTableHeader("name", 0, 28, 999);
+            writer.WriteNameTable(
+                (WellKnownIds.NameIds.FullFontName, "name_c1", c1),
+                (WellKnownIds.NameIds.FontSubfamilyName, "sub_c1", c1),
+                (WellKnownIds.NameIds.FontFamilyName, "fam_c1", c1),
+                (WellKnownIds.NameIds.FullFontName, "name_c2", c2),
+                (WellKnownIds.NameIds.FontSubfamilyName, "sub_c2", c2),
+                (WellKnownIds.NameIds.FontFamilyName, "fam_c2", c2),
+                (WellKnownIds.NameIds.FullFontName, "name_us", usCulture),
+                (WellKnownIds.NameIds.FontSubfamilyName, "sub_us", usCulture),
+                (WellKnownIds.NameIds.FontFamilyName, "fam_us", usCulture)
+                );
+
+            var description = FontDescription.LoadDescription(writer.GetStream(), c2);
+
+            // unknown culture shoudl prioritise US, but missing so will return first
+            Assert.Equal("name_c2", description.FontName);
+            Assert.Equal("sub_c2", description.FontSubFamilyName);
+            Assert.Equal("fam_c2", description.FontFamily);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/SystemFontsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/SystemFontsTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using SixLabors.Fonts;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SixLabors.Fonts.Tests
+{
+    // The fonts which I want to test are preinstalled on Windows, I'm not sure if they are redistributable
+    // So instead of putting those font files inside the repository, we test them in SystemFonts.
+    public class SystemFontsTests
+    {
+        private ITestOutputHelper output;
+
+        public SystemFontsTests(ITestOutputHelper outputHelper)
+        {
+            this.output = outputHelper;
+        }
+
+        [Theory]
+        [InlineData("simhei", "黑体")] // Test Chinese Sans-Serif font SimHei (黑体)
+        public void FindingFontByNamesInMultipleLanguages(params string[] fontFamilyNames)
+        {
+            IEnumerable<FontFamily> families = fontFamilyNames.Select(fontFamily =>
+            {
+                bool found = SystemFonts.TryFind(fontFamily, null, out FontFamily family);
+                // If a family can be found, then it shouldn't be null
+                Assert.Equal(found, family != null);
+                return family;
+            });
+
+            if (families.All(family => family == null))
+            {
+                this.output.WriteLine($"Font [{string.Join(" aka. ", fontFamilyNames)}] is not installed on the current machine, test skipped.");
+                return;
+            }
+
+            // Assert all loaded font families using names in different languages are actually the same
+            foreach (FontFamily family in families)
+            {
+                Assert.Same(family, families.First());
+            }
+        }
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/Tables/General/NameTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/NameTableTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Globalization;
 using SixLabors.Fonts.Exceptions;
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.WellKnownIds;
@@ -27,13 +28,13 @@ namespace SixLabors.Fonts.Tests.Tables.General
 
             var table = NameTable.Load(writer.GetReader());
 
-            Assert.Equal("fullname", table.FontName);
-            Assert.Equal("family", table.FontFamilyName);
-            Assert.Equal("subfamily", table.FontSubFamilyName);
-            Assert.Equal("id", table.Id);
-            Assert.Equal("copyright", table.GetNameById(NameIds.CopyrightNotice));
-            Assert.Equal("other1", table.GetNameById(90));
-            Assert.Equal("other2", table.GetNameById(91));
+            Assert.Equal("fullname", table.FontName(CultureInfo.InvariantCulture));
+            Assert.Equal("family", table.FontFamilyName(CultureInfo.InvariantCulture));
+            Assert.Equal("subfamily", table.FontSubFamilyName(CultureInfo.InvariantCulture));
+            Assert.Equal("id", table.Id(CultureInfo.InvariantCulture));
+            Assert.Equal("copyright", table.GetNameById(CultureInfo.InvariantCulture, NameIds.CopyrightNotice));
+            Assert.Equal("other1", table.GetNameById(CultureInfo.InvariantCulture, 90));
+            Assert.Equal("other2", table.GetNameById(CultureInfo.InvariantCulture, 91));
         }
 
         [Fact]
@@ -58,13 +59,13 @@ namespace SixLabors.Fonts.Tests.Tables.General
 
             var table = NameTable.Load(writer.GetReader());
 
-            Assert.Equal("fullname", table.FontName);
-            Assert.Equal("family", table.FontFamilyName);
-            Assert.Equal("subfamily", table.FontSubFamilyName);
-            Assert.Equal("id", table.Id);
-            Assert.Equal("copyright", table.GetNameById(NameIds.CopyrightNotice));
-            Assert.Equal("other1", table.GetNameById(90));
-            Assert.Equal("other2", table.GetNameById(91));
+            Assert.Equal("fullname", table.FontName(CultureInfo.InvariantCulture));
+            Assert.Equal("family", table.FontFamilyName(CultureInfo.InvariantCulture));
+            Assert.Equal("subfamily", table.FontSubFamilyName(CultureInfo.InvariantCulture));
+            Assert.Equal("id", table.Id(CultureInfo.InvariantCulture));
+            Assert.Equal("copyright", table.GetNameById(CultureInfo.InvariantCulture, NameIds.CopyrightNotice));
+            Assert.Equal("other1", table.GetNameById(CultureInfo.InvariantCulture, 90));
+            Assert.Equal("other2", table.GetNameById(CultureInfo.InvariantCulture, 91));
         }
 
         [Fact]

--- a/tests/SixLabors.Fonts.Tests/WriterExtensions.cs
+++ b/tests/SixLabors.Fonts.Tests/WriterExtensions.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -85,8 +86,13 @@ namespace SixLabors.Fonts.Tests
             writer.WriteUInt16(entrySelector);
             writer.WriteUInt16(rangeShift);
         }
-
         public static void WriteNameTable(this BinaryWriter writer, Dictionary<NameIds, string> names, List<string> languages = null)
+            => writer.WriteNameTable(names.Select(x => (x.Key, x.Value, CultureInfo.InvariantCulture)).ToList(), languages);
+
+        public static void WriteNameTable(this BinaryWriter writer, params (NameIds nameId, string value, CultureInfo culture)[] names)
+            => writer.WriteNameTable(names.ToList());
+
+        public static void WriteNameTable(this BinaryWriter writer, List<(NameIds nameId, string value, CultureInfo culture)> names, List<string> languages = null)
         {
             // Type          | Name                        | Description
             // --------------|-----------------------------|--------------------------------------------------------
@@ -126,14 +132,14 @@ namespace SixLabors.Fonts.Tests
             Encoding encoding = Encoding.BigEndianUnicode; // this is Unicode2
             int stringOffset = 0;
             var offsets = new List<int>();
-            foreach (KeyValuePair<NameIds, string> n in names)
+            foreach ((NameIds name, string value, CultureInfo culture) in names)
             {
-                writer.WriteUInt16(0); // hard code platform
+                writer.WriteUInt16((ushort)PlatformIDs.Windows); // hard code platform
                 writer.WriteUInt16((ushort)EncodingIDs.Unicode2); // hard code encoding
-                writer.WriteUInt16(0); // hard code language
-                writer.WriteUInt16((ushort)n.Key);
+                writer.WriteUInt16((ushort)culture.LCID); // hard code language
+                writer.WriteUInt16((ushort)name);
 
-                int length = Encoding.BigEndianUnicode.GetBytes(n.Value).Length;
+                int length = Encoding.BigEndianUnicode.GetBytes(value).Length;
                 writer.WriteUInt16((ushort)length);
                 writer.WriteOffset16((ushort)stringOffset);
                 offsets.Add(stringOffset);
@@ -159,11 +165,11 @@ namespace SixLabors.Fonts.Tests
 
             int currentItem = 0;
 
-            foreach (KeyValuePair<NameIds, string> n in names)
+            foreach ((NameIds name, string value, CultureInfo culture) in names)
             {
                 int expectedPosition = offsets[currentItem];
                 currentItem++;
-                writer.WriteNoLength(n.Value, Encoding.BigEndianUnicode);
+                writer.WriteNoLength(value, Encoding.BigEndianUnicode);
             }
 
             if (languages != null)


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open ← The current pull request is trying to contribute to an another existing pull request. 
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
These changes are based on the existing pull request https://github.com/SixLabors/Fonts/pull/126 .
I added some features which were written as comments.
Currently I want to merge into [sw/culture-aware-fontnames](https://github.com/SixLabors/Fonts/tree/sw/culture-aware-fontnames), which is the branch of https://github.com/SixLabors/Fonts/pull/126 , before `sw/culture-aware-fontnames` gets merged into `master`.

<!-- Thanks for contributing to SixLabors.Fonts! -->
