### PR TITLE
Use bit masking to limit the glyph id to prevent an off by on error

### DIFF
--- a/src/SixLabors.Fonts/Tables/General/CMap/Format4SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format4SubTable.cs
@@ -34,7 +34,7 @@ namespace SixLabors.Fonts.Tables.General.CMap
                 {
                     if (seg.Offset == 0)
                     {
-                        glyphId = (ushort)((charAsInt + seg.Delta) % ushort.MaxValue); // TODO: bitmask instead?
+                        glyphId = (ushort)((charAsInt + seg.Delta) & ushort.MaxValue);
                         return true;
                     }
                     else

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_104.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_104.cs
@@ -1,4 +1,3 @@
-using SixLabors.Fonts.Exceptions;
 using SixLabors.Fonts.Tables.General.CMap;
 using Xunit;
 using static SixLabors.Fonts.Tables.General.CMap.Format4SubTable;
@@ -19,10 +18,10 @@ namespace SixLabors.Fonts.Tests.Issues
                 )
             }, null);
 
-            var delta = short.MaxValue + 2;// extra 2 to handle the difference between ushort and short when offsettings
-            
-            var codePoint = delta + 5;
-            Assert.True(tbl.TryGetGlyphId(codePoint, out var gid));
+            const int delta = short.MaxValue + 2; // extra 2 to handle the difference between ushort and short when offsettings
+
+            const int codePoint = delta + 5;
+            Assert.True(tbl.TryGetGlyphId(codePoint, out ushort gid));
 
             Assert.Equal(5, gid);
         }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_104.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_104.cs
@@ -1,0 +1,30 @@
+using SixLabors.Fonts.Exceptions;
+using SixLabors.Fonts.Tables.General.CMap;
+using Xunit;
+using static SixLabors.Fonts.Tables.General.CMap.Format4SubTable;
+
+namespace SixLabors.Fonts.Tests.Issues
+{
+    public class Issues_104
+    {
+        [Fact]
+        public void Format4SubTableWithSegmentsHasOffByOneWhenOverflowing()
+        {
+            var tbl = new Format4SubTable(0, WellKnownIds.PlatformIDs.Windows, 0, new[] {
+                new Segment(0,
+                ushort.MaxValue, // end
+                ushort.MinValue, // start of range
+                (short)(short.MaxValue), //delta
+                0 // zero to force correctly tested codepath
+                )
+            }, null);
+
+            var delta = short.MaxValue + 2;// extra 2 to handle the difference between ushort and short when offsettings
+            
+            var codePoint = delta + 5;
+            Assert.True(tbl.TryGetGlyphId(codePoint, out var gid));
+
+            Assert.Equal(5, gid);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
Use bit masking to limit the glyph id to prevent an off by on error. Fix #140

@tocsoft Will need a hand completing tests for this and verifying the fix. I just wanted to get the ball rolling.

<!-- Thanks for contributing to SixLabors.Fonts! -->
