### PR TITLE
Add LineSpacing property to allow manipulating the line height

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,11 +32,6 @@ jobs:
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
 
-            - name: Setup DotNet SDK
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: "3.1.x"
-
             - name: Pack
               shell: pwsh
               run: ./ci-pack.ps1
@@ -87,11 +82,6 @@ jobs:
                   git config --global core.longpaths true
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
-
-            - name: Setup DotNet SDK
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: "3.1.x"
 
             - name: Build
               shell: pwsh

--- a/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
+++ b/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0010" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -27,7 +27,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             FontFamily Wendy_One = fonts.Install(@"Fonts\WendyOne-Regular.ttf");
             FontFamily ColorEmoji = fonts.Install(@"Fonts\Twemoji Mozilla.ttf");
             FontFamily font2 = fonts.Install(@"Fonts\OpenSans-Regular.ttf");
-            var emojiFont = SystemFonts.Find("Segoe UI Emoji");
+            FontFamily emojiFont = SystemFonts.Find("Segoe UI Emoji");
             // fallback font tests
             RenderTextProcessor(ColorEmoji, "a😀d", pointSize: 72, fallbackFonts: new[] { font2 });
             RenderText(ColorEmoji, "a😀d", pointSize: 72, fallbackFonts: new[] { font2 });
@@ -53,6 +53,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             RenderText(font2, "Hello\nWorld", 72);
             RenderText(carter, "Hello\0World", 72);
             RenderText(Wendy_One, "Hello\0World", 72);
+
 
             RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\tx");
             RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\tx");
@@ -164,7 +165,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                 FallbackFontFamilies = textOptions.FallbackFonts?.ToArray()
             };
 
