### PR TITLE
Strong name SixLabors.Fonts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,8 +91,9 @@
       https://www.myget.org/F/sixlabors/api/v3/index.json;
       https://api.nuget.org/v3/index.json;
     </RestoreSources>
-    <SixLaborsPublicKey>002400000c8000009400000006020000002400005253413100040000010001000147e6fe6766715eec6cfed61f1e7dcdbf69748a3e355c67e9d8dfd953acab1d5e012ba34b23308166fdc61ee1d0390d5f36d814a6091dd4b5ed9eda5a26afced924c683b4bfb4b3d64b0586a57eff9f02b1f84e3cb0ddd518bd1697f2c84dcbb97eb8bb5c7801be12112ed0ec86db934b0e9a5171e6bb1384b6d2f7d54dfa97</SixLaborsPublicKey>
+    <SixLaborsPublicKey>00240000048000009400000006020000002400005253413100040000010001000147e6fe6766715eec6cfed61f1e7dcdbf69748a3e355c67e9d8dfd953acab1d5e012ba34b23308166fdc61ee1d0390d5f36d814a6091dd4b5ed9eda5a26afced924c683b4bfb4b3d64b0586a57eff9f02b1f84e3cb0ddd518bd1697f2c84dcbb97eb8bb5c7801be12112ed0ec86db934b0e9a5171e6bb1384b6d2f7d54dfa97</SixLaborsPublicKey>
     <UseSharedCompilation>true</UseSharedCompilation>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <!-- Package references and additional files which are consumed by all projects -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,8 +31,7 @@
     <PackageReference Include="StyleCop.Analyzers" IsImplicitlyDefined="true"  />
 
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2, PublicKeyToken=null" />
-    <InternalsVisibleTo Include="SixLabors.Fonts.Tests" />
+    <InternalsVisibleTo Include="SixLabors.Fonts.Tests" PublicKey="$(SixLaborsPublicKey)"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
StrongNaming our stack all the way down.