### PR TITLE
Allow falling back to alternative font families if glyph is missing

### DIFF
--- a/SixLabors.Fonts.sln
+++ b/SixLabors.Fonts.sln
@@ -38,6 +38,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ListFonts", "samples\ListFonts\ListFonts.csproj", "{6DF4C474-1FDF-4DE0-9CB2-9674D2CCE1BA}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems*{09e744ec-4852-4fc7-be78-c1b399f17967}*SharedItemsImports = 5
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/samples/DrawWithImageSharp/BoundingBoxes.cs
+++ b/samples/DrawWithImageSharp/BoundingBoxes.cs
@@ -3,7 +3,6 @@ using SixLabors.Fonts;
 using SixLabors.Shapes.Temp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Processing.Drawing;
 
 namespace DrawWithImageSharp
 {

--- a/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
+++ b/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -9,11 +9,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="..\..\tests\SixLabors.Fonts.Tests\Fonts\**\*.ttf" Link="Fonts\%(Filename)%(Extension)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\tests\SixLabors.Fonts.Tests\Fonts\**\*.woff" Link="Fonts\%(Filename)%(Extension)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\SixLabors.Fonts\SixLabors.Fonts.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0004" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0007" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
@@ -22,5 +31,6 @@
       <HintPath>System.Web</HintPath>
     </Reference>
   </ItemGroup>
+
 
 </Project>

--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -7,7 +7,6 @@ namespace SixLabors.Fonts.DrawWithImageSharp
     using Shapes;
     using SixLabors.ImageSharp.PixelFormats;
     using SixLabors.ImageSharp.Processing;
-    using SixLabors.ImageSharp.Processing.Drawing;
     using SixLabors.Shapes.Temp;
     using System.Collections.Generic;
     using System.Linq;
@@ -19,11 +18,11 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         public static void Main(string[] args)
         {
             var fonts = new FontCollection();
-            FontFamily font = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.ttf");
-            FontFamily fontWoff = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\SixLaborsSampleAB.woff");
-            FontFamily font2 = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\OpenSans-Regular.ttf");
-            FontFamily carter = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Carter_One\CarterOne.ttf");
-            FontFamily Wendy_One = fonts.Install(@"..\..\tests\SixLabors.Fonts.Tests\Fonts\Wendy_One\WendyOne-Regular.ttf");
+            FontFamily font = fonts.Install(@"Fonts\SixLaborsSampleAB.ttf");
+            FontFamily fontWoff = fonts.Install(@"Fonts\SixLaborsSampleAB.woff");
+            FontFamily font2 = fonts.Install(@"Fonts\OpenSans-Regular.ttf");
+            FontFamily carter = fonts.Install(@"Fonts\CarterOne.ttf");
+            FontFamily Wendy_One = fonts.Install(@"Fonts\WendyOne-Regular.ttf");
 
             RenderText(font, "abc", 72);
             RenderText(font, "ABd", 72);
@@ -95,7 +94,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
 
             using (var img = new Image<Rgba32>(width, height))
             {
-                img.Mutate(x=>x.Fill(Rgba32.White));
+                img.Mutate(x => x.Fill(Rgba32.White));
 
                 IPathCollection shapes = SixLabors.Shapes.Temp.TextBuilder.GenerateGlyphs(text, new Vector2(50f, 4f), new RendererOptions(font, 72));
                 img.Mutate(x => x.Fill(Rgba32.Black, shapes));
@@ -119,9 +118,9 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             builder.Paths
                 .SaveImage((int)size.Width + 20, (int)size.Height + 20, font.Font.Name, text + ".png");
         }
-        public static void RenderText(FontFamily font, string text, float pointSize = 12)
+        public static void RenderText(FontFamily font, string text, float pointSize = 12, IEnumerable<FontFamily> fallbackFonts = null)
         {
-            RenderText(new RendererOptions(new Font(font, pointSize), 96) { ApplyKerning = true, WrappingWidth = 340 }, text);
+            RenderText(new RendererOptions(new Font(font, pointSize), 96, fallbackFonts?.ToArray()) { ApplyKerning = true, WrappingWidth = 340 }, text);
         }
 
         public static void SaveImage(this IEnumerable<IPath> shapes, int width, int height, params string[] path)
@@ -171,7 +170,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                 return s;
             });
             string str = sb.ToString();
-            shape = new ComplexPolygon(converted.Select(x => new Polygon(new LinearLineSegment(x.Points))).ToArray());
+            shape = new ComplexPolygon(converted.Select(x => new Polygon(new LinearLineSegment(x.Points.ToArray()))).ToArray());
 
             path = path.Select(p => System.IO.Path.GetInvalidFileNameChars().Aggregate(p, (x, c) => x.Replace($"{c}", "-"))).ToArray();
             string fullPath = System.IO.Path.GetFullPath(System.IO.Path.Combine("Output", System.IO.Path.Combine(path)));

--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -126,7 +126,12 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         }
         public static void RenderText(FontFamily font, string text, float pointSize = 12, IEnumerable<FontFamily> fallbackFonts = null)
         {
-            RenderText(new RendererOptions(new Font(font, pointSize), 96, fallbackFonts?.ToArray()) { ApplyKerning = true, WrappingWidth = 340 }, text);
+            RenderText(new RendererOptions(new Font(font, pointSize), 96)
+            {
+                ApplyKerning = true,
+                WrappingWidth = 340,
+                FallbackFontFamilies = fallbackFonts?.ToArray()
+            }, text);
         }
 
         public static void SaveImage(this IEnumerable<IPath> shapes, int width, int height, params string[] path)

--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -24,6 +24,12 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             FontFamily carter = fonts.Install(@"Fonts\CarterOne.ttf");
             FontFamily Wendy_One = fonts.Install(@"Fonts\WendyOne-Regular.ttf");
 
+            // fallback font tests
+
+            RenderText(font, "abcdefg", pointSize: 72, fallbackFonts: new[] { font2 });
+
+            // general
+
             RenderText(font, "abc", 72);
             RenderText(font, "ABd", 72);
             RenderText(fontWoff, "abe", 72);