-            var textSize = TextMeasurer.Measure(text, renderOptions);
+            FontRectangle textSize = TextMeasurer.Measure(text, renderOptions);
             using (var img = new Image<Rgba32>((int)Math.Ceiling(textSize.Width) + 20, (int)Math.Ceiling(textSize.Height) + 20))
             {
                 img.Mutate(x => x.Fill(Color.White).ApplyProcessor(new DrawTextProcessorCopy(textOptions, text, font, new SolidBrushCopy(Color.Black), null, new PointF(5, 5))));
@@ -194,13 +195,13 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             using (var img = new Image<Rgba32>(width, height))
             {
                 img.Mutate(x => x.Fill(Color.White));
-                var shapesArray = shapes.ToArray();
-                var colorsArray = colors.ToArray();
+                IPath[] shapesArray = shapes.ToArray();
+                Color?[] colorsArray = colors.ToArray();
 
-                for (var i = 0; i < shapesArray.Length; i++)
+                for (int i = 0; i < shapesArray.Length; i++)
                 {
-                    var s = shapesArray[i];
-                    var c = colorsArray[i] ?? Color.HotPink;
+                    IPath s = shapesArray[i];
+                    Color c = colorsArray[i] ?? Color.HotPink;
 
                     // In ImageSharp.Drawing.Paths there is an extension method that takes in an IShape directly.
                     img.Mutate(x => x.Fill(new ShapeGraphicsOptions
@@ -232,13 +233,16 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             IEnumerable<ISimplePath> converted = shape.Flatten();
             converted.Aggregate(sb, (s, p) =>
             {
-                foreach (Vector2 point in p.Points)
+                ReadOnlySpan<PointF> points = p.Points.Span;
+                for (int i = 0; i < points.Length; i++)
                 {
+                    PointF point = points[i];
                     sb.Append(point.X);
                     sb.Append('x');
                     sb.Append(point.Y);
                     sb.Append(' ');
                 }
+
                 s.Append('\n');
                 return s;
             });

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,8 +43,8 @@
     <!--TODO: Delete this once tests Stylecop issues are fixed-->
     <PackageReference Include="StyleCop.Analyzers" IsImplicitlyDefined="true"  />
 
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
-    <InternalsVisibleTo Include="SixLabors.Fonts.Tests" PublicKey="$(SixLaborsPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
+    <InternalsVisibleTo Include="SixLabors.Fonts.Tests" Key="$(SixLaborsPublicKey)"/>
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -16,10 +16,6 @@
 
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
-  <PropertyGroup>
-    <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
-  </PropertyGroup>
-
   <!-- Workaround for running Coverlet with Determenistic builds -->
   <!-- https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/DeterministicBuild.md -->
   <Target Name="CoverletGetPathMap"
@@ -31,6 +27,9 @@
     </ItemGroup>
   </Target>
 
+  <PropertyGroup>
+    <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
+  </PropertyGroup>
 
   <ItemDefinitionGroup>
     <InternalsVisibleTo>
@@ -47,10 +46,16 @@
           Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(GeneratedInternalsVisibleToFile)">
-    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute" AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity)" Condition="'%(InternalsVisibleTo.PublicKey)' == ''">
+    <CreateItem
+      Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
+      AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity)"
+      Condition="'%(InternalsVisibleTo.Key)' == ''">
       <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
     </CreateItem>
-    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute" AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.PublicKey)" Condition="'%(InternalsVisibleTo.PublicKey)' != ''">
+    <CreateItem
+      Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
+      AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.Key)"
+      Condition="'%(InternalsVisibleTo.Key)' != ''">
       <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
     </CreateItem>
 

--- a/src/SixLabors.Fonts/RendererOptions.cs
+++ b/src/SixLabors.Fonts/RendererOptions.cs
@@ -124,7 +124,7 @@ namespace SixLabors.Fonts
         /// <value>
         ///     if value is -1 then wrapping is disabled.
         /// </value>
-        public float WrappingWidth { get; set; } = 150;
+        public float WrappingWidth { get; set; } = -1;
 
         /// <summary>
         /// Gets or sets the line spacing. Applied as a multiple of the line height.

--- a/src/SixLabors.Fonts/RendererOptions.cs
+++ b/src/SixLabors.Fonts/RendererOptions.cs
@@ -124,7 +124,12 @@ namespace SixLabors.Fonts
         /// <value>
         ///     if value is -1 then wrapping is disabled.
         /// </value>
-        public float WrappingWidth { get; set; } = -1;
+        public float WrappingWidth { get; set; } = 150;
+
+        /// <summary>
+        /// Gets or sets the line spacing. Applied as a multiple of the line height.
+        /// </summary>
+        public float LineSpacing { get; set; } = 1;
 
         /// <summary>
         /// Gets or sets the Horizontal alignment of the text.

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 using SixLabors.Fonts.Exceptions;
 
 namespace SixLabors.Fonts
@@ -97,11 +96,12 @@ namespace SixLabors.Fonts
                     return FontsThrowHelper.ThrowGlyphMissingException<IReadOnlyList<GlyphLayout>>(codePoint);
                 }
 
-                var glyph = glyphs[0];
-                if (glyph.Font.LineHeight > unscaledLineHeight)
+                GlyphInstance? glyph = glyphs[0];
+                float fontHeight = glyph.Font.LineHeight * options.LineSpacing;
+                if (fontHeight > unscaledLineHeight)
                 {
                     // get the larget lineheight thus far
-                    unscaledLineHeight = glyph.Font.LineHeight;
+                    unscaledLineHeight = fontHeight;
                     scale = glyph.Font.EmSize * 72;
                     lineHeight = (unscaledLineHeight * spanStyle.PointSize) / scale;
                 }
@@ -122,12 +122,15 @@ namespace SixLabors.Fonts
 
                 if (firstLine)
                 {
-                    if (lineHeight > lineHeightOfFirstLine)
+                    // Reset the line height for the first line to prevent
+                    // initial lead.
+                    float unspacedLineHeight = lineHeight / options.LineSpacing;
+                    if (unspacedLineHeight > lineHeightOfFirstLine)
                     {
-                        lineHeightOfFirstLine = lineHeight;
+                        lineHeightOfFirstLine = unspacedLineHeight;
                     }
 
-                    var lineGap = lineHeightOfFirstLine - lineMaxAscender - lineMaxDescender;
+                    float lineGap = lineHeightOfFirstLine - lineMaxAscender - lineMaxDescender;
 
                     top = lineHeightOfFirstLine - lineMaxAscender - (lineGap / 2);
                 }
@@ -162,10 +165,10 @@ namespace SixLabors.Fonts
                         location.X = glyphLocation.X;
                     }
 
-                    foreach (var g in glyphs)
+                    foreach (GlyphInstance? g in glyphs)
                     {
-                        var w = (g.AdvanceWidth * spanStyle.PointSize) / scale;
-                        var h = (g.Height * spanStyle.PointSize) / scale;
+                        float w = (g.AdvanceWidth * spanStyle.PointSize) / scale;
+                        float h = (g.Height * spanStyle.PointSize) / scale;
                         layout.Add(new GlyphLayout(codePoint, new Glyph(g, spanStyle.PointSize), glyphLocation, w, h, lineHeight, startOfLine, false, false));
 
                         if (w > glyphWidth)

--- a/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Text;
-using SixLabors.Fonts.Tables.General;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests
@@ -17,6 +14,7 @@ namespace SixLabors.Fonts.Tests
             Assert.Equal(-1, options.WrappingWidth);
             Assert.Equal(HorizontalAlignment.Left, options.HorizontalAlignment);
             Assert.Equal(VerticalAlignment.Top, options.VerticalAlignment);
+            Assert.Equal(1, options.LineSpacing);
         }
 
         [Fact]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Add a new property `RenderOptions.LineSpacing` with a default value of `1`. This is applied as a multiplier of the lineheight in the same manner as MS Word. Fixes #152 

Left is default, Right is with a value of `2`.

![Comparison of line spacing](https://user-images.githubusercontent.com/385879/101967997-ed1c4f00-3c14-11eb-95fe-980d427aa0a9.png)


<!-- Thanks for contributing to SixLabors.Fonts! -->