--- a/samples/DrawWithImageSharp/Properties/launchSettings.json
+++ b/samples/DrawWithImageSharp/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "DrawWithImageSharp": {
-      "commandName": "Project",
-      "workingDirectory": "C:\\Source\\SixLabors.Fonts\\samples\\DrawWithImageSharp"
-    }
-  }
-}

--- a/samples/DrawWithImageSharp/TextAlignment.cs
+++ b/samples/DrawWithImageSharp/TextAlignment.cs
@@ -1,11 +1,10 @@
-﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp;
 using SixLabors.Fonts;
 using SixLabors.Shapes.Temp;
 using System;
 using System.Numerics;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Processing.Drawing;
 
 namespace DrawWithImageSharp
 {

--- a/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
+++ b/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
@@ -1,11 +1,10 @@
-﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp;
 using SixLabors.Fonts;
 using SixLabors.Shapes.Temp;
 using System;
 using System.Numerics;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Processing.Drawing;
 
 namespace DrawWithImageSharp
 {

--- a/src/SixLabors.Fonts/AppliedFontStyle.cs
+++ b/src/SixLabors.Fonts/AppliedFontStyle.cs
@@ -1,15 +1,47 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using System.Numerics;
 
 namespace SixLabors.Fonts
 {
     internal struct AppliedFontStyle
     {
-        public IFontInstance Font;
+        public IEnumerable<IFontInstance> FallbackFonts;
+        public IFontInstance MainFont;
         public float PointSize;
         public float TabWidth;
         public int Start;
         public int End;
         public bool ApplyKerning;
+
+        public GlyphInstance GetGlyph(int codePoint)
+        {
+            GlyphInstance glyph = this.MainFont.GetGlyph(codePoint);
+            if (glyph.Fallback)
+            {
+                foreach (var f in this.FallbackFonts)
+                {
+                    var g = f.GetGlyph(codePoint);
+                    if (!g.Fallback)
+                    {
+                        return g;
+                    }
+                }
+            }
+
+            return glyph;
+        }
+
+        public Vector2 GetOffset(GlyphInstance glyph, GlyphInstance previousGlyph)
+        {
+            if (glyph.Font != previousGlyph?.Font)
+            {
+                return Vector2.Zero;
+            }
+
+            return ((IFontInstance)glyph.Font).GetOffset(glyph, previousGlyph);
+        }
     }
 }

--- a/src/SixLabors.Fonts/AppliedFontStyle.cs
+++ b/src/SixLabors.Fonts/AppliedFontStyle.cs
@@ -8,7 +8,7 @@ namespace SixLabors.Fonts
 {
     internal struct AppliedFontStyle
     {
-        public IEnumerable<IFontInstance> FallbackFonts;
+        public IFontInstance[] FallbackFonts;
         public IFontInstance MainFont;
         public float PointSize;
         public float TabWidth;

--- a/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
@@ -4,9 +4,9 @@
 namespace SixLabors.Fonts.Exceptions
 {
     /// <summary>
-    /// Base class for exceptions thrown by this library.
+    /// Execption for detailing missing font familys.
     /// </summary>
-    /// <seealso cref="System.Exception" />
+    /// <seealso cref="FontException" />
     public class FontFamilyNotFoundException : FontException
     {
         /// <summary>

--- a/src/SixLabors.Fonts/Exceptions/FontsThrowHelper.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontsThrowHelper.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace SixLabors.Fonts.Exceptions
+{
+    /// <summary>
+    /// Helper methods to throw exceptions
+    /// </summary>
+    internal static class FontsThrowHelper
+    {
+        /// <summary>
+        /// Throws an <see cref="GlyphMissingException"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static T ThrowGlyphMissingException<T>(int codePoint)
+        {
+            throw new GlyphMissingException(codePoint);
+        }
+    }
+}

--- a/src/SixLabors.Fonts/Exceptions/GlyphMissingException.cs
+++ b/src/SixLabors.Fonts/Exceptions/GlyphMissingException.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+
+namespace SixLabors.Fonts.Exceptions
+{
+    /// <summary>
+    /// Execption for detailing missing font familys.
+    /// </summary>
+    /// <seealso cref="FontException" />
+    public class GlyphMissingException : FontException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GlyphMissingException"/> class.
+        /// </summary>
+        /// <param name="codePoint">The code point for the glyph we where unable to find.</param>
+        public GlyphMissingException(int codePoint)
+            : base($"Cannot find a glyph for the code point '{codePoint}'")
+        {
+        }
+    }
+}

--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -11,7 +11,6 @@ namespace SixLabors.Fonts
     /// </summary>
     public sealed class Font
     {
-        private readonly FontStyle requestedStyle;
         private readonly Lazy<IFontInstance?> instance;
 
         /// <summary>
@@ -23,7 +22,7 @@ namespace SixLabors.Fonts
         public Font(FontFamily family, float size, FontStyle style)
         {
             this.Family = family ?? throw new ArgumentNullException(nameof(family));
-            this.requestedStyle = style;
+            this.RequestedStyle = style;
             this.Size = size;
             this.instance = new Lazy<IFontInstance?>(this.LoadInstanceInternal);
         }
@@ -65,9 +64,17 @@ namespace SixLabors.Fonts
         /// <param name="prototype">The prototype.</param>
         /// <param name="size">The size.</param>
         public Font(Font prototype, float size)
-            : this(prototype.Family, size, prototype.requestedStyle)
+            : this(prototype.Family, size, prototype.RequestedStyle)
         {
         }
+
+        /// <summary>
+        /// Gets the family.
+        /// </summary>
+        /// <value>
+        /// The family.
+        /// </value>
+        internal FontStyle RequestedStyle { get; }
 
         /// <summary>
         /// Gets the family.
@@ -157,15 +164,15 @@ namespace SixLabors.Fonts
 
         private IFontInstance? LoadInstanceInternal()
         {
-            IFontInstance? instance = this.Family.Find(this.requestedStyle);
+            IFontInstance? instance = this.Family.Find(this.RequestedStyle);
 
-            if (instance is null && this.requestedStyle.HasFlag(FontStyle.Italic))
+            if (instance is null && this.RequestedStyle.HasFlag(FontStyle.Italic))
             {
                 // can find style requested and they want one thats atleast partial itallic try the regual italic
                 instance = this.Family.Find(FontStyle.Italic);
             }
 
-            if (instance is null && this.requestedStyle.HasFlag(FontStyle.Bold))
+            if (instance is null && this.RequestedStyle.HasFlag(FontStyle.Bold))
             {
                 // can find style requested and they want one thats atleast partial bold try the regular bold
                 instance = this.Family.Find(FontStyle.Bold);

--- a/src/SixLabors.Fonts/GlyphInstance.cs
+++ b/src/SixLabors.Fonts/GlyphInstance.cs
@@ -21,7 +21,7 @@ namespace SixLabors.Fonts
         private readonly short leftSideBearing;
         private readonly float scaleFactor;
 
-        internal GlyphInstance(FontInstance font, Vector2[] controlPoints, bool[] onCurves, ushort[] endPoints, Bounds bounds, ushort advanceWidth, short leftSideBearing, ushort sizeOfEm, ushort index)
+        internal GlyphInstance(FontInstance font, Vector2[] controlPoints, bool[] onCurves, ushort[] endPoints, Bounds bounds, ushort advanceWidth, short leftSideBearing, ushort sizeOfEm, ushort index, bool fallback = false)
         {
             this.Font = font;
             this.sizeOfEm = sizeOfEm;
@@ -32,7 +32,7 @@ namespace SixLabors.Fonts
             this.AdvanceWidth = advanceWidth;
             this.Index = index;
             this.Height = sizeOfEm - this.Bounds.Min.Y;
-
+            this.Fallback = fallback;
             this.leftSideBearing = leftSideBearing;
             this.scaleFactor = (float)(this.sizeOfEm * 72f);
         }
@@ -68,6 +68,14 @@ namespace SixLabors.Fonts
         /// The height.
         /// </value>
         public float Height { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this is a fallback glyph vs a real existing glyph
+        /// </summary>
+        /// <value>
+        /// The Fallback status of this glyph
+        /// </value>
+        public bool Fallback { get; }
 
         /// <summary>
         /// Gets the index.

--- a/src/SixLabors.Fonts/RendererOptions.cs
+++ b/src/SixLabors.Fonts/RendererOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 namespace SixLabors.Fonts
@@ -10,14 +12,15 @@ namespace SixLabors.Fonts
     /// </summary>
     public sealed class RendererOptions
     {
+        private static FontFamily[] emptyFamilyCollection = new FontFamily[0];
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RendererOptions"/> class.
         /// </summary>
         /// <param name="font">The font.</param>
         public RendererOptions(Font font)
-            : this(font, 72, 72)
+            : this(font, 72, 72, emptyFamilyCollection)
         {
-            this.Font = font;
         }
 
         /// <summary>
@@ -26,9 +29,8 @@ namespace SixLabors.Fonts
         /// <param name="font">The font.</param>
         /// <param name="dpi">The dpi.</param>
         public RendererOptions(Font font, float dpi)
-            : this(font, dpi, dpi)
+            : this(font, dpi, dpi, emptyFamilyCollection)
         {
-            this.Font = font;
         }
 
         /// <summary>
@@ -38,7 +40,7 @@ namespace SixLabors.Fonts
         /// <param name="dpiX">The X dpi.</param>
         /// <param name="dpiY">The Y dpi.</param>
         public RendererOptions(Font font, float dpiX, float dpiY)
-            : this(font, dpiX, dpiY, Vector2.Zero)
+            : this(font, dpiX, dpiY, Vector2.Zero, emptyFamilyCollection)
         {
         }
 
@@ -48,7 +50,7 @@ namespace SixLabors.Fonts
         /// <param name="font">The font.</param>
         /// <param name="origin">The origin location.</param>
         public RendererOptions(Font font, Vector2 origin)
-            : this(font, 72, 72, origin)
+            : this(font, 72, 72, origin, emptyFamilyCollection)
         {
         }
 
@@ -59,7 +61,7 @@ namespace SixLabors.Fonts
         /// <param name="dpi">The dpi.</param>
         /// <param name="origin">The origin location.</param>
         public RendererOptions(Font font, float dpi, Vector2 origin)
-            : this(font, dpi, dpi, origin)
+            : this(font, dpi, dpi, origin, emptyFamilyCollection)
         {
         }
 
@@ -71,11 +73,81 @@ namespace SixLabors.Fonts
         /// <param name="dpiY">The Y dpi.</param>
         /// <param name="origin">The origin location.</param>
         public RendererOptions(Font font, float dpiX, float dpiY, Vector2 origin)
+            : this(font, dpiX, dpiY, origin, emptyFamilyCollection)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
+        /// </summary>
+        /// <param name="font">The font.</param>
+        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
+        public RendererOptions(Font font, IEnumerable<FontFamily> fallbackFontFamilies)
+            : this(font, 72, 72, fallbackFontFamilies)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
+        /// </summary>
+        /// <param name="font">The font.</param>
+        /// <param name="dpi">The dpi.</param>
+        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
+        public RendererOptions(Font font, float dpi, IEnumerable<FontFamily> fallbackFontFamilies)
+            : this(font, dpi, dpi, fallbackFontFamilies)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
+        /// </summary>
+        /// <param name="font">The font.</param>
+        /// <param name="dpiX">The X dpi.</param>
+        /// <param name="dpiY">The Y dpi.</param>
+        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
+        public RendererOptions(Font font, float dpiX, float dpiY, IEnumerable<FontFamily> fallbackFontFamilies)
+            : this(font, dpiX, dpiY, Vector2.Zero, fallbackFontFamilies)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
+        /// </summary>
+        /// <param name="font">The font.</param>
+        /// <param name="origin">The origin location.</param>
+        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
+        public RendererOptions(Font font, Vector2 origin, IEnumerable<FontFamily> fallbackFontFamilies)
+            : this(font, 72, 72, origin, fallbackFontFamilies)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
+        /// </summary>
+        /// <param name="font">The font.</param>
+        /// <param name="dpi">The dpi.</param>
+        /// <param name="origin">The origin location.</param>
+        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
+        public RendererOptions(Font font, float dpi, Vector2 origin, IEnumerable<FontFamily> fallbackFontFamilies)
+            : this(font, dpi, dpi, origin, fallbackFontFamilies)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
+        /// </summary>
+        /// <param name="font">The font.</param>
+        /// <param name="dpiX">The X dpi.</param>
+        /// <param name="dpiY">The Y dpi.</param>
+        /// <param name="origin">The origin location.</param>
+        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
+        public RendererOptions(Font font, float dpiX, float dpiY, Vector2 origin, IEnumerable<FontFamily> fallbackFontFamilies)
         {
             this.Origin = origin;
             this.Font = font;
             this.DpiX = dpiX;
             this.DpiY = dpiY;
+            this.FallbackFontFamilies = fallbackFontFamilies?.ToArray() ?? new FontFamily[0];
         }
 
         /// <summary>
@@ -111,6 +183,11 @@ namespace SixLabors.Fonts
         /// Gets or sets the the current Ys DPI to render/measure the text at.
         /// </summary>
         public float DpiY { get; set; }
+
+        /// <summary>
+        /// Gets the collection of Fallback fontfamiles to try and use when enspecific glyph is missing.
+        /// </summary>
+        public IEnumerable<FontFamily> FallbackFontFamilies { get; }
 
         /// <summary>
         /// Gets or sets the width relative to the current DPI at which text will automatically wrap onto a newline
@@ -150,7 +227,8 @@ namespace SixLabors.Fonts
                 Start = 0,
                 End = length - 1,
                 PointSize = this.Font.Size,
-                Font = this.Font.Instance,
+                MainFont = this.Font.Instance,
+                FallbackFonts = this.FallbackFontFamilies.Select(x => new Font(x, this.Font.Size, this.Font.RequestedStyle).Instance).ToArray(),
                 TabWidth = this.TabWidth,
                 ApplyKerning = this.ApplyKerning
             };

--- a/src/SixLabors.Fonts/RendererOptions.cs
+++ b/src/SixLabors.Fonts/RendererOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -12,14 +13,12 @@ namespace SixLabors.Fonts
     /// </summary>
     public sealed class RendererOptions
     {
-        private static FontFamily[] emptyFamilyCollection = new FontFamily[0];
-
         /// <summary>
         /// Initializes a new instance of the <see cref="RendererOptions"/> class.
         /// </summary>
         /// <param name="font">The font.</param>
         public RendererOptions(Font font)
-            : this(font, 72, 72, emptyFamilyCollection)
+            : this(font, 72, 72)
         {
         }
 
@@ -29,7 +28,7 @@ namespace SixLabors.Fonts
         /// <param name="font">The font.</param>
         /// <param name="dpi">The dpi.</param>
         public RendererOptions(Font font, float dpi)
-            : this(font, dpi, dpi, emptyFamilyCollection)
+            : this(font, dpi, dpi)
         {
         }
 
@@ -40,7 +39,7 @@ namespace SixLabors.Fonts
         /// <param name="dpiX">The X dpi.</param>
         /// <param name="dpiY">The Y dpi.</param>
         public RendererOptions(Font font, float dpiX, float dpiY)
-            : this(font, dpiX, dpiY, Vector2.Zero, emptyFamilyCollection)
+            : this(font, dpiX, dpiY, Vector2.Zero)
         {
         }
 
@@ -50,7 +49,7 @@ namespace SixLabors.Fonts
         /// <param name="font">The font.</param>
         /// <param name="origin">The origin location.</param>
         public RendererOptions(Font font, Vector2 origin)
-            : this(font, 72, 72, origin, emptyFamilyCollection)
+            : this(font, 72, 72, origin)
         {
         }
 
@@ -61,7 +60,7 @@ namespace SixLabors.Fonts
         /// <param name="dpi">The dpi.</param>
         /// <param name="origin">The origin location.</param>
         public RendererOptions(Font font, float dpi, Vector2 origin)
-            : this(font, dpi, dpi, origin, emptyFamilyCollection)
+            : this(font, dpi, dpi, origin)
         {
         }
 
@@ -73,81 +72,11 @@ namespace SixLabors.Fonts
         /// <param name="dpiY">The Y dpi.</param>
         /// <param name="origin">The origin location.</param>
         public RendererOptions(Font font, float dpiX, float dpiY, Vector2 origin)
-            : this(font, dpiX, dpiY, origin, emptyFamilyCollection)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
-        /// </summary>
-        /// <param name="font">The font.</param>
-        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
-        public RendererOptions(Font font, IEnumerable<FontFamily> fallbackFontFamilies)
-            : this(font, 72, 72, fallbackFontFamilies)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
-        /// </summary>
-        /// <param name="font">The font.</param>
-        /// <param name="dpi">The dpi.</param>
-        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
-        public RendererOptions(Font font, float dpi, IEnumerable<FontFamily> fallbackFontFamilies)
-            : this(font, dpi, dpi, fallbackFontFamilies)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
-        /// </summary>
-        /// <param name="font">The font.</param>
-        /// <param name="dpiX">The X dpi.</param>
-        /// <param name="dpiY">The Y dpi.</param>
-        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
-        public RendererOptions(Font font, float dpiX, float dpiY, IEnumerable<FontFamily> fallbackFontFamilies)
-            : this(font, dpiX, dpiY, Vector2.Zero, fallbackFontFamilies)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
-        /// </summary>
-        /// <param name="font">The font.</param>
-        /// <param name="origin">The origin location.</param>
-        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
-        public RendererOptions(Font font, Vector2 origin, IEnumerable<FontFamily> fallbackFontFamilies)
-            : this(font, 72, 72, origin, fallbackFontFamilies)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
-        /// </summary>
-        /// <param name="font">The font.</param>
-        /// <param name="dpi">The dpi.</param>
-        /// <param name="origin">The origin location.</param>
-        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
-        public RendererOptions(Font font, float dpi, Vector2 origin, IEnumerable<FontFamily> fallbackFontFamilies)
-            : this(font, dpi, dpi, origin, fallbackFontFamilies)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RendererOptions"/> class.
-        /// </summary>
-        /// <param name="font">The font.</param>
-        /// <param name="dpiX">The X dpi.</param>
-        /// <param name="dpiY">The Y dpi.</param>
-        /// <param name="origin">The origin location.</param>
-        /// <param name="fallbackFontFamilies">An optional collection of font families to fallback to if the glyph is missing from the <paramref name="font"/>.</param>
-        public RendererOptions(Font font, float dpiX, float dpiY, Vector2 origin, IEnumerable<FontFamily> fallbackFontFamilies)
         {
             this.Origin = origin;
             this.Font = font;
             this.DpiX = dpiX;
             this.DpiY = dpiY;
-            this.FallbackFontFamilies = fallbackFontFamilies?.ToArray() ?? new FontFamily[0];
         }
 
         /// <summary>
@@ -185,9 +114,9 @@ namespace SixLabors.Fonts
         public float DpiY { get; set; }
 
         /// <summary>
-        /// Gets the collection of Fallback fontfamiles to try and use when enspecific glyph is missing.
+        /// Gets or sets the collection of Fallback fontfamiles to try and use when enspecific glyph is missing.
         /// </summary>
-        public IEnumerable<FontFamily> FallbackFontFamilies { get; }
+        public IEnumerable<FontFamily> FallbackFontFamilies { get; set; } = Array.Empty<FontFamily>();
 
         /// <summary>
         /// Gets or sets the width relative to the current DPI at which text will automatically wrap onto a newline
@@ -210,7 +139,7 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Gets or sets the rendering origin.
         /// </summary>
-        public Vector2 Origin { get; set; }
+        public Vector2 Origin { get; set; } = Vector2.Zero;
 
         /// <summary>
         /// Gets the style. In derived classes this could switchout to different fonts mid stream
@@ -222,13 +151,23 @@ namespace SixLabors.Fonts
         /// </returns>
         internal AppliedFontStyle GetStyle(int index, int length)
         {
+            IFontInstance[] fallbackFontInstances;
+            if (this.FallbackFontFamilies == null)
+            {
+                fallbackFontInstances = Array.Empty<IFontInstance>();
+            }
+            else
+            {
+                fallbackFontInstances = this.FallbackFontFamilies.Select(x => new Font(x, this.Font.Size, this.Font.RequestedStyle).Instance).ToArray();
+            }
+
             return new AppliedFontStyle
             {
                 Start = 0,
                 End = length - 1,
                 PointSize = this.Font.Size,
                 MainFont = this.Font.Instance,
-                FallbackFonts = this.FallbackFontFamilies.Select(x => new Font(x, this.Font.Size, this.Font.RequestedStyle).Instance).ToArray(),
+                FallbackFonts = fallbackFontInstances,
                 TabWidth = this.TabWidth,
                 ApplyKerning = this.ApplyKerning
             };

--- a/src/SixLabors.Fonts/Tables/General/CMap/CMapSubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/CMapSubTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Fonts.WellKnownIds;
@@ -24,6 +24,6 @@ namespace SixLabors.Fonts.Tables.General.CMap
 
         public ushort Encoding { get; }
 
-        public abstract ushort GetGlyphId(int codePoint);
+        public abstract bool TryGetGlyphId(int codePoint, out ushort glyphId);
     }
 }

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format0SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format0SubTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
@@ -19,15 +19,17 @@ namespace SixLabors.Fonts.Tables.General.CMap
 
         public byte[] GlyphIds { get; }
 
-        public override ushort GetGlyphId(int codePoint)
+        public override bool TryGetGlyphId(int codePoint, out ushort glyphId)
         {
             uint b = (uint)codePoint;
             if (b >= this.GlyphIds.Length)
             {
-                return 0;
+                glyphId = 0;
+                return false;
             }
 
-            return this.GlyphIds[b];
+            glyphId = this.GlyphIds[b];
+            return true;
         }
 
         public static IEnumerable<Format0SubTable> Load(IEnumerable<EncodingRecord> encodings, BinaryReader reader)

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format4SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format4SubTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
@@ -22,7 +22,7 @@ namespace SixLabors.Fonts.Tables.General.CMap
 
         public ushort Language { get; }
 
-        public override ushort GetGlyphId(int codePoint)
+        public override bool TryGetGlyphId(int codePoint, out ushort glyphId)
         {
             uint charAsInt = (uint)codePoint;
 
@@ -34,17 +34,20 @@ namespace SixLabors.Fonts.Tables.General.CMap
                 {
                     if (seg.Offset == 0)
                     {
-                        return (ushort)((charAsInt + seg.Delta) % ushort.MaxValue); // TODO: bitmask instead?
+                        glyphId = (ushort)((charAsInt + seg.Delta) % ushort.MaxValue); // TODO: bitmask instead?
+                        return true;
                     }
                     else
                     {
                         long offset = (seg.Offset / 2) + (charAsInt - seg.Start);
-                        return this.GlyphIds[offset - this.Segments.Length + seg.Index];
+                        glyphId = this.GlyphIds[offset - this.Segments.Length + seg.Index];
+                        return true;
                     }
                 }
             }
 
-            return 0;
+            glyphId = 0;
+            return false;
         }
 
         public static IEnumerable<Format4SubTable> Load(IEnumerable<EncodingRecord> encodings, BinaryReader reader)

--- a/src/SixLabors.Fonts/Tables/General/CMapTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMapTable.cs
@@ -40,26 +40,26 @@ namespace SixLabors.Fonts.Tables.General
 
         internal CMapSubTable[] Tables { get; }
 
-        public ushort GetGlyphId(int codePoint)
+        public bool TryGetGlyphId(int codePoint, out ushort glyphId)
         {
             // use the best match only
             if (this.table is object)
             {
-                return this.table.GetGlyphId(codePoint);
+                return this.table.TryGetGlyphId(codePoint, out glyphId);
             }
 
             // didn't have a windows match just use any and hope for the best
             foreach (CMapSubTable t in this.Tables)
             {
                 // keep looking until we have an index thats not the fallback.
-                ushort index = t.GetGlyphId(codePoint);
-                if (index > 0)
+                if (t.TryGetGlyphId(codePoint, out glyphId))
                 {
-                    return index;
+                    return true;
                 }
             }
 
-            return 0;
+            glyphId = 0;
+            return false;
         }
 
         public static CMapTable Load(FontReader reader)

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
+using SixLabors.Fonts.Exceptions;
 
 namespace SixLabors.Fonts
 {
@@ -91,7 +92,7 @@ namespace SixLabors.Fonts
                 GlyphInstance glyph = spanStyle.GetGlyph(codePoint);
                 if (glyph == null)
                 {
-                    throw new Exceptions.FontException($"Cannot find a glyph for code point {codePoint}");
+                    return FontsThrowHelper.ThrowGlyphMissingException<IReadOnlyList<GlyphLayout>>(codePoint);
                 }
 
                 if (glyph.Font.LineHeight > unscaledLineHeight)

--- a/tests/SixLabors.Fonts.Tests/FakeFont.cs
+++ b/tests/SixLabors.Fonts.Tests/FakeFont.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 
 using SixLabors.Fonts.Tests.Fakes;
 
@@ -19,8 +19,14 @@ namespace SixLabors.Fonts.Tests
 
         public static Font CreateFont(string text)
         {
+            return CreateFontWithInstance(text, out _);
+        }
+
+        internal static Font CreateFontWithInstance(string text, out FakeFontInstance instance)
+        {
             var fc = new FontCollection();
-            Font d = fc.Install(FakeFontInstance.CreateFontWithVaryingVerticalFontMetrics(text)).CreateFont(12);
+            instance = FakeFontInstance.CreateFontWithVaryingVerticalFontMetrics(text);
+            Font d = fc.Install(instance).CreateFont(12);
             return new Font(d, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeCmapSubtable.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeCmapSubtable.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using SixLabors.Fonts.Tables.General.CMap;
 
 namespace SixLabors.Fonts.Tests.Fakes
@@ -12,16 +12,18 @@ namespace SixLabors.Fonts.Tests.Fakes
             this.glyphs = glyphs;
         }
 
-        public override ushort GetGlyphId(int codePoint)
+        public override bool TryGetGlyphId(int codePoint, out ushort glyphId)
         {
             foreach (FakeGlyphSource c in this.glyphs)
             {
                 if (c.CodePoint == codePoint)
                 {
-                    return c.Index;
+                    glyphId = c.Index;
+                    return true;
                 }
             }
-            return 0;
+            glyphId = 0;
+            return false;
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using Xunit;
+
+namespace SixLabors.Fonts.Tests
+{
+    public class RendererOptionsTests
+    {
+        private static void VerifyPropertyDefault(RendererOptions options)
+        {
+            Assert.Equal(4, options.TabWidth);
+            Assert.True(options.ApplyKerning);
+            Assert.Equal(-1, options.WrappingWidth);
+            Assert.Equal(HorizontalAlignment.Left, options.HorizontalAlignment);
+            Assert.Equal(VerticalAlignment.Top, options.VerticalAlignment);
+        }
+
+        [Fact]
+        public void ContructorTest_FontOnly()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var options = new RendererOptions(font);
+
+            Assert.Equal(72, options.DpiX);
+            Assert.Equal(72, options.DpiY);
+            Assert.Empty(options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(Vector2.Zero, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void ContructorTest_FontWithSingleDpi()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            float dpi = 123;
+            var options = new RendererOptions(font, dpi);
+
+            Assert.Equal(dpi, options.DpiX);
+            Assert.Equal(dpi, options.DpiY);
+            Assert.Empty(options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(Vector2.Zero, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void ContructorTest_FontWithXandYDpis()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            float dpix = 123;
+            float dpiy = 456;
+            var options = new RendererOptions(font, dpix, dpiy);
+
+            Assert.Equal(dpix, options.DpiX);
+            Assert.Equal(dpiy, options.DpiY);
+            Assert.Empty(options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(Vector2.Zero, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+
+
+        [Fact]
+        public void ContructorTest_FontWithOrigin()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var origin = new Vector2(123, 345);
+            var options = new RendererOptions(font, origin);
+
+            Assert.Equal(72, options.DpiX);
+            Assert.Equal(72, options.DpiY);
+            Assert.Empty(options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(origin, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void ContructorTest_FontWithSingleDpiWithOrigin()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var origin = new Vector2(123, 345);
+            float dpi = 123;
+            var options = new RendererOptions(font, dpi, origin);
+
+            Assert.Equal(dpi, options.DpiX);
+            Assert.Equal(dpi, options.DpiY);
+            Assert.Empty(options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(origin, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void ContructorTest_FontWithXandYDpisWithOrigin()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var origin = new Vector2(123, 345);
+            float dpix = 123;
+            float dpiy = 456;
+            var options = new RendererOptions(font, dpix, dpiy, origin);
+
+            Assert.Equal(dpix, options.DpiX);
+            Assert.Equal(dpiy, options.DpiY);
+            Assert.Empty(options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(origin, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void ContructorTest_FontOnly_WithFallbackFonts()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var fontFamilys = new[]{
+                    FakeFont.CreateFont("DEF").Family,
+                    FakeFont.CreateFont("GHI").Family
+                    };
+
+            var options = new RendererOptions(font, fontFamilys);
+
+            Assert.Equal(72, options.DpiX);
+            Assert.Equal(72, options.DpiY);
+            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(Vector2.Zero, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void ContructorTest_FontWithSingleDpi_WithFallbackFonts()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var fontFamilys = new[]{
+                    FakeFont.CreateFont("DEF").Family,
+                    FakeFont.CreateFont("GHI").Family
+                    };
+            float dpi = 123;
+            var options = new RendererOptions(font, dpi, fontFamilys);
+
+            Assert.Equal(dpi, options.DpiX);
+            Assert.Equal(dpi, options.DpiY);
+            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(Vector2.Zero, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void ContructorTest_FontWithXandYDpis_WithFallbackFonts()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var fontFamilys = new[]{
+                    FakeFont.CreateFont("DEF").Family,
+                    FakeFont.CreateFont("GHI").Family
+                    };
+            float dpix = 123;
+            float dpiy = 456;
+            var options = new RendererOptions(font, dpix, dpiy, fontFamilys);
+
+            Assert.Equal(dpix, options.DpiX);
+            Assert.Equal(dpiy, options.DpiY);
+            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(Vector2.Zero, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+
+
+        [Fact]
+        public void ContructorTest_FontWithOrigin_WithFallbackFonts()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var fontFamilys = new[]{
+                    FakeFont.CreateFont("DEF").Family,
+                    FakeFont.CreateFont("GHI").Family
+                    };
+            var origin = new Vector2(123, 345);
+            var options = new RendererOptions(font, origin, fontFamilys);
+
+            Assert.Equal(72, options.DpiX);
+            Assert.Equal(72, options.DpiY);
+            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(origin, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void ContructorTest_FontWithSingleDpiWithOrigin_WithFallbackFonts()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var fontFamilys = new[]{
+                    FakeFont.CreateFont("DEF").Family,
+                    FakeFont.CreateFont("GHI").Family
+                    };
+            var origin = new Vector2(123, 345);
+            float dpi = 123;
+            var options = new RendererOptions(font, dpi, origin, fontFamilys);
+
+            Assert.Equal(dpi, options.DpiX);
+            Assert.Equal(dpi, options.DpiY);
+            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(origin, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void ContructorTest_FontWithXandYDpisWithOrigin_WithFallbackFonts()
+        {
+            var font = FakeFont.CreateFont("ABC");
+            var fontFamilys = new[]{
+                    FakeFont.CreateFont("DEF").Family,
+                    FakeFont.CreateFont("GHI").Family
+                    };
+            var origin = new Vector2(123, 345);
+            float dpix = 123;
+            float dpiy = 456;
+            var options = new RendererOptions(font, dpix, dpiy, origin, fontFamilys);
+
+            Assert.Equal(dpix, options.DpiX);
+            Assert.Equal(dpiy, options.DpiY);
+            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(font, options.Font);
+            Assert.Equal(origin, options.Origin);
+            VerifyPropertyDefault(options);
+        }
+
+        [Fact]
+        public void GetStylePassesCorrectValues()
+        {
+            var font = FakeFont.CreateFontWithInstance("ABC", out var abcFontInstance);
+            var fontFamilys = new[]{
+                    FakeFont.CreateFontWithInstance("DEF", out var defFontInstance).Family,
+                    FakeFont.CreateFontWithInstance("GHI", out var ghiFontInstance).Family
+                    };
+            var options = new RendererOptions(font, fontFamilys);
+
+            var style = options.GetStyle(4, 10);
+
+            Assert.Equal(0, style.Start);
+            Assert.Equal(9, style.End);
+            Assert.Equal(font.Size, style.PointSize);
+            Assert.Equal(4, style.TabWidth);
+            Assert.True(style.ApplyKerning);
+
+            Assert.Equal(abcFontInstance, style.MainFont);
+            Assert.Equal(2, style.FallbackFonts.Count());
+            Assert.Contains(defFontInstance, style.FallbackFonts);
+            Assert.Contains(ghiFontInstance, style.FallbackFonts);
+        }
+
+        [Fact]
+        public void GetMissingGlyphFromMainFont()
+        {
+            var font = FakeFont.CreateFontWithInstance("ABC", out var abcFontInstance);
+            var fontFamilys = new[] {
+                    FakeFont.CreateFontWithInstance("DEF", out var defFontInstance).Family,
+                    FakeFont.CreateFontWithInstance("GHI", out var ghiFontInstance).Family
+             };
+
+            var options = new RendererOptions(font, fontFamilys);
+
+            var style = options.GetStyle(4, 10);
+
+            var glyph = style.GetGlyph('Z');
+            Assert.True(glyph.Fallback);
+            Assert.Equal(abcFontInstance, glyph.Font);
+        }
+
+        [Theory]
+        [InlineData('A', "abcFontInstance")]
+        [InlineData('F', "defFontInstance")]
+        [InlineData('H', "efghiFontInstance")]
+        public void GetGlyphFromFirstAvailableInstance(char character, string instance)
+        {
+            var font = FakeFont.CreateFontWithInstance("ABC", out var abcFontInstance);
+            var fontFamilys = new[] {
+                    FakeFont.CreateFontWithInstance("DEF", out var defFontInstance).Family,
+                    FakeFont.CreateFontWithInstance("EFGHI", out var efghiFontInstance).Family
+             };
+
+            var options = new RendererOptions(font, fontFamilys);
+
+            var style = options.GetStyle(4, 10);
+
+            var glyph = style.GetGlyph(character);
+            Assert.False(glyph.Fallback);
+            var expectedInstance = instance switch
+            {
+                "abcFontInstance" => abcFontInstance,
+                "defFontInstance" => defFontInstance,
+                "efghiFontInstance" => efghiFontInstance,
+                _ => throw new Exception("does not match")
+            };
+
+            Assert.Equal(expectedInstance, glyph.Font);
+        }
+
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
@@ -122,7 +122,9 @@ namespace SixLabors.Fonts.Tests
                     FakeFont.CreateFont("GHI").Family
                     };
 
-            var options = new RendererOptions(font, fontFamilys);
+            var options = new RendererOptions(font) {
+                FallbackFontFamilies = fontFamilys
+            };
 
             Assert.Equal(72, options.DpiX);
             Assert.Equal(72, options.DpiY);
@@ -141,7 +143,10 @@ namespace SixLabors.Fonts.Tests
                     FakeFont.CreateFont("GHI").Family
                     };
             float dpi = 123;
-            var options = new RendererOptions(font, dpi, fontFamilys);
+            var options = new RendererOptions(font, dpi)
+            {
+                FallbackFontFamilies = fontFamilys
+            };
 
             Assert.Equal(dpi, options.DpiX);
             Assert.Equal(dpi, options.DpiY);
@@ -161,7 +166,10 @@ namespace SixLabors.Fonts.Tests
                     };
             float dpix = 123;
             float dpiy = 456;
-            var options = new RendererOptions(font, dpix, dpiy, fontFamilys);
+            var options = new RendererOptions(font, dpix, dpiy)
+            {
+                FallbackFontFamilies = fontFamilys
+            };
 
             Assert.Equal(dpix, options.DpiX);
             Assert.Equal(dpiy, options.DpiY);
@@ -182,7 +190,10 @@ namespace SixLabors.Fonts.Tests
                     FakeFont.CreateFont("GHI").Family
                     };
             var origin = new Vector2(123, 345);
-            var options = new RendererOptions(font, origin, fontFamilys);
+            var options = new RendererOptions(font, origin)
+            {
+                FallbackFontFamilies = fontFamilys
+            };
 
             Assert.Equal(72, options.DpiX);
             Assert.Equal(72, options.DpiY);
@@ -202,7 +213,10 @@ namespace SixLabors.Fonts.Tests
                     };
             var origin = new Vector2(123, 345);
             float dpi = 123;
-            var options = new RendererOptions(font, dpi, origin, fontFamilys);
+            var options = new RendererOptions(font, dpi, origin)
+            {
+                FallbackFontFamilies = fontFamilys
+            };
 
             Assert.Equal(dpi, options.DpiX);
             Assert.Equal(dpi, options.DpiY);
@@ -223,7 +237,10 @@ namespace SixLabors.Fonts.Tests
             var origin = new Vector2(123, 345);
             float dpix = 123;
             float dpiy = 456;
-            var options = new RendererOptions(font, dpix, dpiy, origin, fontFamilys);
+            var options = new RendererOptions(font, dpix, dpiy, origin)
+            {
+                FallbackFontFamilies = fontFamilys
+            };
 
             Assert.Equal(dpix, options.DpiX);
             Assert.Equal(dpiy, options.DpiY);
@@ -241,7 +258,10 @@ namespace SixLabors.Fonts.Tests
                     FakeFont.CreateFontWithInstance("DEF", out var defFontInstance).Family,
                     FakeFont.CreateFontWithInstance("GHI", out var ghiFontInstance).Family
                     };
-            var options = new RendererOptions(font, fontFamilys);
+            var options = new RendererOptions(font)
+            {
+                FallbackFontFamilies = fontFamilys
+            };
 
             var style = options.GetStyle(4, 10);
 
@@ -266,7 +286,10 @@ namespace SixLabors.Fonts.Tests
                     FakeFont.CreateFontWithInstance("GHI", out var ghiFontInstance).Family
              };
 
-            var options = new RendererOptions(font, fontFamilys);
+            var options = new RendererOptions(font)
+            {
+                FallbackFontFamilies = fontFamilys
+            };
 
             var style = options.GetStyle(4, 10);
 
@@ -287,7 +310,10 @@ namespace SixLabors.Fonts.Tests
                     FakeFont.CreateFontWithInstance("EFGHI", out var efghiFontInstance).Family
              };
 
-            var options = new RendererOptions(font, fontFamilys);
+            var options = new RendererOptions(font)
+            {
+                FallbackFontFamilies = fontFamilys
+            };
 
             var style = options.GetStyle(4, 10);
 

--- a/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
+++ b/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format0SubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format0SubTableTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using SixLabors.Fonts.Tables.General.CMap;
 using SixLabors.Fonts.WellKnownIds;
 
@@ -39,8 +39,9 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
         {
             var format = new Format0SubTable(0, PlatformIDs.Windows, 2, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
 
-            ushort id = format.GetGlyphId(4);
+            var found = format.TryGetGlyphId(4, out ushort id);
 
+            Assert.True(found);
             Assert.Equal(5, id);
         }
 
@@ -49,8 +50,9 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
         {
             var format = new Format0SubTable(0, PlatformIDs.Windows, 2, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
 
-            ushort id = format.GetGlyphId(99);
+            var found = format.TryGetGlyphId(99, out ushort id);
 
+            Assert.False(found);
             Assert.Equal(0, id);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format4SubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format4SubTableTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using SixLabors.Fonts.Tables.General.CMap;
 using SixLabors.Fonts.WellKnownIds;
 
@@ -48,12 +48,12 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
         }
 
         [Theory]
-        [InlineData(10, 1)]
-        [InlineData(20, 11)]
-        [InlineData(30, 12)]
-        [InlineData(90, 72)]
-        [InlineData(500, 0)] //not in range
-        public void GetCharcter(int src, int expected)
+        [InlineData(10, 1, true)]
+        [InlineData(20, 11, true)]
+        [InlineData(30, 12, true)]
+        [InlineData(90, 72, true)]
+        [InlineData(500, 0, false)] //not in range
+        public void GetCharcter(int src, int expected, bool expectedFound)
         {
             // segCountX2:    8
             // searchRange:   8
@@ -77,9 +77,11 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
                         new Format4SubTable.Segment(2, 480, 153, -27, 0),
                     },
                 glyphs);
-            ushort id = table.GetGlyphId(src);
+            //ushort id = table.GetGlyphId(src);
+            var found = table.TryGetGlyphId(src, out var id);
 
             Assert.Equal(expected, id);
+            Assert.Equal(expectedFound, found);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Provides addition APIs on the `RenderOptions` class that allows for specific alternative font families for falling back to if the currently provided font doesn't contain the have the required glyph.


Resolves #117 