### PR TITLE
Use Shared Props/Targets + Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,375 +1,436 @@
-###############################################################################
-# EditorConfig is awesome: http://EditorConfig.org
-###############################################################################
+# Version: 1.6.2 (Using https://semver.org/)
+# Updated: 2020-11-02
+# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
+# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+# See http://EditorConfig.org for more information about .editorconfig files.
 
-###############################################################################
-# Top-most EditorConfig file
-###############################################################################
+##########################################
+# Common Settings
+##########################################
+
+# This file is the top-most EditorConfig file
 root = true
 
-###############################################################################
-# Set default behavior to:
-#   a UTF-8 encoding,
-#   Unix-style line endings,
-#   a newline ending the file,
-#   4 space indentation, and
-#   trimming of trailing whitespace
-###############################################################################
+# All Files
 [*]
 charset = utf-8
-end_of_line = lf
-insert_final_newline = true
 indent_style = space
 indent_size = 4
+end_of_line = lf
+insert_final_newline = true
 trim_trailing_whitespace = true
 
-###############################################################################
-# Set file behavior to:
-#   2 space indentation
-###############################################################################
-[*.{cmd,config,csproj,json,props,ps1,resx,sh,targets}]
-indent_size = 2
+##########################################
+# File Extension Settings
+##########################################
 
-###############################################################################
-# Set file behavior to:
-#   Windows-style line endings, and
-#   tabular indentation
-###############################################################################
+# Visual Studio Solution Files
 [*.sln]
-end_of_line = crlf
 indent_style = tab
 
-###############################################################################
-# Set dotnet naming rules to:
-#    suggest async members be pascal case suffixed with Async
-#    suggest const declarations be pascal case
-#    suggest interfaces be pascal case prefixed with I
-#    suggest parameters be camel case
-#    suggest private and internal static fields be camel case
-#    suggest private and internal fields be camel case
-#    suggest public and protected declarations be pascal case
-#    suggest static readonly declarations be pascal case
-#    suggest type parameters be prefixed with T
-###############################################################################
-[*.cs]
-dotnet_naming_rule.async_members_should_be_pascal_case_suffixed_with_async.severity = suggestion
-dotnet_naming_rule.async_members_should_be_pascal_case_suffixed_with_async.style = pascal_case_suffixed_with_async
-dotnet_naming_rule.async_members_should_be_pascal_case_suffixed_with_async.symbols = async_members
+# Visual Studio XML Project Files
+[*.{csproj,vbproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
 
-dotnet_naming_rule.const_declarations_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.const_declarations_should_be_pascal_case.style = pascal_case
-dotnet_naming_rule.const_declarations_should_be_pascal_case.symbols = const_declarations
+# T4 Templates Files
+[*.{tt,ttinclude}]
+end_of_line = crlf
 
-dotnet_naming_rule.interfaces_should_be_pascal_case_prefixed_with_i.severity = suggestion
-dotnet_naming_rule.interfaces_should_be_pascal_case_prefixed_with_i.style = pascal_case_prefixed_with_i
-dotnet_naming_rule.interfaces_should_be_pascal_case_prefixed_with_i.symbols = interfaces
+# XML Configuration Files
+[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
 
-dotnet_naming_rule.parameters_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.parameters_should_be_camel_case.style = camel_case
-dotnet_naming_rule.parameters_should_be_camel_case.symbols = parameters
+# JSON Files
+[*.{json,json5,webmanifest}]
+indent_size = 2
 
-dotnet_naming_rule.private_and_internal_static_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.private_and_internal_static_fields_should_be_camel_case.style = camel_case
-dotnet_naming_rule.private_and_internal_static_fields_should_be_camel_case.symbols = private_and_internal_static_fields
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
 
-dotnet_naming_rule.private_and_internal_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.private_and_internal_fields_should_be_camel_case.style = camel_case
-dotnet_naming_rule.private_and_internal_fields_should_be_camel_case.symbols = private_and_internal_fields
+# Markdown Files
+[*.md]
+trim_trailing_whitespace = false
 
-dotnet_naming_rule.public_and_protected_declarations_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.public_and_protected_declarations_should_be_pascal_case.style = pascal_case
-dotnet_naming_rule.public_and_protected_declarations_should_be_pascal_case.symbols = public_and_protected_declarations
-dotnet_naming_symbols.public_and_protected_declarations.applicable_kinds = method, field, event, property
+# Web Files
+[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,svg,vue}]
+indent_size = 2
 
-dotnet_naming_rule.static_readonly_declarations_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.static_readonly_declarations_should_be_pascal_case.style = pascal_case
-dotnet_naming_rule.static_readonly_declarations_should_be_pascal_case.symbols = static_readonly_declarations
+# Batch Files
+[*.{cmd,bat}]
+end_of_line = crlf
 
-dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.severity = suggestion
-dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.style = pascal_case_prefixed_with_t
-dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.symbols = type_parameters
+# Makefiles
+[Makefile]
+indent_style = tab
 
-###############################################################################
-# Set dotnet naming styles to define:
-#   camel case
-#   pascal case
-#   pascal case suffixed with Async
-#   pascal case prefixed with I
-#   pascal case prefixed with T
-###############################################################################
-[*.cs]
-dotnet_naming_style.camel_case.capitalization = camel_case
+##########################################
+# File Header (Uncomment to support file headers)
+# https://docs.microsoft.com/visualstudio/ide/reference/add-file-header
+##########################################
 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
+# [*.{cs,csx,cake,vb,vbx,tt,ttinclude}]
+file_header_template = Copyright (c) Six Labors.\nLicensed under the Apache License, Version 2.0.
 
-dotnet_naming_style.pascal_case_suffixed_with_async.capitalization = pascal_case
-dotnet_naming_style.pascal_case_suffixed_with_async.required_suffix = Async
+# SA1636: File header copyright text should match
+# Justification: .editorconfig supports file headers. If this is changed to a value other than "none", a stylecop.json file will need to added to the project.
+# dotnet_diagnostic.SA1636.severity = none
 
-dotnet_naming_style.pascal_case_prefixed_with_i.capitalization = pascal_case
-dotnet_naming_style.pascal_case_prefixed_with_i.required_prefix = I
+##########################################
+# .NET Language Conventions
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions
+##########################################
 
-dotnet_naming_style.pascal_case_prefixed_with_t.capitalization = pascal_case
-dotnet_naming_style.pascal_case_prefixed_with_t.required_prefix = T
-
-###############################################################################
-# Set dotnet naming symbols to:
-#   async members
-#   const declarations
-#   interfaces
-#   private and internal fields
-#   private and internal static fields
-#   public and protected declarations
-#   static readonly declarations
-#   type parameters
-###############################################################################
-[*.cs]
-dotnet_naming_symbols.async_members.required_modifiers = async
-
-dotnet_naming_symbols.const_declarations.required_modifiers = const
-
-dotnet_naming_symbols.interfaces.applicable_kinds = interface
-
-dotnet_naming_symbols.parameters.applicable_kinds = parameter
-
-dotnet_naming_symbols.private_and_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_symbols.private_and_internal_fields.applicable_kinds = field
-
-dotnet_naming_symbols.private_and_internal_static_fields.applicable_accessibilities = private, internal
-dotnet_naming_symbols.private_and_internal_static_fields.applicable_kinds = field
-dotnet_naming_symbols.private_and_internal_static_fields.required_modifiers = static
-
-dotnet_naming_symbols.public_and_protected_declarations.applicable_accessibilities = public, protected
-
-dotnet_naming_symbols.static_readonly_declarations.required_modifiers = static, readonly
-
-dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
-
-###############################################################################
-# Set dotnet sort options to:
-#   do not separate import directives into groups, and
-#   sort system directives first
-###############################################################################
-[*.cs]
-dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = true
-
-###############################################################################
-# Set dotnet style options to:
-#   suggest null-coalescing expressions,
-#   suggest collection-initializers,
-#   suggest explicit tuple names,
-#   suggest null-propogation
-#   suggest object-initializers,
-#   generate parentheses in arithmetic binary operators for clarity,
-#   generate parentheses in other binary operators for clarity,
-#   don't generate parentheses in other operators if unnecessary,
-#   generate parentheses in relational binary operators for clarity,
-#   warn when not using predefined-types for locals, parameters, and members,
-#   generate predefined-types of type names for member access,
-#   generate auto properties,
-#   suggest compound assignment,
-#   generate conditional expression over assignment,
-#   generate conditional expression over return,
-#   suggest inferred anonymous types,
-#   suggest inferred tuple names,
-#   suggest 'is null' checks over '== null',
-#   don't generate 'this.' and 'Me.' for events,
-#   warn when not using 'this.' and 'Me.' for fields,
-#   warn when not using 'this.' and 'Me.' for methods,
-#   warn when not using 'this.' and 'Me.' for properties,
-#   suggest readonly fields, and
-#   generate accessibility modifiers for non interface members
-###############################################################################
-[*.cs]
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_object_initializer = true:suggestion
-
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
-
-dotnet_style_predefined_type_for_locals_parameters_members = true:warning
-dotnet_style_predefined_type_for_member_access = true:silent
-
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-
-dotnet_style_qualification_for_event = false:silent
+# .NET Code Style Settings
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#net-code-style-settings
+[*.{cs,csx,cake,vb,vbx}]
+# "this." and "Me." qualifiers
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#this-and-me
 dotnet_style_qualification_for_field = true:warning
-dotnet_style_qualification_for_method = true:warning
 dotnet_style_qualification_for_property = true:warning
+dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_event = true:warning
+# Language keywords instead of framework type names for type references
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#language-keywords
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+# Modifier preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#normalize-modifiers
+dotnet_style_require_accessibility_modifiers = always:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:warning
+dotnet_style_readonly_field = true:warning
+# Parentheses preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parentheses-preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+# Expression-level preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
+dotnet_style_prefer_conditional_expression_over_return = false:suggestion
+dotnet_style_prefer_compound_assignment = true:warning
+# Null-checking preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#null-checking-preferences
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+# Parameter preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parameter-preferences
+dotnet_code_quality_unused_parameters = all:warning
+# More style options (Undocumented)
+# https://github.com/MicrosoftDocs/visualstudio-docs/issues/3641
+dotnet_style_operator_placement_when_wrapping = end_of_line
+# https://github.com/dotnet/roslyn/pull/40070
+dotnet_style_prefer_simplified_interpolation = true:warning
 
-dotnet_style_readonly_field = true:suggestion
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+# C# Code Style Settings
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-code-style-settings
+[*.{cs,csx,cake}]
+# Implicit and explicit types
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#implicit-and-explicit-types
+csharp_style_var_for_built_in_types = never
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = false:warning
+# Expression-bodied members
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-bodied-members
+csharp_style_expression_bodied_methods = true:warning
+csharp_style_expression_bodied_constructors = true:warning
+csharp_style_expression_bodied_operators = true:warning
+csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_accessors = true:warning
+csharp_style_expression_bodied_lambdas = true:warning
+csharp_style_expression_bodied_local_functions = true:warning
+# Pattern matching
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#pattern-matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+# Inlined variable declarations
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#inlined-variable-declarations
+csharp_style_inlined_variable_declaration = true:warning
+# Expression-level preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
+csharp_prefer_simple_default_expression = true:warning
+# "Null" checking preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-null-checking-preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+# Code block preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#code-block-preferences
+csharp_prefer_braces = true:warning
+# Unused value preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#unused-value-preferences
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+# Index and range preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#index-and-range-preferences
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+# Miscellaneous preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#miscellaneous-preferences
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_using_directive_placement = outside_namespace:warning
+csharp_prefer_static_local_function = true:warning
+csharp_prefer_simple_using_statement = true:suggestion
 
-###############################################################################
-# Set dotnet style options to:
-#   suggest removing all unused parameters
-###############################################################################
-[*.cs]
-dotnet_code_quality_unused_parameters = all:suggestion
+##########################################
+# .NET Formatting Conventions
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-code-style-settings-reference#formatting-conventions
+##########################################
 
-###############################################################################
-# Set csharp indent options to:
-#   indent block contents,
-#   not indent braces,
-#   indent case contents,
-#   not indent case contents when block,
-#   indent labels one less than the current, and
-#   indent switch labels
-###############################################################################
-[*.cs]
+# Organize usings
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#organize-using-directives
+dotnet_sort_system_directives_first = true
+# Newline options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#new-line-options
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#indentation-options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
 csharp_indent_block_contents = true
 csharp_indent_braces = false
-csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = false
-csharp_indent_labels = one_less_than_current
-csharp_indent_switch_labels = true
-
-###############################################################################
-# Set csharp new-line options to:
-#   insert a new-line before "catch",
-#   insert a new-line before "else",
-#   insert a new-line before "finally",
-#   insert a new-line before members in anonymous-types,
-#   insert a new-line before members in object-initializers, and
-#   insert a new-line before all open braces
-###############################################################################
-[*.cs]
-csharp_new_line_before_catch = true
-csharp_new_line_before_else = true
-csharp_new_line_before_finally = true
-
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_members_in_object_initializers = true
-
-csharp_new_line_before_open_brace = all
-
-###############################################################################
-# Set csharp preserve options to:
-#   preserve single-line blocks, and
-#   preserve single-line statements
-###############################################################################
-[*.cs]
-csharp_preserve_single_line_blocks = true
-csharp_preserve_single_line_statements = true
-
-###############################################################################
-# Set csharp space options to:
-#   remove any space after a cast,
-#   add a space after the colon in an inheritance clause,
-#   add a space after a comma,
-#   remove any space after a dot,
-#   add a space after keywords in control flow statements,
-#   add a space after a semicolon in a "for" statement,
-#   add a space before and after binary operators,
-#   remove space around declaration statements,
-#   add a space before the colon in an inheritance clause,
-#   remove any space before a comma,
-#   remove any space before a dot,
-#   remove any space before an open square-bracket,
-#   remove any space before a semicolon in a "for" statement,
-#   remove any space between empty square-brackets,
-#   remove any space between a method call's empty parameter list parenthesis,
-#   remove any space between a method call's name and its opening parenthesis,
-#   remove any space between a method call's parameter list parenthesis,
-#   remove any space between a method declaration's empty parameter list parenthesis,
-#   remove any space between a method declaration's name and its openening parenthesis,
-#   remove any space between a method declaration's parameter list parenthesis,
-#   remove any space between parentheses, and
-#   remove any space between square brackets
-###############################################################################
-[*.cs]
+# Spacing options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#spacing-options
 csharp_space_after_cast = false
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_after_comma = true
-csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_after_semicolon_in_for_statement = true
-
-csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = do_not_ignore
-
+csharp_space_between_parentheses = false
 csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_before_comma = false
-csharp_space_before_dot = false
-csharp_space_before_open_square_brackets = false
-csharp_space_before_semicolon_in_for_statement = false
-
-csharp_space_between_empty_square_brackets = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
 csharp_space_between_method_declaration_name_and_open_parenthesis = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
 csharp_space_between_square_brackets = false
+# Wrapping options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#wrap-options
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
 
-###############################################################################
-# Set csharp style options to:
-#   generate braces,
-#   suggest simple default expressions,
-#   generate a preferred modifier order,
-#   suggest conditional delegate calls,
-#   suggest deconstructed variable declarations,
-#   generate expression-bodied accessors,
-#   generate expression-bodied constructors,
-#   generate expression-bodied indexers,
-#   generate expression-bodied lambdas,
-#   generate expression-bodied methods,
-#   generate expression-bodied operators,
-#   generate expression-bodied properties,
-#   suggest inlined variable declarations,
-#   suggest local over anonymous functions,
-#   suggest pattern-matching over "as" with "null" check,
-#   suggest pattern-matching over "is" with "cast" check,
-#   suggest throw expressions,
-#   generate a discard variable for unused value expression statements,
-#   suggest a discard variable for unused assignments,
-#   warn when using var for built-in types,
-#   warn when using var when the type is not apparent, and
-#   warn when not using var when the type is apparent
-###############################################################################
-[*.cs]
-csharp_prefer_braces = true:silent
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+##########################################
+# .NET Naming Conventions
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-naming-conventions
+##########################################
 
-csharp_style_conditional_delegate_call = true:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
+[*.{cs,csx,cake,vb,vbx}]
 
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_constructors = true:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_methods = true:silent
-csharp_style_expression_bodied_operators = true:silent
-csharp_style_expression_bodied_properties = true:silent
+##########################################
+# Styles
+##########################################
 
-csharp_style_inlined_variable_declaration = true:suggestion
+# camel_case_style - Define the camelCase style
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+# pascal_case_style - Define the PascalCase style
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+# first_upper_style - The first character must start with an upper-case character
+dotnet_naming_style.first_upper_style.capitalization = first_word_upper
+# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+# disallowed_style - Anything that has this style applied is marked as disallowed
+dotnet_naming_style.disallowed_style.capitalization  = pascal_case
+dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
+dotnet_naming_style.disallowed_style.required_suffix = ____RULE_VIOLATION____
+# internal_error_style - This style should never occur... if it does, it indicates a bug in file or in the parser using the file
+dotnet_naming_style.internal_error_style.capitalization  = pascal_case
+dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
+dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
 
-csharp_style_pattern_local_over_anonymous_function = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+##########################################
+# .NET Design Guideline Field Naming Rules
+# Naming rules for fields follow the .NET Framework design guidelines
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/index
+##########################################
 
-csharp_style_throw_expression = true:suggestion
+# All public/protected/protected_internal constant fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols    = public_protected_constant_fields_group
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity   = warning
 
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+# All public/protected/protected_internal static readonly fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols    = public_protected_static_readonly_fields_group
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
 
-csharp_style_var_for_built_in_types = false:warning
-csharp_style_var_elsewhere = false:warning
-csharp_style_var_when_type_is_apparent = true:warning
+# No other public/protected/protected_internal fields are allowed
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds           = field
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols             = other_public_protected_fields_group
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style               = disallowed_style
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity            = error
 
-# SA1011: Closing square brackets should be spaced correctly
-dotnet_diagnostic.SA1011.severity = none
+##########################################
+# StyleCop Field Naming Rules
+# Naming rules for fields follow the StyleCop analyzers
+# This does not override any rules using disallowed_style above
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
+##########################################
+
+# All constant fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols    = stylecop_constant_fields_group
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All static readonly fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols    = stylecop_static_readonly_fields_group
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No non-private instance fields are allowed
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols               = stylecop_fields_must_be_private_group
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style                 = disallowed_style
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity              = error
+
+# Private fields must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols     = stylecop_private_fields_group
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity    = warning
+
+# Local variables must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds           = local
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols     = stylecop_local_fields_group
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity    = silent
+
+# This rule should never fire.  However, it's included for at least two purposes:
+# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
+# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds           = field
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols  = sanity_check_uncovered_field_case_group
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style    = internal_error_style
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
+
+
+##########################################
+# Other Naming Rules
+##########################################
+
+# All of the following must be PascalCase:
+# - Namespaces
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-namespaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Classes and Enumerations
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Delegates
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types
+# - Constructors, Properties, Events, Methods
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-type-members
+dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
+dotnet_naming_rule.element_rule.symbols              = element_group
+dotnet_naming_rule.element_rule.style                = pascal_case_style
+dotnet_naming_rule.element_rule.severity             = warning
+
+# Interfaces use PascalCase and are prefixed with uppercase 'I'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.interface_group.applicable_kinds = interface
+dotnet_naming_rule.interface_rule.symbols              = interface_group
+dotnet_naming_rule.interface_rule.style                = prefix_interface_with_i_style
+dotnet_naming_rule.interface_rule.severity             = warning
+
+# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameter_rule.symbols              = type_parameter_group
+dotnet_naming_rule.type_parameter_rule.style                = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameter_rule.severity             = warning
+
+# Function parameters use camelCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters
+dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
+dotnet_naming_rule.parameters_rule.symbols              = parameters_group
+dotnet_naming_rule.parameters_rule.style                = camel_case_style
+dotnet_naming_rule.parameters_rule.severity             = warning
+
+##########################################
+# License
+##########################################
+# The following applies as to the .editorconfig file ONLY, and is
+# included below for reference, per the requirements of the license
+# corresponding to this .editorconfig file.
+# See: https://github.com/RehanSaeed/EditorConfig
+#
+# MIT License
+#
+# Copyright (c) 2017-2019 Muhammad Rehan Saeed
+# Copyright (c) 2019 Henry Gabryjelski
+#
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject
+# to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+##########################################

--- a/.gitattributes
+++ b/.gitattributes
@@ -87,17 +87,34 @@
 # Set explicit file behavior to:
 #   treat as binary
 ###############################################################################
+*.basis             binary
 *.bmp               binary
+*.dds               binary
 *.dll               binary
+*.eot               binary
 *.exe               binary
 *.gif               binary
 *.jpg               binary
+*.ktx               binary
+*.otf               binary
+*.pbm               binary
+*.pdf               binary
 *.png               binary
-*.ttf               binary
+*.ppt               binary
+*.pptx              binary
+*.pvr               binary
 *.snk               binary
+*.tga               binary
+*.tif               binary
+*.tiff              binary
 *.ttc               binary
 *.ttf               binary
+*.wbmp              binary
+*.webp              binary
 *.woff              binary
+*.woff2             binary
+*.xls               binary
+*.xlsx              binary
 
 ###############################################################################
 # Set explicit file behavior to:
@@ -109,3 +126,4 @@
 *.pdf               diff=astextplain
 *.pptx              diff=astextplain
 *.rtf               diff=astextplain
+*.svg               diff=astextplain

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,41 +11,15 @@ on:
             - master
 
 jobs:
-    Publish:
-        needs: [Build]
-
-        runs-on: windows-latest
-
-        if: (github.event_name == 'push')
-
-        steps:
-            - uses: actions/checkout@v2
-
-            - name: Install NuGet
-              uses: NuGet/setup-nuget@v1
-
-            - name: Setup Git
-              shell: bash
-              run: |
-                  git config --global core.autocrlf false
-                  git config --global core.longpaths true
-                  git fetch --prune --unshallow
-                  git submodule -q update --init --recursive
-
-            - name: Pack
-              shell: pwsh
-              run: ./ci-pack.ps1
-
-            - name: Publish to MyGet
-              shell: pwsh
-              run: nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
-              # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org
-
     Build:
         strategy:
             matrix:
                 options:
                     - os: ubuntu-latest
+                      framework: netcoreapp3.1
+                      runtime: -x64
+                      codecov: false
+                    - os: macos-latest
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: false
@@ -83,6 +57,14 @@ jobs:
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
 
+            - name: Setup NuGet Cache
+              uses: actions/cache@v2
+              id: nuget-cache
+              with:
+                  path: ~/.nuget
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+                  restore-keys: ${{ runner.os }}-nuget-
+
             - name: Build
               shell: pwsh
               run: ./ci-build.ps1
@@ -94,8 +76,46 @@ jobs:
                   CI : True
                   XUNIT_PATH: .\tests\SixLabors.Fonts.Tests # Required for xunit
 
+            - name: Export Failed Output
+              uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                  name: actual_output_${{ runner.os }}_${{ matrix.options.framework }}${{ matrix.options.runtime }}.zip
+                  path: tests/Images/ActualOutput/
+
             - name: Update Codecov
-              uses: codecov/codecov-action@v1.0.7
+              uses: codecov/codecov-action@v1
               if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
               with:
                   flags: unittests
+
+    Publish:
+        needs: [Build]
+
+        runs-on: windows-latest
+
+        if: (github.event_name == 'push')
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Install NuGet
+              uses: NuGet/setup-nuget@v1
+
+            - name: Setup Git
+              shell: bash
+              run: |
+                  git config --global core.autocrlf false
+                  git config --global core.longpaths true
+                  git fetch --prune --unshallow
+                  git submodule -q update --init --recursive
+
+            - name: Pack
+              shell: pwsh
+              run: ./ci-pack.ps1
+
+            - name: Publish to MyGet
+              shell: pwsh
+              run: |
+                  nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
+                  nuget.exe push .\artifacts\*.snupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v3/index.json

--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ ClientBin/
 *.publishsettings
 node_modules/
 orleans.codegen.cs
+.DS_STORE
 
 # Since there are multiple workflows, uncomment next line to ignore bower_components
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,106 +10,46 @@
     that is done by the file that imports us.
   -->
 
-  <!-- Default settings that are used by other settings -->
   <PropertyGroup>
-    <BaseArtifactsPath>$(MSBuildThisFileDirectory)artifacts/</BaseArtifactsPath>
-    <BaseArtifactsPathSuffix>$(ImageSharpProjectCategory)/$(MSBuildProjectName)</BaseArtifactsPathSuffix>
-    <RepositoryUrl Condition="'$(RepositoryUrl)' == ''">https://github.com/SixLabors/Fonts/</RepositoryUrl>
+    <!-- This MUST be defined before importing props. -->
+    <SixLaborsSolutionDirectory>$(MSBuildThisFileDirectory)</SixLaborsSolutionDirectory>
   </PropertyGroup>
 
-  <!-- Default settings that explicitly differ from the Sdk.props defaults  -->
-  <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
-    <DebugType Condition="'$(codecov)' != ''">full</DebugType>
-    <NullableContextOptions>disable</NullableContextOptions>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-  </PropertyGroup>
+  <!-- Import the shared global .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)shared-infrastructure\msbuild\props\SixLabors.Global.props" />
 
   <!--
     https://apisof.net/
-    +===================+=======+==========+=====================+=============+=================+====================+==============+==================+=====================+
-    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE | CULTUREINFO_LCID | NULLABLE_ATTRIBUTES |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+==================+=====================+
-    | netcoreapp3.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |         Y        |         Y           |
-    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |         Y        |         N           |
-    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |         Y        |         N           |
-    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |         Y        |         Y           |
-    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |         Y        |         N           |
-    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |         N        |         N           |
-    | net472            |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |         Y        |         N           |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+==================+=====================+
-    -->
+    +===================+=======+==========+=====================+
+    | SUPPORTS          | CULTUREINFO_LCID | NULLABLE_ATTRIBUTES |
+    +===================+==================+=====================+
+    | netcoreapp3.1     |         Y        |         Y           |
+    | netcoreapp2.1     |         Y        |         N           |
+    | netcoreapp2.0     |         Y        |         N           |
+    | netstandard2.1    |         Y        |         Y           |
+    | netstandard2.0    |         Y        |         N           |
+    | netstandard1.3    |         N        |         N           |
+    | net472            |         Y        |         N           |
+    +===================+==================+=====================+
+  -->
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_RUNTIME_INTRINSICS;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID;NULLABLE_ATTRIBUTES</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CULTUREINFO_LCID;NULLABLE_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
+    <DefineConstants>$(DefineConstants)SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
+    <DefineConstants>$(DefineConstants)SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID;NULLABLE_ATTRIBUTES</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CULTUREINFO_LCID;NULLABLE_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_CODECOVERAGE;SUPPORTS_CULTUREINFO_LCID</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CULTUREINFO_LCID</DefineConstants>
   </PropertyGroup>
-
-  <!-- Default settings that explicitly differ from the Sdk.targets defaults-->
-  <PropertyGroup>
-    <Authors>Six Labors and contributors</Authors>
-    <Company>Six Labors</Company>
-    <PackageOutputPath>$(BaseArtifactsPath)pkg/$(BaseArtifactsPathSuffix)/$(Configuration)/</PackageOutputPath>
-    <Product>SixLabors.Fonts</Product>
-    <VersionPrefix>0.0.1</VersionPrefix>
-    <VersionPrefix Condition="'$(packageversion)' != ''">$(PackageVersion)</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
-  </PropertyGroup>
-
-  <!--MinVer Properties for versioning-->
-  <PropertyGroup>
-    <MinVerTagPrefix>v</MinVerTagPrefix>
-    <MinVerVerbosity>normal</MinVerVerbosity>
-  </PropertyGroup>
-
-  <!-- Default settings that are otherwise undefined -->
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)shared-infrastructure/SixLabors.snk</AssemblyOriginatorKeyFile>
-    <Copyright>Copyright © Six Labors</Copyright>
-    <Features>strict;IOperation</Features>
-    <HighEntropyVA>true</HighEntropyVA>
-    <LangVersion>8.0</LangVersion>
-    <NeutralLanguage>en</NeutralLanguage>
-    <OverwriteReadOnlyFiles>true</OverwriteReadOnlyFiles>
-    <PackageIcon>sixlabors.fonts.128.png</PackageIcon>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <RepositoryType>git</RepositoryType>
-    <RestoreSources>
-      https://www.myget.org/F/sixlabors/api/v3/index.json;
-      https://api.nuget.org/v3/index.json;
-    </RestoreSources>
-    <SixLaborsPublicKey>00240000048000009400000006020000002400005253413100040000010001000147e6fe6766715eec6cfed61f1e7dcdbf69748a3e355c67e9d8dfd953acab1d5e012ba34b23308166fdc61ee1d0390d5f36d814a6091dd4b5ed9eda5a26afced924c683b4bfb4b3d64b0586a57eff9f02b1f84e3cb0ddd518bd1697f2c84dcbb97eb8bb5c7801be12112ed0ec86db934b0e9a5171e6bb1384b6d2f7d54dfa97</SixLaborsPublicKey>
-    <UseSharedCompilation>true</UseSharedCompilation>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-
-  <!-- Package references and additional files which are consumed by all projects -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" IsImplicitlyDefined="true"  />
-    <!--TODO: Enable this once tests Stylecop issues are fixed-->
-    <!--<PackageReference Include="StyleCop.Analyzers" IsImplicitlyDefined="true"  />-->
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)shared-infrastructure\stylecop.json" Visible="false" />
-    <!--NuGet package icon source-->
-    <None Include="$(MSBuildThisFileDirectory)shared-infrastructure\branding\icons\fonts\sixlabors.fonts.128.png" Pack="true" PackagePath="" />
-  </ItemGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,36 +5,12 @@
     Directory.Build.targets is automatically picked up and imported by
     Microsoft.Common.targets. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly late and most other props/targets will have been
+    instead. They import fairly late and most other props/targets will have been
     imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <!-- Settings that append the existing setting value -->
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);$(OS)</DefineConstants>
-  </PropertyGroup>
-
-  <!-- Package versions for package references across all projects -->
-  <ItemGroup>
-    <!--Global Dependencies-->
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.3.1" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
-    <PackageReference Update="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
-
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Update="MinVer" PrivateAssets="All" Version="2.3.0" />
-
-    <!--Src Dependencies-->
-    <PackageReference Update="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Update="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Update="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
-    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
-    <PackageReference Update="System.Threading.Tasks.Parallel" Version="4.3.0" />
-    <PackageReference Update="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Update="System.Buffers" Version="4.5.0" />
-    <PackageReference Update="System.Memory" Version="4.5.3" />
-
-  </ItemGroup>
+  <!-- Import the shared global .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)shared-infrastructure\msbuild\targets\SixLabors.Global.targets"/>
 
 </Project>

--- a/SixLabors.Fonts.sln
+++ b/SixLabors.Fonts.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{815C0625-CD3
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
+		src\Fonts.ruleset = src\Fonts.ruleset
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{56801022-D71A-4FBE-BC5B-CBA08E2284EC}"

--- a/SixLabors.Fonts.sln
+++ b/SixLabors.Fonts.sln
@@ -35,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{71A3
 	ProjectSection(SolutionItems) = preProject
 		samples\Directory.Build.props = samples\Directory.Build.props
 		samples\Directory.Build.targets = samples\Directory.Build.targets
+		samples\Fonts.Samples.ruleset = samples\Fonts.Samples.ruleset
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrawWithImageSharp", "samples\DrawWithImageSharp\DrawWithImageSharp.csproj", "{999EDFB3-9FE4-4E09-B669-CB02E597EC20}"

--- a/SixLabors.Fonts.sln
+++ b/SixLabors.Fonts.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29512.175
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C317F1B1-D75E-4C6D-83EB-80367343E0D7}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_root", "_root", "{C317F1B1-D75E-4C6D-83EB-80367343E0D7}"
 	ProjectSection(SolutionItems) = preProject
 		standards\.editorconfig = standards\.editorconfig
 		ci-build.ps1 = ci-build.ps1
@@ -14,13 +14,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{815C0625-CD3D-440F-9F80-2D83856AB7AE}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{815C0625-CD3D-440F-9F80-2D83856AB7AE}"
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{56801022-D71A-4FBE-BC5B-CBA08E2284EC}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{56801022-D71A-4FBE-BC5B-CBA08E2284EC}"
 	ProjectSection(SolutionItems) = preProject
 		tests\Directory.Build.props = tests\Directory.Build.props
 		tests\Directory.Build.targets = tests\Directory.Build.targets
@@ -31,6 +31,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SixLabors.Fonts.Tests", "tests\SixLabors.Fonts.Tests\SixLabors.Fonts.Tests.csproj", "{F836E8E6-B4D9-4208-8346-140C74678B91}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{71A3911C-D6B9-4EBE-9691-2FE28BDF462E}"
+	ProjectSection(SolutionItems) = preProject
+		samples\Directory.Build.props = samples\Directory.Build.props
+		samples\Directory.Build.targets = samples\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrawWithImageSharp", "samples\DrawWithImageSharp\DrawWithImageSharp.csproj", "{999EDFB3-9FE4-4E09-B669-CB02E597EC20}"
 EndProject
@@ -89,6 +93,7 @@ Global
 		{F836E8E6-B4D9-4208-8346-140C74678B91} = {56801022-D71A-4FBE-BC5B-CBA08E2284EC}
 		{999EDFB3-9FE4-4E09-B669-CB02E597EC20} = {71A3911C-D6B9-4EBE-9691-2FE28BDF462E}
 		{6DF4C474-1FDF-4DE0-9CB2-9674D2CCE1BA} = {71A3911C-D6B9-4EBE-9691-2FE28BDF462E}
+		{7CDD4908-7CCD-4945-860C-D2F1732D3AE6} = {C317F1B1-D75E-4C6D-83EB-80367343E0D7}
 		{EC0F1812-C6AF-48D8-882B-5637730D2DB1} = {7CDD4908-7CCD-4945-860C-D2F1732D3AE6}
 		{CFCC940C-DEA3-42CC-9626-0B7D09289FF4} = {7CDD4908-7CCD-4945-860C-D2F1732D3AE6}
 	EndGlobalSection

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -19,4 +19,8 @@
   <!-- Import the solution .props file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Fonts.Samples.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -5,25 +5,18 @@
     Directory.Build.props is automatically picked up and imported by
     Microsoft.Common.props. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly early and only Sdk.props will have been
+    instead. They import fairly early and only Sdk.props will have been
     imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
+  <!--Set product category-->
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.props</MSBuildAllProjects>
-    <ImageSharpProjectCategory>samples</ImageSharpProjectCategory>
+    <SixLaborsProjectCategory>samples</SixLaborsProjectCategory>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\shared-infrastructure\SixLabors.Tests.ruleset</CodeAnalysisRuleSet>
-    <!--TODO: We should remove all obsolete code from the solution-->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
-  </PropertyGroup>
-
+  <!-- Import the solution .props file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
-
-
 
 </Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -13,8 +13,4 @@
   <!-- Import the solution .targets file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
-  <ItemGroup>
-    <!-- Since our src does not target NET 472 we need to explicitly target the reference pack -->
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" IsImplicitlyDefined="true"  />
-  </ItemGroup>
 </Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -13,4 +13,8 @@
   <!-- Import the solution .targets file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
+  <ItemGroup>
+    <!-- Since our src does not target NET 472 we need to explicitly target the reference pack -->
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" IsImplicitlyDefined="true"  />
+  </ItemGroup>
 </Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -5,47 +5,12 @@
     Directory.Build.targets is automatically picked up and imported by
     Microsoft.Common.targets. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly late and most other props/targets will have
+    instead. They import fairly late and most other props/targets will have
     been imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.targets</MSBuildAllProjects>
-  </PropertyGroup>
-
+  <!-- Import the solution .targets file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
-
-  <!-- Tool versions for tool references across all projects -->
-  <ItemGroup>
-    <!--dotnet tools does not have an x86 runner. You have to use separate SDKs-->
-    <!--https://github.com/actions/setup-dotnet/issues/72-->
-    <DotNetCliToolReference Update="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-
-  <!--Code coverage specific settings-->
-  <!--https://github.com/tonerdo/coverlet-->
-  <PropertyGroup Condition="'$(codecov)' == 'true'">
-    <CollectCoverage>true</CollectCoverage>
-    <UseSourceLink>true</UseSourceLink>
-    <CoverletOutputFormat>opencover</CoverletOutputFormat>
-    <!--Output injects target framework into name despite explicit config. See build yml-->
-    <CoverletOutput>$(MSBuildThisFileDirectory)..\coverage.xml</CoverletOutput>
-    <!--Used by coverlet dues to reference issues with SixLabors.Core-->
-    <!--https://github.com/tonerdo/coverlet/blob/master/Documentation/KnowIssues.md#4-failed-to-resolve-assembly-during-instrumentation-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <!--Test Dependencies-->
-    <PackageReference Update="BenchmarkDotNet" Version="0.12.0" />
-    <PackageReference Update="coverlet.collector" Version="1.1.0" PrivateAssets="All"/>
-    <PackageReference Update="coverlet.msbuild" Version="2.8.0" PrivateAssets="All"/>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Update="Moq" Version="4.10.0" />
-    <!--TODO: Fix implicit conversion issues so we can move to 2.4.1-->
-    <PackageReference Update="xunit" Version="2.3.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.3.1" />
-  </ItemGroup>
 
 </Project>

--- a/samples/DrawWithImageSharp/BoundingBoxes.cs
+++ b/samples/DrawWithImageSharp/BoundingBoxes.cs
@@ -1,10 +1,12 @@
-using SixLabors.ImageSharp;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using SixLabors.Fonts;
-using SixLabors.Shapes.Temp;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Drawing.Processing;
-using SixLabors.ImageSharp.Drawing;
 using TextBuilder = SixLabors.Shapes.Temp.TextBuilder;
 
 namespace DrawWithImageSharp
@@ -15,7 +17,7 @@ namespace DrawWithImageSharp
         {
             using (var img = new Image<Rgba32>(1000, 1000))
             {
-                img.Mutate(x=>x.Fill(Color.White));
+                img.Mutate(x => x.Fill(Color.White));
 
                 FontRectangle box = TextMeasurer.MeasureBounds(text, new RendererOptions(font));
                 (IPathCollection paths, IPathCollection boxes, IPath textBox) = TextBuilder.GenerateGlyphsWithBox(text, new RendererOptions(font));

--- a/samples/DrawWithImageSharp/ImageSharpDrawingCachingGlyphRenderer/DrawTextProcessorCopy.cs
+++ b/samples/DrawWithImageSharp/ImageSharpDrawingCachingGlyphRenderer/DrawTextProcessorCopy.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing.Processors;
+
+namespace SixLabors.Fonts.DrawWithImageSharp
+{
+    /// <summary>
+    /// Defines a processor to draw text on an <see cref="Image"/>.
+    /// </summary>
+    public class DrawTextProcessorCopy : IImageProcessor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DrawTextProcessorCopy"/> class.
+        /// </summary>
+        /// <param name="options">The options</param>
+        /// <param name="text">The text we want to render</param>
+        /// <param name="font">The font we want to render with</param>
+        /// <param name="brush">The brush to source pixel colors from.</param>
+        /// <param name="pen">The pen to outline text with.</param>
+        /// <param name="location">The location on the image to start drawing the text from.</param>
+        public DrawTextProcessorCopy(TextGraphicsOptionsCopy options, string text, Font font, SolidBrushCopy brush, IPen pen, PointF location)
+        {
+            // Guard.NotNull(text, nameof(text));
+            // Guard.NotNull(font, nameof(font));
+            if (brush is null && pen is null)
+            {
+                throw new ArgumentNullException($"Expected a {nameof(brush)} or {nameof(pen)}. Both were null");
+            }
+
+            this.Options = options;
+            this.Text = text;
+            this.Font = font;
+            this.Location = location;
+            this.Brush = brush;
+            this.Pen = pen;
+        }
+
+        /// <summary>
+        /// Gets the brush used to fill the glyphs.
+        /// </summary>
+        public SolidBrushCopy Brush { get; }
+
+        /// <summary>
+        /// Gets the <see cref="TextGraphicsOptionsCopy"/> defining blending modes and text-specific drawing settings.
+        /// </summary>
+        public TextGraphicsOptionsCopy Options { get; }
+
+        /// <summary>
+        /// Gets the text to draw.
+        /// </summary>
+        public string Text { get; }
+
+        /// <summary>
+        /// Gets the pen used for outlining the text, if Null then we will not outline
+        /// </summary>
+        public IPen Pen { get; }
+
+        /// <summary>
+        /// Gets the font used to render the text.
+        /// </summary>
+        public Font Font { get; }
+
+        /// <summary>
+        /// Gets the location to draw the text at.
+        /// </summary>
+        public PointF Location { get; }
+
+        /// <inheritdoc />
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+            where TPixel : unmanaged, IPixel<TPixel>
+            => new DrawTextProcessorCopy<TPixel>(configuration, this, source, sourceRectangle);
+    }
+}

--- a/samples/DrawWithImageSharp/ImageSharpDrawingCachingGlyphRenderer/DrawTextProcessorCopy{TPixel}.cs
+++ b/samples/DrawWithImageSharp/ImageSharpDrawingCachingGlyphRenderer/DrawTextProcessorCopy{TPixel}.cs
@@ -503,11 +503,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
 
                 public Buffer2D<float> FillMap;
 
-                public PointF FillOffset;
-
                 public Buffer2D<float> OutlineMap;
-
-                internal PointF OutlineOffset;
 
                 public void Dispose()
                 {
@@ -552,7 +548,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         private bool isDisposed;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SolidBrushApplicator{TPixel}"/> class.
+        /// Initializes a new instance of the <see cref="SolidBrushApplicatorCopy{TPixel}"/> class.
         /// </summary>
         /// <param name="configuration">The configuration instance to use when performing operations.</param>
         /// <param name="options">The graphics options.</param>
@@ -676,7 +672,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         protected ImageFrame<TPixel> Target { get; }
 
         /// <summary>
-        /// Gets thegraphics options
+        /// Gets the graphics options
         /// </summary>
         protected GraphicsOptions Options { get; }
 

--- a/samples/DrawWithImageSharp/ImageSharpDrawingCachingGlyphRenderer/DrawTextProcessorCopy{TPixel}.cs
+++ b/samples/DrawWithImageSharp/ImageSharpDrawingCachingGlyphRenderer/DrawTextProcessorCopy{TPixel}.cs
@@ -6,9 +6,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using SixLabors.Fonts;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Memory;
@@ -30,9 +28,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
 
         public DrawTextProcessorCopy(Configuration configuration, DrawTextProcessorCopy definition, Image<TPixel> source, Rectangle sourceRectangle)
             : base(configuration, source, sourceRectangle)
-        {
-            this.definition = definition;
-        }
+            => this.definition = definition;
 
         private TextGraphicsOptionsCopy Options => this.definition.Options;
 
@@ -62,16 +58,11 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                 ColorFontSupport = this.definition.Options.RenderColorFonts ? ColorFontSupport.MicrosoftColrFormat : ColorFontSupport.None,
             };
 
-            // (this.definition.Options.RenderColorFonts)
-            //{
-                this.textRenderer = new ColorCachingGlyphRenderer(this.Configuration.MemoryAllocator, this.Text.Length, this.Pen, this.Brush != null);
-           // }
-           // else
-           // {
-           //     this.textRenderer = new CachingGlyphRenderer(this.Configuration.MemoryAllocator, this.Text.Length, this.Pen, this.Brush != null);
-           // }
+            this.textRenderer = new ColorCachingGlyphRenderer(this.Configuration.MemoryAllocator, this.Text.Length, this.Pen, this.Brush != null)
+            {
+                Options = (GraphicsOptions)this.Options
+            };
 
-            this.textRenderer.Options = (GraphicsOptions)this.Options;
             var renderer = new TextRenderer(this.textRenderer);
             renderer.RenderText(this.Text, style);
         }
@@ -88,7 +79,6 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         {
             // this is a no-op as we have processes all as an image, we should be able to pass out of before email apply a skip frames outcome
             Draw(this.textRenderer.FillOperations, this.Brush);
-            //Draw(this.textRenderer.OutlineOperations, this.Pen?.StrokeFill);
 
             void Draw(List<DrawingOperation> operations, SolidBrushCopy brush)
             {
@@ -110,7 +100,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                     {
                         foreach (DrawingOperation operation in operations)
                         {
-                            var currentApp = app;
+                            BrushApplicatorCopy<TPixel> currentApp = app;
                             if (operation.Color != null)
                             {
                                 brushes.TryGetValue(operation.Color.Value, out currentApp);
@@ -160,7 +150,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                         }
                     }
 
-                    foreach (var app in brushes.Values)
+                    foreach (BrushApplicatorCopy<TPixel> app in brushes.Values)
                     {
                         app.Dispose();
                     }
@@ -185,9 +175,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             }
 
             public void SetColor(GlyphColor color)
-            {
-                this.SetLayerColor(new Color(new Rgba32(color.Red, color.Green, color.Blue, color.Alpha)));
-            }
+                => this.SetLayerColor(new Color(new Rgba32(color.Red, color.Green, color.Blue, color.Alpha)));
         }
 
         private sealed class CachingGlyphRenderer : BaseCachingGlyphRenderer
@@ -245,9 +233,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             }
 
             protected void SetLayerColor(Color color)
-            {
-                this.currentColor = color;
-            }
+                => this.currentColor = color;
 
             public List<DrawingOperation> FillOperations { get; }
 
@@ -260,9 +246,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             public GraphicsOptions Options { get; internal set; }
 
             public void BeginFigure()
-            {
-                this.builder.StartFigure();
-            }
+                => this.builder.StartFigure();
 
             public bool BeginGlyph(FontRectangle bounds, GlyphRendererParameters parameters)
             {
@@ -317,10 +301,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                 this.glyphData.Clear();
             }
 
-            public void EndFigure()
-            {
-                this.builder.CloseFigure();
-            }
+            public void EndFigure() => this.builder.CloseFigure();
 
             public void EndGlyph()
             {
@@ -546,27 +527,22 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         /// Initializes a new instance of the <see cref="SolidBrush"/> class.
         /// </summary>
         /// <param name="color">The color.</param>
-        public SolidBrushCopy(Color color)
-        {
-            this.Color = color;
-        }
+        public SolidBrushCopy(Color color) => this.Color = color;
 
         /// <summary>
         /// Gets the color.
         /// </summary>
         public Color Color { get; }
 
-        /// <inheritdoc />
         public BrushApplicatorCopy<TPixel> CreateApplicator<TPixel>(
             Configuration configuration,
             GraphicsOptions options,
             ImageFrame<TPixel> source,
             RectangleF region)
             where TPixel : unmanaged, IPixel<TPixel>
-        {
-            return new SolidBrushApplicatorCopy<TPixel>(configuration, options, source, this.Color.ToPixel<TPixel>());
-        }
+            => new SolidBrushApplicatorCopy<TPixel>(configuration, options, source, this.Color.ToPixel<TPixel>());
     }
+
     /// <summary>
     /// The solid brush applicator.
     /// </summary>
@@ -767,6 +743,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             }
         }
     }
+
     /// <summary>
     /// Optimized quick sort implementation for Span{float} input
     /// </summary>
@@ -823,13 +800,13 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             {
                 do
                 {
-                    i = i + 1;
+                    i += 1;
                 }
                 while (Unsafe.Add(ref data0, i) < pivot && i < hi);
 
                 do
                 {
-                    j = j - 1;
+                    j -= 1;
                 }
                 while (Unsafe.Add(ref data0, j) > pivot && j > lo);
 
@@ -900,13 +877,13 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             {
                 do
                 {
-                    i = i + 1;
+                    i += 1;
                 }
                 while (Unsafe.Add(ref data0, i) < pivot && i < hi);
 
                 do
                 {
-                    j = j - 1;
+                    j -= 1;
                 }
                 while (Unsafe.Add(ref data0, j) > pivot && j > lo);
 
@@ -977,13 +954,13 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             {
                 do
                 {
-                    i = i + 1;
+                    i += 1;
                 }
                 while (Unsafe.Add(ref data0, i) < pivot && i < hi);
 
                 do
                 {
-                    j = j - 1;
+                    j -= 1;
                 }
                 while (Unsafe.Add(ref data0, j) > pivot && j > lo);
 

--- a/samples/DrawWithImageSharp/ImageSharpDrawingCachingGlyphRenderer/TextGraphicsOptionsCopy.cs
+++ b/samples/DrawWithImageSharp/ImageSharpDrawingCachingGlyphRenderer/TextGraphicsOptionsCopy.cs
@@ -3,92 +3,18 @@
 
 using System;
 using System.Collections.Generic;
-using SixLabors.Fonts;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing.Processors;
 
 namespace SixLabors.Fonts.DrawWithImageSharp
 {
-    /// <summary>
-    /// Defines a processor to draw text on an <see cref="Image"/>.
-    /// </summary>
-    public class DrawTextProcessorCopy : IImageProcessor
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DrawTextProcessor"/> class.
-        /// </summary>
-        /// <param name="options">The options</param>
-        /// <param name="text">The text we want to render</param>
-        /// <param name="font">The font we want to render with</param>
-        /// <param name="brush">The brush to source pixel colors from.</param>
-        /// <param name="pen">The pen to outline text with.</param>
-        /// <param name="location">The location on the image to start drawing the text from.</param>
-        public DrawTextProcessorCopy(TextGraphicsOptionsCopy options, string text, Font font, SolidBrushCopy brush, IPen pen, PointF location)
-        {
-           // Guard.NotNull(text, nameof(text));
-           // Guard.NotNull(font, nameof(font));
-
-            if (brush is null && pen is null)
-            {
-                throw new ArgumentNullException($"Expected a {nameof(brush)} or {nameof(pen)}. Both were null");
-            }
-
-            this.Options = options;
-            this.Text = text;
-            this.Font = font;
-            this.Location = location;
-            this.Brush = brush;
-            this.Pen = pen;
-        }
-
-        /// <summary>
-        /// Gets the brush used to fill the glyphs.
-        /// </summary>
-        public SolidBrushCopy Brush { get; }
-
-        /// <summary>
-        /// Gets the <see cref="TextGraphicsOptionsCopy"/> defining blending modes and text-specific drawing settings.
-        /// </summary>
-        public TextGraphicsOptionsCopy Options { get; }
-
-        /// <summary>
-        /// Gets the text to draw.
-        /// </summary>
-        public string Text { get; }
-
-        /// <summary>
-        /// Gets the pen used for outlining the text, if Null then we will not outline
-        /// </summary>
-        public IPen Pen { get; }
-
-        /// <summary>
-        /// Gets the font used to render the text.
-        /// </summary>
-        public Font Font { get; }
-
-        /// <summary>
-        /// Gets the location to draw the text at.
-        /// </summary>
-        public PointF Location { get; }
-
-        /// <inheritdoc />
-        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
-            where TPixel : unmanaged, IPixel<TPixel>
-            => new DrawTextProcessorCopy<TPixel>(configuration, this, source, sourceRectangle);
-    }
-
     /// <summary>
     /// Options for influencing the drawing functions.
     /// </summary>
     public class TextGraphicsOptionsCopy : IDeepCloneable<TextGraphicsOptionsCopy>
     {
-        private int antialiasSubpixelDepth = 16;
-        private float blendPercentage = 1F;
-        private float tabWidth = 4F;
-        private float dpiX = 72F;
-        private float dpiY = 72F;
+        private float lineSpacing = 1F;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextGraphicsOptionsCopy"/> class.
@@ -107,6 +33,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             this.ColorBlendingMode = source.ColorBlendingMode;
             this.DpiX = source.DpiX;
             this.DpiY = source.DpiY;
+            this.LineSpacing = source.LineSpacing;
             this.HorizontalAlignment = source.HorizontalAlignment;
             this.TabWidth = source.TabWidth;
             this.WrapTextWidth = source.WrapTextWidth;
@@ -123,36 +50,12 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         /// <summary>
         /// Gets or sets a value indicating the number of subpixels to use while rendering with antialiasing enabled.
         /// </summary>
-        public int AntialiasSubpixelDepth
-        {
-            get
-            {
-                return this.antialiasSubpixelDepth;
-            }
-
-            set
-            {
-                //Guard.MustBeGreaterThanOrEqualTo(value, 0, nameof(this.AntialiasSubpixelDepth));
-                this.antialiasSubpixelDepth = value;
-            }
-        }
+        public int AntialiasSubpixelDepth { get; set; } = 16;
 
         /// <summary>
         /// Gets or sets a value indicating the blending percentage to apply to the drawing operation.
         /// </summary>
-        public float BlendPercentage
-        {
-            get
-            {
-                return this.blendPercentage;
-            }
-
-            set
-            {
-               //Guard.MustBeBetweenOrEqualTo(value, 0, 1F, nameof(this.BlendPercentage));
-                this.blendPercentage = value;
-            }
-        }
+        public float BlendPercentage { get; set; } = 1F;
 
         /// <summary>
         /// Gets or sets a value indicating the color blending percentage to apply to the drawing operation.
@@ -176,19 +79,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         /// Gets or sets a value indicating the number of space widths a tab should lock to.
         /// Defaults to 4.
         /// </summary>
-        public float TabWidth
-        {
-            get
-            {
-                return this.tabWidth;
-            }
-
-            set
-            {
-              //  Guard.MustBeGreaterThanOrEqualTo(value, 0, nameof(this.TabWidth));
-                this.tabWidth = value;
-            }
-        }
+        public float TabWidth { get; set; } = 4F;
 
         /// <summary>
         /// Gets or sets a value, if greater than 0, indicating the width at which text should wrap.
@@ -200,35 +91,30 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         /// Gets or sets a value indicating the DPI (Dots Per Inch) to render text along the X axis.
         /// Defaults to 72.
         /// </summary>
-        public float DpiX
-        {
-            get
-            {
-                return this.dpiX;
-            }
-
-            set
-            {
-              //  Guard.MustBeGreaterThanOrEqualTo(value, 0, nameof(this.DpiX));
-                this.dpiX = value;
-            }
-        }
+        public float DpiX { get; set; } = 72F;
 
         /// <summary>
         /// Gets or sets a value indicating the DPI (Dots Per Inch) to render text along the Y axis.
         /// Defaults to 72.
         /// </summary>
-        public float DpiY
+        public float DpiY { get; set; } = 72F;
+
+        /// <summary>
+        /// Gets or sets the line spacing. Applied as a multiple of the line height.
+        /// Defaults to 1.
+        /// </summary>
+        public float LineSpacing
         {
-            get
-            {
-                return this.dpiY;
-            }
+            get => this.lineSpacing;
 
             set
             {
-               // Guard.MustBeGreaterThanOrEqualTo(value, 0, nameof(this.DpiY));
-                this.dpiY = value;
+                if (value == 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(this.LineSpacing));
+                }
+
+                this.lineSpacing = value;
             }
         }
 
@@ -267,16 +153,14 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         /// The result of the conversion.
         /// </returns>
         public static implicit operator TextGraphicsOptionsCopy(GraphicsOptions options)
-        {
-            return new TextGraphicsOptionsCopy()
+            => new TextGraphicsOptionsCopy()
             {
                 Antialias = options.Antialias,
                 AntialiasSubpixelDepth = options.AntialiasSubpixelDepth,
-                blendPercentage = options.BlendPercentage,
+                BlendPercentage = options.BlendPercentage,
                 ColorBlendingMode = options.ColorBlendingMode,
                 AlphaCompositionMode = options.AlphaCompositionMode
             };
-        }
 
         /// <summary>
         /// Performs an explicit conversion from <see cref="TextGraphicsOptions"/> to <see cref="GraphicsOptions"/>.
@@ -286,8 +170,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         /// The result of the conversion.
         /// </returns>
         public static explicit operator GraphicsOptions(TextGraphicsOptionsCopy options)
-        {
-            return new GraphicsOptions()
+            => new GraphicsOptions()
             {
                 Antialias = options.Antialias,
                 AntialiasSubpixelDepth = options.AntialiasSubpixelDepth,
@@ -295,7 +178,6 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                 AlphaCompositionMode = options.AlphaCompositionMode,
                 BlendPercentage = options.BlendPercentage
             };
-        }
 
         /// <inheritdoc/>
         public TextGraphicsOptionsCopy DeepClone() => new TextGraphicsOptionsCopy(this);

--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -1,21 +1,22 @@
-using SixLabors.ImageSharp;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using global::DrawWithImageSharp;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.Shapes.Temp;
 
 namespace SixLabors.Fonts.DrawWithImageSharp
 {
-    using global::DrawWithImageSharp;
-    using Shapes;
-    using SixLabors.ImageSharp.Drawing;
-    using SixLabors.ImageSharp.Drawing.Processing;
-    using SixLabors.ImageSharp.PixelFormats;
-    using SixLabors.ImageSharp.Processing;
-    using SixLabors.Shapes.Temp;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Numerics;
-    using System.Text;
-
     public static class Program
     {
         public static void Main(string[] args)
@@ -24,17 +25,18 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             FontFamily font = fonts.Install(@"Fonts\SixLaborsSampleAB.ttf");
             FontFamily fontWoff = fonts.Install(@"Fonts\SixLaborsSampleAB.woff");
             FontFamily carter = fonts.Install(@"Fonts\CarterOne.ttf");
-            FontFamily Wendy_One = fonts.Install(@"Fonts\WendyOne-Regular.ttf");
-            FontFamily ColorEmoji = fonts.Install(@"Fonts\Twemoji Mozilla.ttf");
+            FontFamily wendy_One = fonts.Install(@"Fonts\WendyOne-Regular.ttf");
+            FontFamily colorEmoji = fonts.Install(@"Fonts\Twemoji Mozilla.ttf");
             FontFamily font2 = fonts.Install(@"Fonts\OpenSans-Regular.ttf");
             FontFamily emojiFont = SystemFonts.Find("Segoe UI Emoji");
-            // fallback font tests
-            RenderTextProcessor(ColorEmoji, "a😀d", pointSize: 72, fallbackFonts: new[] { font2 });
-            RenderText(ColorEmoji, "a😀d", pointSize: 72, fallbackFonts: new[] { font2 });
 
-            RenderText(ColorEmoji, "😀", pointSize: 72, fallbackFonts: new[] { font2 });
+            // fallback font tests
+            RenderTextProcessor(colorEmoji, "a😀d", pointSize: 72, fallbackFonts: new[] { font2 });
+            RenderText(colorEmoji, "a😀d", pointSize: 72, fallbackFonts: new[] { font2 });
+
+            RenderText(colorEmoji, "😀", pointSize: 72, fallbackFonts: new[] { font2 });
             RenderText(emojiFont, "😀", pointSize: 72, fallbackFonts: new[] { font2 });
-            RenderText(font2, "", pointSize: 72, fallbackFonts: new[] { emojiFont });
+            RenderText(font2, string.Empty, pointSize: 72, fallbackFonts: new[] { emojiFont });
             RenderText(font2, "😀 Hello World! 😀", pointSize: 72, fallbackFonts: new[] { emojiFont });
 
             //// general
@@ -52,8 +54,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             RenderText(font2, "aaaaaa\ta", 72);
             RenderText(font2, "Hello\nWorld", 72);
             RenderText(carter, "Hello\0World", 72);
-            RenderText(Wendy_One, "Hello\0World", 72);
-
+            RenderText(wendy_One, "Hello\0World", 72);
 
             RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\tx");
             RenderText(new RendererOptions(new Font(font2, 72)) { TabWidth = 4 }, "\t\t\tx");
@@ -86,14 +87,17 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             {
                 sb.Append(c);
             }
+
             for (char c = 'A'; c <= 'Z'; c++)
             {
                 sb.Append(c);
             }
+
             for (char c = '0'; c <= '9'; c++)
             {
                 sb.Append(c);
             }
+
             string text = sb.ToString();
 
             foreach (FontFamily f in fonts.Families)
@@ -111,7 +115,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             {
                 img.Mutate(x => x.Fill(Color.White));
 
-                IPathCollection shapes = SixLabors.Shapes.Temp.TextBuilder.GenerateGlyphs(text, new Vector2(50f, 4f), new RendererOptions(font, 72));
+                IPathCollection shapes = Shapes.Temp.TextBuilder.GenerateGlyphs(text, new Vector2(50f, 4f), new RendererOptions(font, 72));
                 img.Mutate(x => x.Fill(Color.Black, shapes));
 
                 Directory.CreateDirectory(System.IO.Path.GetDirectoryName(fullPath));
@@ -134,17 +138,22 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             builder.Paths
                 .SaveImage(builder.PathColors, (int)size.Width + 20, (int)size.Height + 20, font.Font.Name, text + ".png");
         }
+
         public static void RenderText(FontFamily font, string text, float pointSize = 12, IEnumerable<FontFamily> fallbackFonts = null)
-        {
-            RenderText(new RendererOptions(new Font(font, pointSize), 96)
-            {
-                ApplyKerning = true,
-                WrappingWidth = 340,
-                FallbackFontFamilies = fallbackFonts?.ToArray(),
-                ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
-            }, text);
-        }
-        public static void RenderTextProcessor(FontFamily fontFamily, string text, float pointSize = 12, IEnumerable<FontFamily> fallbackFonts = null)
+            => RenderText(
+                new RendererOptions(new Font(font, pointSize), 96)
+                {
+                    ApplyKerning = true,
+                    WrappingWidth = 340,
+                    FallbackFontFamilies = fallbackFonts?.ToArray(),
+                    ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
+                }, text);
+
+        public static void RenderTextProcessor(
+            FontFamily fontFamily,
+            string text,
+            float pointSize = 12,
+            IEnumerable<FontFamily> fallbackFonts = null)
         {
             var textOptions = new TextGraphicsOptionsCopy
             {
@@ -157,6 +166,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             {
                 textOptions.FallbackFonts.AddRange(fallbackFonts);
             }
+
             var font = new Font(fontFamily, pointSize);
             var renderOptions = new RendererOptions(font, textOptions.DpiX, textOptions.DpiY)
             {
@@ -177,13 +187,10 @@ namespace SixLabors.Fonts.DrawWithImageSharp
         }
 
         public static void SaveImage(this IEnumerable<IPath> shapes, int width, int height, params string[] path)
-        {
-            shapes.SaveImage(new Color?[shapes.Count()], width, height, path);
-        }
+            => shapes.SaveImage(new Color?[shapes.Count()], width, height, path);
 
         private static string CreatePath(params string[] path)
         {
-
             path = path.Select(p => System.IO.Path.GetInvalidFileNameChars().Aggregate(p, (x, c) => x.Replace($"{c}", "-"))).ToArray();
             string fullPath = System.IO.Path.GetFullPath(System.IO.Path.Combine("Output", System.IO.Path.Combine(path)));
             return fullPath;
@@ -204,13 +211,18 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                     Color c = colorsArray[i] ?? Color.HotPink;
 
                     // In ImageSharp.Drawing.Paths there is an extension method that takes in an IShape directly.
-                    img.Mutate(x => x.Fill(new ShapeGraphicsOptions
-                    {
-                        ShapeOptions = {
-                            IntersectionRule = IntersectionRule.Nonzero
-                        }
-                    }, c, s.Translate(new Vector2(0, 0))));
+                    img.Mutate(x => x.Fill(
+                        new ShapeGraphicsOptions
+                        {
+                            ShapeOptions =
+                            {
+                                IntersectionRule = IntersectionRule.Nonzero
+                            }
+                        },
+                        c,
+                        s.Translate(new Vector2(0, 0))));
                 }
+
                 // img.Draw(Color.LawnGreen, 1, shape);
 
                 // Ensure directory exists
@@ -251,6 +263,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
 
             path = path.Select(p => System.IO.Path.GetInvalidFileNameChars().Aggregate(p, (x, c) => x.Replace($"{c}", "-"))).ToArray();
             string fullPath = System.IO.Path.GetFullPath(System.IO.Path.Combine("Output", System.IO.Path.Combine(path)));
+
             // pad even amount around shape
             int width = (int)(shape.Bounds.Left + shape.Bounds.Right);
             int height = (int)(shape.Bounds.Top + shape.Bounds.Bottom);
@@ -258,16 +271,19 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             {
                 width = 1;
             }
+
             if (height < 1)
             {
                 height = 1;
             }
+
             using (var img = new Image<Rgba32>(width, height))
             {
                 img.Mutate(x => x.Fill(Color.DarkBlue));
 
                 // In ImageSharp.Drawing.Paths there is an extension method that takes in an IShape directly.
                 img.Mutate(x => x.Fill(Color.HotPink, shape));
+
                 // img.Draw(Color.LawnGreen, 1, shape);
 
                 // Ensure directory exists

--- a/samples/DrawWithImageSharp/TextAlignment.cs
+++ b/samples/DrawWithImageSharp/TextAlignment.cs
@@ -1,18 +1,20 @@
-using SixLabors.ImageSharp;
-using SixLabors.Fonts;
-using SixLabors.Shapes.Temp;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Numerics;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Drawing.Processing;
-using SixLabors.ImageSharp.Drawing;
+using SixLabors.Shapes.Temp;
 
 namespace DrawWithImageSharp
 {
     public static class TextAlignment
     {
-
         public static void Generate(Font font)
         {
             using (var img = new Image<Rgba32>(1000, 1000))
@@ -26,6 +28,7 @@ namespace DrawWithImageSharp
                         Draw(img, font, v, h);
                     }
                 }
+
                 img.Save("Output/Alignment.png");
             }
         }
@@ -48,6 +51,7 @@ namespace DrawWithImageSharp
                 default:
                     break;
             }
+
             switch (horiz)
             {
                 case HorizontalAlignment.Left:

--- a/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
+++ b/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
@@ -1,22 +1,24 @@
-using SixLabors.ImageSharp;
-using SixLabors.Fonts;
-using SixLabors.Shapes.Temp;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Numerics;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Drawing.Processing;
-using SixLabors.ImageSharp.Drawing;
+using SixLabors.Shapes.Temp;
 
 namespace DrawWithImageSharp
 {
     public static class TextAlignmentWrapped
     {
-
         public static void Generate(Font font)
         {
             int wrappingWidth = 400;
-            int size = (wrappingWidth + wrappingWidth / 3) * 3;
+            int size = (wrappingWidth + (wrappingWidth / 3)) * 3;
             using (var img = new Image<Rgba32>(size, size))
             {
                 img.Mutate(x => x.Fill(Color.White));
@@ -28,6 +30,7 @@ namespace DrawWithImageSharp
                         Draw(img, font, v, h, wrappingWidth);
                     }
                 }
+
                 img.Save("Output/AlignmentWrapped.png");
             }
         }
@@ -49,6 +52,7 @@ namespace DrawWithImageSharp
                 default:
                     break;
             }
+
             switch (horiz)
             {
                 case HorizontalAlignment.Left:

--- a/samples/DrawWithImageSharp/TextBuilder/BaseGlyphBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/BaseGlyphBuilder.cs
@@ -1,10 +1,12 @@
-using System.Collections.Generic;
-using System.Numerics;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
 
-using SixLabors.Fonts;
+using System.Collections.Generic;
 using System.Linq;
-using SixLabors.ImageSharp.Drawing;
+using System.Numerics;
+using SixLabors.Fonts;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.Shapes.Temp
@@ -18,20 +20,20 @@ namespace SixLabors.Shapes.Temp
         private readonly List<FontRectangle> glyphBounds = new List<FontRectangle>();
         private readonly List<IPath> paths = new List<IPath>();
         private readonly List<Color?> colors = new List<Color?>();
-        private Vector2 currentPoint = default(Vector2);
+        private Vector2 currentPoint = default;
         private Color? currentColor = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GlyphBuilder"/> class.
         /// </summary>
         public BaseGlyphBuilder()
-        {
-            // glyphs are renderd realative to bottom left so invert the Y axis to allow it to render on top left origin surface
-            this.builder = new PathBuilder();
-        }
+
+           // glyphs are renderd relative to bottom left so invert
+           // the Y axis to allow it to render on top left origin surface
+           => this.builder = new PathBuilder();
 
         /// <summary>
-        /// Get the colors for each path, where null means use user provided brush
+        /// Gets the colors for each path, where null means use user provided brush
         /// </summary>
         public IEnumerable<Color?> PathColors => this.colors;
 
@@ -64,11 +66,7 @@ namespace SixLabors.Shapes.Temp
         {
         }
 
-        /// <summary>
-        /// Begins the glyph.
-        /// </summary>
-        /// <param name="location">The offset that the glyph will be rendered at.</param>
-        /// <param name="size">The size.</param>
+        /// <inheritdoc/>
         bool IGlyphRenderer.BeginGlyph(FontRectangle rect, GlyphRendererParameters cachKey)
         {
             this.currentColor = null;
@@ -90,10 +88,7 @@ namespace SixLabors.Shapes.Temp
         /// <summary>
         /// Begins the figure.
         /// </summary>
-        void IGlyphRenderer.BeginFigure()
-        {
-            this.builder.StartFigure();
-        }
+        void IGlyphRenderer.BeginFigure() => this.builder.StartFigure();
 
         /// <summary>
         /// Draws a cubic bezier from the current point  to the <paramref name="point"/>
@@ -117,17 +112,13 @@ namespace SixLabors.Shapes.Temp
         }
 
         void IColorGlyphRenderer.SetColor(GlyphColor color)
-        {
-            this.currentColor = new Color(new Rgba32(color.Red, color.Green, color.Blue, color.Alpha));
-        }
+            => this.currentColor = new Color(new Rgba32(color.Red, color.Green, color.Blue, color.Alpha));
 
         /// <summary>
         /// Ends the figure.
         /// </summary>
         void IGlyphRenderer.EndFigure()
-        {
-            this.builder.CloseFigure();
-        }
+            => this.builder.CloseFigure();
 
         /// <summary>
         /// Draws a line from the current point  to the <paramref name="point"/>.
@@ -153,15 +144,15 @@ namespace SixLabors.Shapes.Temp
         /// Draws a quadratics bezier from the current point  to the <paramref name="point"/>
         /// </summary>
         /// <param name="secondControlPoint">The second control point.</param>
-        /// <param name="point">The point.</param>
+        /// <param name="endPoint">The point.</param>
         void IGlyphRenderer.QuadraticBezierTo(Vector2 secondControlPoint, Vector2 endPoint)
         {
             Vector2 startPointVector = this.currentPoint;
             Vector2 controlPointVector = secondControlPoint;
             Vector2 endPointVector = endPoint;
 
-            Vector2 c1 = (((controlPointVector - startPointVector) * 2) / 3) + startPointVector;
-            Vector2 c2 = (((controlPointVector - endPointVector) * 2) / 3) + endPointVector;
+            Vector2 c1 = ((controlPointVector - startPointVector) * 2 / 3) + startPointVector;
+            Vector2 c2 = ((controlPointVector - endPointVector) * 2 / 3) + endPointVector;
 
             this.builder.AddBezier(startPointVector, c1, c2, endPoint);
             this.currentPoint = endPoint;

--- a/samples/DrawWithImageSharp/TextBuilder/GlyphBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/GlyphBuilder.cs
@@ -1,4 +1,7 @@
-﻿using System.Numerics;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Numerics;
 
 namespace SixLabors.Shapes.Temp
 {
@@ -21,8 +24,6 @@ namespace SixLabors.Shapes.Temp
         /// <param name="origin">The origin.</param>
         public GlyphBuilder(Vector2 origin)
             : base()
-        {
-            this.builder.SetOrigin(origin);
-        }
+            => this.builder.SetOrigin(origin);
     }
 }

--- a/samples/DrawWithImageSharp/TextBuilder/PathGlyphBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/PathGlyphBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Numerics;
 using SixLabors.Fonts;
@@ -11,11 +14,8 @@ namespace SixLabors.Shapes.Temp
     internal class PathGlyphBuilder : GlyphBuilder
     {
         private readonly IPath path;
-
         private float offsetY = 0;
-
-        const float Pi = (float)Math.PI;
-        const float HalfPi = Pi / 2f;
+        private const float Pi = MathF.PI;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GlyphBuilder"/> class.
@@ -23,14 +23,10 @@ namespace SixLabors.Shapes.Temp
         /// <param name="path">The path to render the glyps along.</param>
         public PathGlyphBuilder(IPath path)
             : base()
-        {
-            this.path = path;
-        }
+            => this.path = path;
 
         protected override void BeginText(FontRectangle rect)
-        {
-            this.offsetY = rect.Height;
-        }
+            => this.offsetY = rect.Height;
 
         protected override void BeginGlyph(FontRectangle rect)
         {

--- a/samples/DrawWithImageSharp/TextBuilder/TextBuilder.cs
+++ b/samples/DrawWithImageSharp/TextBuilder/TextBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Numerics;
 using SixLabors.Fonts;
 using SixLabors.ImageSharp.Drawing;
@@ -15,7 +18,7 @@ namespace SixLabors.Shapes.Temp
         /// <param name="text">The text to generate glyphs for</param>
         /// <param name="location">The location</param>
         /// <param name="style">The style and settings to use while rendering the glyphs</param>
-        /// <returns></returns>
+        /// <returns>The paths, boxes, and text box.</returns>
         public static (IPathCollection paths, IPathCollection boxes, IPath textBox) GenerateGlyphsWithBox(string text, Vector2 location, RendererOptions style)
         {
             var glyphBuilder = new GlyphBuilder(location);
@@ -33,33 +36,27 @@ namespace SixLabors.Shapes.Temp
         /// <param name="text">The text to generate glyphs for</param>
         /// <param name="location">The location</param>
         /// <param name="style">The style and settings to use while rendering the glyphs</param>
-        /// <returns></returns>
+        /// <returns>The <see cref="IPathCollection"/>.</returns>
         public static IPathCollection GenerateGlyphs(string text, Vector2 location, RendererOptions style)
-        {
-            return GenerateGlyphsWithBox(text, location, style).paths;
-        }
+            => GenerateGlyphsWithBox(text, location, style).paths;
 
         /// <summary>
         /// Generates the shapes corresponding the glyphs described by the font and with the setting ing withing the FontSpan
         /// </summary>
         /// <param name="text">The text to generate glyphs for</param>
         /// <param name="style">The style and settings to use while rendering the glyphs</param>
-        /// <returns></returns>
+        /// <returns>The <see cref="IPathCollection"/>.</returns>
         public static IPathCollection GenerateGlyphs(string text, RendererOptions style)
-        {
-            return GenerateGlyphs(text, Vector2.Zero, style);
-        }
+            => GenerateGlyphs(text, Vector2.Zero, style);
 
         /// <summary>
         /// Generates the shapes corresponding the glyphs described by the font and with the setting ing withing the FontSpan
         /// </summary>
         /// <param name="text">The text to generate glyphs for</param>
         /// <param name="style">The style and settings to use while rendering the glyphs</param>
-        /// <returns></returns>
+        /// <returns>The paths, boxes, and text box.</returns>
         public static (IPathCollection paths, IPathCollection boxes, IPath textBox) GenerateGlyphsWithBox(string text, RendererOptions style)
-        {
-            return GenerateGlyphsWithBox(text, Vector2.Zero, style);
-        }
+            => GenerateGlyphsWithBox(text, Vector2.Zero, style);
 
         /// <summary>
         /// Generates the shapes corresponding the glyphs described by the font and with the setting in within the FontSpan along the described path.
@@ -67,7 +64,7 @@ namespace SixLabors.Shapes.Temp
         /// <param name="text">The text to generate glyphs for</param>
         /// <param name="path">The path to draw the text in relation to</param>
         /// <param name="style">The style and settings to use while rendering the glyphs</param>
-        /// <returns></returns>
+        /// <returns>The <see cref="IPathCollection"/>.</returns>
         public static IPathCollection GenerateGlyphs(string text, IPath path, RendererOptions style)
         {
             var glyphBuilder = new PathGlyphBuilder(path);

--- a/samples/Fonts.Samples.ruleset
+++ b/samples/Fonts.Samples.ruleset
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Fonts.Samples" ToolsVersion="16.0">
+  <Include Path="..\shared-infrastructure\sixlabors.tests.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0060" Action="None" />
+  </Rules>
+</RuleSet>

--- a/samples/ListFonts/ListFonts.csproj
+++ b/samples/ListFonts/ListFonts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ListFonts/Program.cs
+++ b/samples/ListFonts/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Diagnostics;
 using System.Linq;

--- a/samples/ListFonts/Program.cs
+++ b/samples/ListFonts/Program.cs
@@ -6,9 +6,9 @@ using SixLabors.Fonts;
 
 namespace ListFonts
 {
-    class Program
+    public class Program
     {
-        static void Main(string[] args)
+        public static void Main(string[] args)
         {
             System.Collections.Generic.IEnumerable<FontFamily> families = SystemFonts.Families;
             IOrderedEnumerable<FontFamily> orderd = families.OrderBy(x => x.Name);
@@ -17,15 +17,15 @@ namespace ListFonts
             {
                 Console.Write(f.Name.PadRight(len));
                 Console.Write('\t');
-                Console.Write(string.Join(",", f.AvailableStyles.OrderBy(x=>x).Select(x => x.ToString())));
+                Console.Write(string.Join(",", f.AvailableStyles.OrderBy(x => x).Select(x => x.ToString())));
                 Console.WriteLine();
 
-                var g = f.CreateFont(10).Instance.GetGlyph(1);
+                GlyphInstance g = f.CreateFont(10).Instance.GetGlyph(1);
             }
 
             if (Debugger.IsAttached)
             {
-                Console.WriteLine("");
+                Console.WriteLine(string.Empty);
                 while (!Console.KeyAvailable)
                 {
                     Thread.Sleep(100);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,44 +5,24 @@
     Directory.Build.props is automatically picked up and imported by
     Microsoft.Common.props. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly early and only Sdk.props will have been
+    instead. They import fairly early and only Sdk.props will have been
     imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.props</MSBuildAllProjects>
-    <ImageSharpProjectCategory>src</ImageSharpProjectCategory>
-  </PropertyGroup>
+  <!-- Import the shared src .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\shared-infrastructure\msbuild\props\SixLabors.Src.props" />
 
+  <!-- Import the solution .props file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\shared-infrastructure\SixLabors.ruleset</CodeAnalysisRuleSet>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-
+  <!-- Compilation properties. -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <!--Add deterministic builds in CI-->
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-
   <ItemGroup>
-    <!--TODO: Delete this once tests Stylecop issues are fixed-->
-    <PackageReference Include="StyleCop.Analyzers" IsImplicitlyDefined="true"  />
-
+    <!-- DynamicProxyGenAssembly2 is needed so Moq can use our internals -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
     <InternalsVisibleTo Include="SixLabors.Fonts.Tests" Key="$(SixLaborsPublicKey)"/>
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,6 +16,10 @@
   <!-- Import the solution .props file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Fonts.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
   <!-- Compilation properties. -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,68 +5,15 @@
     Directory.Build.targets is automatically picked up and imported by
     Microsoft.Common.targets. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly late and most other props/targets will have
+    instead. They import fairly late and most other props/targets will have
     been imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.targets</MSBuildAllProjects>
-  </PropertyGroup>
+  <!-- Import the shared src .targets file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\shared-infrastructure\msbuild\targets\SixLabors.Src.targets" />
 
+  <!-- Import the solution .targets file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
-
-  <!-- Workaround for running Coverlet with Determenistic builds -->
-  <!-- https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/DeterministicBuild.md -->
-  <Target Name="CoverletGetPathMap"
-            DependsOnTargets="InitializeSourceRootMappedPaths"
-            Returns="@(_LocalTopLevelSourceRoot)"
-            Condition="'$(DeterministicSourcePaths)' == 'true'">
-    <ItemGroup>
-      <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
-    </ItemGroup>
-  </Target>
-
-  <PropertyGroup>
-    <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
-  </PropertyGroup>
-
-  <ItemDefinitionGroup>
-    <InternalsVisibleTo>
-      <Visible>false</Visible>
-    </InternalsVisibleTo>
-  </ItemDefinitionGroup>
-
-  <Target Name="GenerateInternalsVisibleTo"
-          BeforeTargets="CoreCompile"
-          DependsOnTargets="PrepareForBuild;CoreGenerateInternalsVisibleTo"
-          Condition="'@(InternalsVisibleTo)' != ''" />
-
-  <Target Name="CoreGenerateInternalsVisibleTo"
-          Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'"
-          Inputs="$(MSBuildAllProjects)"
-          Outputs="$(GeneratedInternalsVisibleToFile)">
-    <CreateItem
-      Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
-      AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity)"
-      Condition="'%(InternalsVisibleTo.Key)' == ''">
-      <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
-    </CreateItem>
-    <CreateItem
-      Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
-      AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.Key)"
-      Condition="'%(InternalsVisibleTo.Key)' != ''">
-      <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
-    </CreateItem>
-
-    <WriteCodeFragment AssemblyAttributes="@(InternalsVisibleToAttribute)" Language="$(Language)" OutputFile="$(GeneratedInternalsVisibleToFile)">
-      <Output TaskParameter="OutputFile" ItemName="Compile" />
-      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
-    </WriteCodeFragment>
-  </Target>
-
-  <!-- Empty target so that `dotnet test` will work on the solution -->
-  <!-- https://github.com/Microsoft/vstest/issues/411 -->
-  <Target Name="VSTest" />
 
 </Project>

--- a/src/Fonts.ruleset
+++ b/src/Fonts.ruleset
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Fonts" ToolsVersion="16.0">
+  <Include Path="..\shared-infrastructure\sixlabors.ruleset" Action="Default" />
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1011" Action="Info" />
+  </Rules>
+</RuleSet>

--- a/src/SixLabors.Fonts/AppliedFontStyle.cs
+++ b/src/SixLabors.Fonts/AppliedFontStyle.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.Numerics;
 
 namespace SixLabors.Fonts
@@ -22,9 +21,9 @@ namespace SixLabors.Fonts
             GlyphInstance glyph = this.MainFont.GetGlyph(codePoint);
             if (glyph.GlyphType == GlyphType.Fallback)
             {
-                foreach (var f in this.FallbackFonts)
+                foreach (IFontInstance? f in this.FallbackFonts)
                 {
-                    var g = f.GetGlyph(codePoint);
+                    GlyphInstance? g = f.GetGlyph(codePoint);
                     if (g.GlyphType != GlyphType.Fallback)
                     {
                         glyph = g;
@@ -40,7 +39,7 @@ namespace SixLabors.Fonts
 
             if (colorFontOptions == ColorFontSupport.MicrosoftColrFormat)
             {
-                if (glyph.Font.TryGetColoredVectors(glyph.Index, out var layers))
+                if (glyph.Font.TryGetColoredVectors(glyph.Index, out GlyphInstance[]? layers))
                 {
                     return layers;
                 }

--- a/src/SixLabors.Fonts/Exceptions/FontException.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontException.cs
@@ -8,7 +8,7 @@ namespace SixLabors.Fonts.Exceptions
     /// <summary>
     /// Base class for exceptions thrown by this library.
     /// </summary>
-    /// <seealso cref="System.Exception" />
+    /// <seealso cref="Exception" />
     public class FontException : Exception
     {
         /// <summary>

--- a/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
@@ -15,9 +15,7 @@ namespace SixLabors.Fonts.Exceptions
         /// <param name="family">The name of the missing font family.</param>
         public FontFamilyNotFoundException(string family)
             : base($"{family} could not be found")
-        {
-            this.FontFamily = family;
-        }
+            => this.FontFamily = family;
 
         /// <summary>
         /// Gets the name of the font familiy we failed to find.

--- a/src/SixLabors.Fonts/Exceptions/FontsThrowHelper.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontsThrowHelper.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace SixLabors.Fonts.Exceptions
@@ -16,8 +15,6 @@ namespace SixLabors.Fonts.Exceptions
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static T ThrowGlyphMissingException<T>(int codePoint)
-        {
-            throw new GlyphMissingException(codePoint);
-        }
+            => throw new GlyphMissingException(codePoint);
     }
 }

--- a/src/SixLabors.Fonts/Exceptions/GlyphMissingException.cs
+++ b/src/SixLabors.Fonts/Exceptions/GlyphMissingException.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-
 namespace SixLabors.Fonts.Exceptions
 {
     /// <summary>

--- a/src/SixLabors.Fonts/Exceptions/InvalidFontFileException.cs
+++ b/src/SixLabors.Fonts/Exceptions/InvalidFontFileException.cs
@@ -8,7 +8,7 @@ namespace SixLabors.Fonts.Exceptions
     /// <summary>
     /// Exception font loading can throw if it encounteres invalid data during font loading.
     /// </summary>
-    /// <seealso cref="System.Exception" />
+    /// <seealso cref="Exception" />
     public class InvalidFontFileException : Exception
     {
         /// <summary>

--- a/src/SixLabors.Fonts/Exceptions/InvalidFontTableException.cs
+++ b/src/SixLabors.Fonts/Exceptions/InvalidFontTableException.cs
@@ -1,12 +1,14 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
+
+using System;
 
 namespace SixLabors.Fonts.Exceptions
 {
     /// <summary>
     /// Exception font loading can throw if it encounteres invalid data during font loading.
     /// </summary>
-    /// <seealso cref="System.Exception" />
+    /// <seealso cref="Exception" />
     public class InvalidFontTableException : InvalidFontFileException
     {
         /// <summary>
@@ -16,9 +18,7 @@ namespace SixLabors.Fonts.Exceptions
         /// <param name="table">The table.</param>
         public InvalidFontTableException(string message, string table)
             : base(message)
-        {
-            this.Table = table;
-        }
+            => this.Table = table;
 
         /// <summary>
         /// Gets the table where the error originated.

--- a/src/SixLabors.Fonts/Exceptions/MissingFontTableException.cs
+++ b/src/SixLabors.Fonts/Exceptions/MissingFontTableException.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
+
 namespace SixLabors.Fonts.Exceptions
 {
     /// <summary>
     /// Exception font loading can throw if it finds a required table is missing during font loading.
     /// </summary>
-    /// <seealso cref="System.Exception" />
+    /// <seealso cref="Exception" />
     public class MissingFontTableException : InvalidFontFileException
     {
         /// <summary>
@@ -16,9 +18,7 @@ namespace SixLabors.Fonts.Exceptions
         /// <param name="table">The table.</param>
         public MissingFontTableException(string message, string table)
             : base(message)
-        {
-            this.Table = table;
-        }
+            => this.Table = table;
 
         /// <summary>
         /// Gets the table where the error originated.

--- a/src/SixLabors.Fonts/FontInstance.cs
+++ b/src/SixLabors.Fonts/FontInstance.cs
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
 using System.Numerics;
 using SixLabors.Fonts.Tables;
 using SixLabors.Fonts.Tables.General;
+using SixLabors.Fonts.Tables.General.Colr;
 using SixLabors.Fonts.Tables.General.Glyphs;
 
 namespace SixLabors.Fonts
@@ -101,9 +100,7 @@ namespace SixLabors.Fonts
         public FontDescription Description { get; }
 
         internal bool TryGetGlyphIndex(int codePoint, out ushort glyphId)
-        {
-            return this.cmap.TryGetGlyphId(codePoint, out glyphId);
-        }
+            => this.cmap.TryGetGlyphId(codePoint, out glyphId);
 
         /// <summary>
         /// Gets the glyph.
@@ -112,7 +109,7 @@ namespace SixLabors.Fonts
         /// <returns>the glyph for a known character.</returns>
         GlyphInstance IFontInstance.GetGlyph(int codePoint)
         {
-            var foundGlyph = this.TryGetGlyphIndex(codePoint, out var idx);
+            bool foundGlyph = this.TryGetGlyphIndex(codePoint, out ushort idx);
             if (!foundGlyph)
             {
                 idx = 0;
@@ -155,19 +152,19 @@ namespace SixLabors.Fonts
             vectors = this.colorGlyphCache[idx];
             if (vectors is null)
             {
-                var indexes = this.colrTable.GetLayers(idx);
+                Span<LayerRecord> indexes = this.colrTable.GetLayers(idx);
                 if (indexes.Length > 0)
                 {
                     vectors = new GlyphInstance[indexes.Length];
-                    for (var i = 0; i < indexes.Length; i++)
+                    for (int i = 0; i < indexes.Length; i++)
                     {
-                        var layer = indexes[i];
+                        LayerRecord? layer = indexes[i];
 
                         vectors[i] = this.CreateInstance(layer.GlyphId, GlyphType.ColrLayer, layer.PalletteIndex);
                     }
                 }
 
-                vectors = vectors ?? Array.Empty<GlyphInstance>();
+                vectors ??= Array.Empty<GlyphInstance>();
                 this.colorGlyphCache[idx] = vectors;
             }
 

--- a/src/SixLabors.Fonts/FontReader.cs
+++ b/src/SixLabors.Fonts/FontReader.cs
@@ -142,11 +142,9 @@ namespace SixLabors.Fonts
         }
 
         public TableHeader? GetHeader(string tag)
-        {
-            return this.Headers.TryGetValue(tag, out TableHeader header)
+            => this.Headers.TryGetValue(tag, out TableHeader header)
                 ? header
                 : null;
-        }
 
         public BinaryReader GetReaderAtTablePosition(string tableName)
         {

--- a/src/SixLabors.Fonts/FontRectangle.cs
+++ b/src/SixLabors.Fonts/FontRectangle.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace SixLabors.Fonts
 {
@@ -261,9 +259,7 @@ namespace SixLabors.Fonts
         /// <returns>New <see cref="FontRectangle"/> representing the intersections between the two rectrangles.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FontRectangle Intersect(FontRectangle rectangle)
-        {
-            return Intersect(rectangle, this);
-        }
+            => Intersect(rectangle, this);
 
         /// <summary>
         /// Inflates this <see cref="FontRectangle"/> by the specified amount.
@@ -273,13 +269,11 @@ namespace SixLabors.Fonts
         /// <returns>New <see cref="FontRectangle"/> representing the inflated rectrangle</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FontRectangle Inflate(float width, float height)
-        {
-            return new FontRectangle(
+            => new FontRectangle(
                 this.X - width,
                 this.Y - height,
                 this.Width + (2 * width),
                 this.Height + (2 * height));
-        }
 
         /// <summary>
         /// Inflates this <see cref="FontRectangle"/> by the specified amount.
@@ -345,31 +339,27 @@ namespace SixLabors.Fonts
         /// <returns>New <see cref="FontRectangle"/> representing the inflated rectrangle.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FontRectangle Offset(float dx, float dy)
-        {
-            return new FontRectangle(this.X + dx, this.Y + dy, this.Width, this.Height);
-        }
+            => new FontRectangle(this.X + dx, this.Y + dy, this.Width, this.Height);
 
         /// <inheritdoc/>
         public override int GetHashCode()
-        {
-            return HashCode.Combine(this.X, this.Y, this.Width, this.Height);
-        }
+            => HashCode.Combine(this.X, this.Y, this.Width, this.Height);
 
         /// <inheritdoc/>
         public override string ToString()
-        {
-            return $"FontRectangle [ X={this.X}, Y={this.Y}, Width={this.Width}, Height={this.Height} ]";
-        }
+            => $"FontRectangle [ X={this.X}, Y={this.Y}, Width={this.Width}, Height={this.Height} ]";
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is FontRectangle other && this.Equals(other);
+        public override bool Equals(object obj)
+            => obj is FontRectangle other
+            && this.Equals(other);
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(FontRectangle other) =>
-            this.X.Equals(other.X) &&
-            this.Y.Equals(other.Y) &&
-            this.Width.Equals(other.Width) &&
-            this.Height.Equals(other.Height);
+        public bool Equals(FontRectangle other)
+            => this.X.Equals(other.X)
+            && this.Y.Equals(other.Y)
+            && this.Width.Equals(other.Width)
+            && this.Height.Equals(other.Height);
     }
 }

--- a/src/SixLabors.Fonts/GlobalSuppressions.cs
+++ b/src/SixLabors.Fonts/GlobalSuppressions.cs
@@ -1,8 +1,0 @@
-// Copyright (c) Six Labors.
-// Licensed under the Apache License, Version 2.0.
-
-// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1011:Closing square brackets should be spaced correctly", Justification = "style cop not liking nullable arrays", Scope = "type", Target = "~T:SixLabors.Fonts.IO.ZlibInflateStream")]

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -10,12 +10,11 @@ namespace SixLabors.Fonts
     /// </summary>
     public readonly struct Glyph
     {
-        private readonly GlyphInstance instance;
         private readonly float pointSize;
 
         internal Glyph(GlyphInstance instance, float pointSize)
         {
-            this.instance = instance;
+            this.Instance = instance;
             this.pointSize = pointSize;
         }
 
@@ -25,7 +24,7 @@ namespace SixLabors.Fonts
         /// <value>
         /// The glyph instance.
         /// </value>
-        public GlyphInstance Instance => this.instance;
+        public GlyphInstance Instance { get; }
 
         /// <summary>
         /// Calculates the bounding box
@@ -34,9 +33,7 @@ namespace SixLabors.Fonts
         /// <param name="dpi">dpi to calualtes in relation to</param>
         /// <returns>The bounding box</returns>
         public FontRectangle BoundingBox(Vector2 location, Vector2 dpi)
-        {
-            return this.instance.BoundingBox(location, this.pointSize * dpi);
-        }
+            => this.Instance.BoundingBox(location, this.pointSize * dpi);
 
         /// <summary>
         /// Renders to.
@@ -46,9 +43,7 @@ namespace SixLabors.Fonts
         /// <param name="dpi">The dpi.</param>
         /// <param name="lineHeight">The line height.</param>
         internal void RenderTo(IGlyphRenderer surface, Vector2 location, float dpi, float lineHeight)
-        {
-            this.RenderTo(surface, location, dpi, dpi, lineHeight);
-        }
+            => this.RenderTo(surface, location, dpi, dpi, lineHeight);
 
         /// <summary>
         /// Renders the glyph to the render surface in font units relative to a bottom left origin at (0,0)
@@ -60,8 +55,6 @@ namespace SixLabors.Fonts
         /// <param name="lineHeight">The line height.</param>
         /// <exception cref="System.NotSupportedException">Too many control points</exception>
         internal void RenderTo(IGlyphRenderer surface, Vector2 location, float dpiX, float dpiY, float lineHeight)
-        {
-            this.instance.RenderTo(surface, this.pointSize, location, new Vector2(dpiX, dpiY), lineHeight);
-        }
+            => this.Instance.RenderTo(surface, this.pointSize, location, new Vector2(dpiX, dpiY), lineHeight);
     }
 }

--- a/src/SixLabors.Fonts/GlyphInstance.cs
+++ b/src/SixLabors.Fonts/GlyphInstance.cs
@@ -138,7 +138,7 @@ namespace SixLabors.Fonts
         /// <exception cref="NotSupportedException">Too many control points</exception>
         public void RenderTo(IGlyphRenderer surface, float pointSize, Vector2 location, Vector2 dpi, float lineHeight)
         {
-            location = location * dpi;
+            location *= dpi;
 
             Vector2 firstPoint = Vector2.Zero;
 

--- a/src/SixLabors.Fonts/GlyphMetric.cs
+++ b/src/SixLabors.Fonts/GlyphMetric.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-
 namespace SixLabors.Fonts
 {
     /// <summary>
@@ -46,8 +44,6 @@ namespace SixLabors.Fonts
 
         /// <inheritdoc/>
         public override string ToString()
-        {
-            return $"Character: {this.Character}, bounds: {this.Bounds}, is control char: {this.IsControlCharacter}";
-        }
+            => $"Character: {this.Character}, bounds: {this.Bounds}, is control char: {this.IsControlCharacter}";
     }
 }

--- a/src/SixLabors.Fonts/GlyphRendererParameters.cs
+++ b/src/SixLabors.Fonts/GlyphRendererParameters.cs
@@ -21,7 +21,7 @@ namespace SixLabors.Fonts
             this.DpiX = dpi.X;
             this.DpiY = dpi.Y;
             this.GlyphType = glyph.GlyphType;
-            this.GlyphColor = glyph.GlyphColor ?? default(GlyphColor);
+            this.GlyphColor = glyph.GlyphColor ?? default;
         }
 
         /// <summary>
@@ -96,25 +96,22 @@ namespace SixLabors.Fonts
 
         /// <inheritdoc/>
         public bool Equals(GlyphRendererParameters other)
-        {
-            return other.PointSize == this.PointSize
-                && other.FontStyle == this.FontStyle
-                && other.DpiX == this.DpiX
-                && other.DpiY == this.DpiY
-                && other.GlyphIndex == this.GlyphIndex
-                && other.GlyphType == this.GlyphType
-                && other.GlyphColor.Equals(this.GlyphColor)
-                && ((other.Font is null && this.Font is null)
-                || (other.Font?.Equals(this.Font, StringComparison.OrdinalIgnoreCase) == true));
-        }
+            => other.PointSize == this.PointSize
+            && other.FontStyle == this.FontStyle
+            && other.DpiX == this.DpiX
+            && other.DpiY == this.DpiY
+            && other.GlyphIndex == this.GlyphIndex
+            && other.GlyphType == this.GlyphType
+            && other.GlyphColor.Equals(this.GlyphColor)
+            && ((other.Font is null && this.Font is null)
+            || (other.Font?.Equals(this.Font, StringComparison.OrdinalIgnoreCase) == true));
 
         /// <inheritdoc/>
         public override bool Equals(object obj) => obj is GlyphRendererParameters p && this.Equals(p);
 
         /// <inheritdoc/>
         public override int GetHashCode()
-        {
-            return HashCode.Combine(
+            => HashCode.Combine(
                 this.Font,
                 this.PointSize,
                 this.GlyphIndex,
@@ -123,6 +120,5 @@ namespace SixLabors.Fonts
                 this.FontStyle,
                 this.DpiX,
                 this.DpiY);
-        }
     }
 }

--- a/src/SixLabors.Fonts/HorizontalAlignment.cs
+++ b/src/SixLabors.Fonts/HorizontalAlignment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts

--- a/src/SixLabors.Fonts/IColorGlyphRenderer.cs
+++ b/src/SixLabors.Fonts/IColorGlyphRenderer.cs
@@ -93,21 +93,17 @@ namespace SixLabors.Fonts
         /// True if the current color is equal to the <paramref name="other"/> parameter; otherwise, false.
         /// </returns>
         public bool Equals(GlyphColor other)
-        {
-            return other.Red == this.Red
-                && other.Green == this.Green
-                && other.Blue == this.Blue
-                && other.Alpha == this.Alpha;
-        }
+            => other.Red == this.Red
+            && other.Green == this.Green
+            && other.Blue == this.Blue
+            && other.Alpha == this.Alpha;
 
         /// <inheritdoc/>
         public override int GetHashCode()
-        {
-            return HashCode.Combine(
+            => HashCode.Combine(
                 this.Red,
                 this.Green,
                 this.Blue,
                 this.Alpha);
-        }
     }
 }

--- a/src/SixLabors.Fonts/IFontCollection.cs
+++ b/src/SixLabors.Fonts/IFontCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
@@ -8,7 +8,7 @@ namespace SixLabors.Fonts
     /// <summary>
     /// A readable and writable collection of fonts.
     /// </summary>
-    /// <seealso cref="SixLabors.Fonts.IReadOnlyFontCollection" />
+    /// <seealso cref="IReadOnlyFontCollection" />
     public interface IFontCollection : IReadOnlyFontCollection
     {
         /// <summary>

--- a/src/SixLabors.Fonts/IGlyphRendererExtensions.cs
+++ b/src/SixLabors.Fonts/IGlyphRendererExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;

--- a/src/SixLabors.Fonts/IO/ZlibInflateStream.cs
+++ b/src/SixLabors.Fonts/IO/ZlibInflateStream.cs
@@ -112,27 +112,17 @@ namespace SixLabors.Fonts.IO
         /// <inheritdoc/>
         public override long Position
         {
-            get
-            {
-                return this.position;
-            }
+            get => this.position;
 
-            set
-            {
-                throw new NotSupportedException();
-            }
+            set => throw new NotSupportedException();
         }
 
         /// <inheritdoc/>
         public override void Flush()
-        {
-            this.deflateStream?.Flush();
-        }
+            => this.deflateStream?.Flush();
 
         public override int ReadByte()
-        {
-            return base.ReadByte();
-        }
+            => base.ReadByte();
 
         /// <inheritdoc/>
         public override int Read(byte[] buffer, int offset, int count)
@@ -165,7 +155,7 @@ namespace SixLabors.Fonts.IO
             if (origin == SeekOrigin.Begin)
             {
                 origin = SeekOrigin.Current;
-                offset = offset - this.position;
+                offset -= this.position;
             }
 
             if (origin == SeekOrigin.Current && offset >= 0)
@@ -184,15 +174,11 @@ namespace SixLabors.Fonts.IO
 
         /// <inheritdoc/>
         public override void SetLength(long value)
-        {
-            throw new NotSupportedException();
-        }
+            => throw new NotSupportedException();
 
         /// <inheritdoc/>
         public override void Write(byte[] buffer, int offset, int count)
-        {
-            throw new NotSupportedException();
-        }
+            => throw new NotSupportedException();
 
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)

--- a/src/SixLabors.Fonts/IReadonlyFontCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontCollectionExtensions.cs
@@ -19,9 +19,7 @@ namespace SixLabors.Fonts
         /// <param name="style">The style.</param>
         /// <returns>The font for the representing the configured options.</returns>
         public static Font CreateFont(this IReadOnlyFontCollection collection, string fontFamily, float size, FontStyle style)
-        {
-            return new Font(collection.Find(fontFamily), size, style);
-        }
+            => new Font(collection.Find(fontFamily), size, style);
 
         /// <summary>
         /// Create a new instance of the <see cref="Font"/> for the named font family with regular styling.
@@ -31,9 +29,7 @@ namespace SixLabors.Fonts
         /// <param name="size">The size.</param>
         /// <returns>The font for the representing the configured options.</returns>
         public static Font CreateFont(this IReadOnlyFontCollection collection, string fontFamily, float size)
-        {
-            return new Font(collection.Find(fontFamily), size);
-        }
+            => new Font(collection.Find(fontFamily), size);
 
 #if SUPPORTS_CULTUREINFO_LCID
         /// <summary>
@@ -46,9 +42,7 @@ namespace SixLabors.Fonts
         /// <param name="style">The style.</param>
         /// <returns>The font for the representing the configured options.</returns>
         public static Font CreateFont(this IReadOnlyFontCollection collection, string fontFamily, CultureInfo culture, float size, FontStyle style)
-        {
-            return new Font(collection.Find(fontFamily, culture), size, style);
-        }
+            => new Font(collection.Find(fontFamily, culture), size, style);
 
         /// <summary>
         /// Create a new instance of the <see cref="Font"/> for the named font family with regular styling.
@@ -59,9 +53,7 @@ namespace SixLabors.Fonts
         /// <param name="size">The size.</param>
         /// <returns>The font for the representing the configured options.</returns>
         public static Font CreateFont(this IReadOnlyFontCollection collection, string fontFamily, CultureInfo culture, float size)
-        {
-            return new Font(collection.Find(fontFamily, culture), size);
-        }
+            => new Font(collection.Find(fontFamily, culture), size);
 #endif
     }
 }

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\shared-infrastructure\branding\icons\imagesharp.drawing\sixlabors.fonts.128.png" Pack="true" PackagePath="" />
+    <None Include="..\..\shared-infrastructure\branding\icons\fonts\sixlabors.fonts.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -1,32 +1,36 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>SixLabors.Fonts</AssemblyName>
     <AssemblyTitle>SixLabors.Fonts</AssemblyTitle>
-    <Description>A cross-platform library for loading and laying out fonts for processing and measuring; written in C#</Description>
-    <NeutralLanguage>en</NeutralLanguage>
-
-    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <RootNamespace>SixLabors.Fonts</RootNamespace>
     <PackageId>SixLabors.Fonts</PackageId>
+    <PackageIcon>sixlabors.fonts.128.png</PackageIcon>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <RepositoryUrl Condition="'$(RepositoryUrl)' == ''">https://github.com/SixLabors/Fonts/</RepositoryUrl>
+    <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageTags>font;truetype;opentype;woff</PackageTags>
-    <LangVersion>8.0</LangVersion>
+    <Description>A cross-platform library for loading and laying out fonts for processing and measuring; written in C#</Description>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
-    <PackageReference Include="System.Numerics.Vectors" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.1' ">
-    <PackageReference Include="System.Buffers" />
-    <PackageReference Include="System.Memory" />
+  <ItemGroup>
+    <None Include="..\..\shared-infrastructure\branding\icons\imagesharp.drawing\sixlabors.fonts.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub"/>
-    <PackageReference Include="MinVer" PrivateAssets="All" />
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+    <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.1' ">
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -29,8 +29,8 @@
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.1' ">
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -20,7 +20,8 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Gets the default set of locations we probe for System Fonts.
         /// </summary>
-        private static IReadOnlyCollection<string> standardFontLocations = new[]
+        private static readonly IReadOnlyCollection<string> StandardFontLocations
+            = new[]
             {
                 // windows directories
                 "%SYSTEMROOT%\\Fonts",
@@ -39,7 +40,7 @@ namespace SixLabors.Fonts
             };
 
         public SystemFontCollection()
-            : this(standardFontLocations)
+            : this(StandardFontLocations)
         {
         }
 

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -14,7 +14,7 @@ namespace SixLabors.Fonts
     /// </summary>
     public static class SystemFonts
     {
-        private static Lazy<IReadOnlyFontCollection> lazySystemFonts = new Lazy<IReadOnlyFontCollection>(() => new SystemFontCollection());
+        private static readonly Lazy<IReadOnlyFontCollection> LazySystemFonts = new Lazy<IReadOnlyFontCollection>(() => new SystemFontCollection());
 
         /// <summary>
         /// Gets the collection containing the globaly installled system fonts.
@@ -22,7 +22,7 @@ namespace SixLabors.Fonts
         /// <value>
         /// The system fonts.
         /// </value>
-        public static IReadOnlyFontCollection Collection => lazySystemFonts.Value;
+        public static IReadOnlyFontCollection Collection => LazySystemFonts.Value;
 
         /// <summary>
         /// Gets the collection of <see cref="FontFamily"/>s installed on current system.

--- a/src/SixLabors.Fonts/Tables/General/CMap/EncodingRecord.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/EncodingRecord.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Fonts.WellKnownIds;

--- a/src/SixLabors.Fonts/Tables/General/ColrTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/ColrTable.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Linq;
 using SixLabors.Fonts.Tables.General.Colr;
-using SixLabors.Fonts.Tables.General.Glyphs;
 
 namespace SixLabors.Fonts.Tables.General
 {

--- a/src/SixLabors.Fonts/Tables/General/CpalTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CpalTable.cs
@@ -1,11 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-using System.Linq;
-using SixLabors.Fonts.Tables.General.Colr;
-using SixLabors.Fonts.Tables.General.Glyphs;
-
 namespace SixLabors.Fonts.Tables.General
 {
     [TableName(TableName)]
@@ -22,13 +17,11 @@ namespace SixLabors.Fonts.Tables.General
         }
 
         public GlyphColor GetGlyphColor(int palletteIndex, int palletteEntryIndex)
-        {
-            return this.palletteEntries[this.palletteOffsets[palletteIndex] + palletteEntryIndex];
-        }
+            => this.palletteEntries[this.palletteOffsets[palletteIndex] + palletteEntryIndex];
 
         public static CpalTable? Load(FontReader reader)
         {
-            using (var binaryReader = reader.TryGetReaderAtTablePosition(TableName))
+            using (BinaryReader? binaryReader = reader.TryGetReaderAtTablePosition(TableName))
             {
                 if (binaryReader == null)
                 {

--- a/src/SixLabors.Fonts/Tables/General/GlyphTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/GlyphTable.cs
@@ -12,16 +12,12 @@ namespace SixLabors.Fonts.Tables.General
         private readonly GlyphLoader[] loaders;
 
         public GlyphTable(GlyphLoader[] glyphLoaders)
-        {
-            this.loaders = glyphLoaders;
-        }
+            => this.loaders = glyphLoaders;
 
         public int GlyphCount => this.loaders.Length;
 
         internal virtual GlyphVector GetGlyph(int index)
-        {
-            return this.loaders[index].CreateGlyph(this);
-        }
+            => this.loaders[index].CreateGlyph(this);
 
         public static GlyphTable Load(FontReader reader)
         {

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/EmptyGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/EmptyGlyphLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
@@ -12,9 +12,7 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
         private GlyphVector? glyph;
 
         public EmptyGlyphLoader(Bounds fallbackEmptyBounds)
-        {
-            this.fallbackEmptyBounds = fallbackEmptyBounds;
-        }
+            => this.fallbackEmptyBounds = fallbackEmptyBounds;
 
         public override GlyphVector CreateGlyph(GlyphTable table)
         {

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/SimpleGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/SimpleGlyphLoader.cs
@@ -44,10 +44,9 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
         }
 
         public override GlyphVector CreateGlyph(GlyphTable table)
-        {
+
             // lets build some shapes ??? here from
-            return new GlyphVector(Convert(this.xs, this.ys), this.onCurves, this.endPoints, this.bounds);
-        }
+            => new GlyphVector(Convert(this.xs, this.ys), this.onCurves, this.endPoints, this.bounds);
 
         private static Vector2[] Convert(short[] xs, short[] ys)
         {

--- a/src/SixLabors.Fonts/Tables/General/HeadTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/HeadTable.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-
 using SixLabors.Fonts.Exceptions;
 
 namespace SixLabors.Fonts.Tables.General
@@ -179,7 +178,7 @@ namespace SixLabors.Fonts.Tables.General
             {
                 // Clear upper 32 bits, some fonts seem to have a non-zero upper 32 bits, like "C:\\Windows/Fonts\\cityb___.ttf"
                 // The max date for UInt32.MaxValue seconds is {06/02/2040 06:28:15}, which should be plenty for the time being.
-                seconds = seconds & 0x00000000ffffffff;
+                seconds &= 0x00000000ffffffff;
                 created = startDate.AddSeconds(seconds);
             }
 
@@ -189,7 +188,7 @@ namespace SixLabors.Fonts.Tables.General
             {
                 // Clear upper 32 bits, some fonts seem to have a non-zero upper 32 bits, like "C:\\Windows/Fonts\\cityb___.ttf"
                 // The max date for UInt32.MaxValue seconds is {06/02/2040 06:28:15}, which should be plenty for the time being.
-                seconds = seconds & 0x00000000ffffffff;
+                seconds &= 0x00000000ffffffff;
                 modified = startDate.AddSeconds(seconds);
             }
 

--- a/src/SixLabors.Fonts/Tables/General/HorizontalMetricsTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/HorizontalMetricsTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Tables.General

--- a/src/SixLabors.Fonts/Tables/General/IndexLocationTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/IndexLocationTable.cs
@@ -11,9 +11,7 @@ namespace SixLabors.Fonts.Tables.General
         private const string TableName = "loca";
 
         public IndexLocationTable(uint[] convertedData)
-        {
-            this.GlyphOffsets = convertedData;
-        }
+            => this.GlyphOffsets = convertedData;
 
         public uint[] GlyphOffsets { get; }
 

--- a/src/SixLabors.Fonts/Tables/General/Kern/Format0SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/Kern/Format0SubTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -11,9 +11,7 @@ namespace SixLabors.Fonts.Tables.General.Kern
 
         public Format0SubTable(KearningPair[] pairs, KerningCoverage coverage)
             : base(coverage)
-        {
-            this.pairs = pairs;
-        }
+            => this.pairs = pairs;
 
         public static Format0SubTable Load(BinaryReader reader, in KerningCoverage coverage)
         {

--- a/src/SixLabors.Fonts/Tables/General/Kern/KearningPair.cs
+++ b/src/SixLabors.Fonts/Tables/General/Kern/KearningPair.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -30,18 +30,15 @@ namespace SixLabors.Fonts.Tables.General.Kern
         }
 
         public static KearningPair Read(BinaryReader reader)
-        {
-            // Type   | Field | Description
-            // -------|-------|-------------------------------
-            // uint16 | left  | The glyph index for the left-hand glyph in the kerning pair.
-            // uint16 | right | The glyph index for the right-hand glyph in the kerning pair.
-            // FWORD  | value | The kerning value for the above pair, in FUnits.If this value is greater than zero, the characters will be moved apart.If this value is less than zero, the character will be moved closer together.
-            return new KearningPair(reader.ReadUInt16(), reader.ReadUInt16(), reader.ReadFWORD());
-        }
+
+             // Type   | Field | Description
+             // -------|-------|-------------------------------
+             // uint16 | left  | The glyph index for the left-hand glyph in the kerning pair.
+             // uint16 | right | The glyph index for the right-hand glyph in the kerning pair.
+             // FWORD  | value | The kerning value for the above pair, in FUnits.If this value is greater than zero, the characters will be moved apart.If this value is less than zero, the character will be moved closer together.
+             => new KearningPair(reader.ReadUInt16(), reader.ReadUInt16(), reader.ReadFWORD());
 
         public int CompareTo(KearningPair other)
-        {
-            return this.Key.CompareTo(other.Key);
-        }
+            => this.Key.CompareTo(other.Key);
     }
 }

--- a/src/SixLabors.Fonts/Tables/General/Kern/KerningSubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/Kern/KerningSubTable.cs
@@ -10,9 +10,7 @@ namespace SixLabors.Fonts.Tables.General.Kern
         private readonly KerningCoverage coverage;
 
         public KerningSubTable(KerningCoverage coverage)
-        {
-            this.coverage = coverage;
-        }
+            => this.coverage = coverage;
 
         public static KerningSubTable? Load(BinaryReader reader)
         {

--- a/src/SixLabors.Fonts/Tables/General/KerningTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/KerningTable.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Numerics;
-
 using SixLabors.Fonts.Tables.General.Kern;
 
 namespace SixLabors.Fonts.Tables.General
@@ -15,9 +14,7 @@ namespace SixLabors.Fonts.Tables.General
         private readonly KerningSubTable[] kerningSubTable;
 
         public KerningTable(KerningSubTable[] kerningSubTable)
-        {
-            this.kerningSubTable = kerningSubTable;
-        }
+            => this.kerningSubTable = kerningSubTable;
 
         public static KerningTable Load(FontReader reader)
         {

--- a/src/SixLabors.Fonts/Tables/General/MaximumProfileTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/MaximumProfileTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Tables.General
@@ -9,9 +9,7 @@ namespace SixLabors.Fonts.Tables.General
         private const string TableName = "maxp";
 
         public MaximumProfileTable(ushort numGlyphs)
-        {
-            this.GlyphCount = numGlyphs;
-        }
+            => this.GlyphCount = numGlyphs;
 
         public MaximumProfileTable(ushort numGlyphs, ushort maxPoints, ushort maxContours, ushort maxCompositePoints, ushort maxCompositeContours, ushort maxZones, ushort maxTwilightPoints, ushort maxStorage, ushort maxFunctionDefs, ushort maxInstructionDefs, ushort maxStackElements, ushort maxSizeOfInstructions, ushort maxComponentElements, ushort maxComponentDepth)
                 : this(numGlyphs)

--- a/src/SixLabors.Fonts/Tables/General/Name/NameRecord.cs
+++ b/src/SixLabors.Fonts/Tables/General/Name/NameRecord.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Text;
-
 using SixLabors.Fonts.Utilities;
 using SixLabors.Fonts.WellKnownIds;
 

--- a/src/SixLabors.Fonts/Tables/General/NameTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/NameTable.cs
@@ -18,9 +18,7 @@ namespace SixLabors.Fonts.Tables.General
         private readonly NameRecord[] names;
 
         internal NameTable(NameRecord[] names, string[] languages)
-        {
-            this.names = names;
-        }
+            => this.names = names;
 
         /// <summary>
         /// Gets the name of the font.
@@ -100,9 +98,7 @@ namespace SixLabors.Fonts.Tables.General
         }
 
         public string GetNameById(CultureInfo culture, ushort nameId)
-        {
-            return this.GetNameById(culture, (NameIds)nameId);
-        }
+            => this.GetNameById(culture, (NameIds)nameId);
 
         public static NameTable Load(FontReader reader)
         {

--- a/src/SixLabors.Fonts/Tables/TableLoader.cs
+++ b/src/SixLabors.Fonts/Tables/TableLoader.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-
 using SixLabors.Fonts.Tables.General;
 
 namespace SixLabors.Fonts.Tables
@@ -80,12 +79,11 @@ namespace SixLabors.Fonts.Tables
         }
 
         internal Table? Load(string tag, FontReader reader)
-        {
-            // loader missing register an unknow type loader and carry on
-            return this.loaders.TryGetValue(tag, out Func<FontReader, Table?> func)
+
+             // loader missing? register an unknown type loader and carry on
+             => this.loaders.TryGetValue(tag, out Func<FontReader, Table?> func)
                 ? func.Invoke(reader)
                 : new UnknownTable(tag);
-        }
 
         internal TTable? Load<TTable>(FontReader reader)
             where TTable : Table

--- a/src/SixLabors.Fonts/Tables/TableNameAttribute.cs
+++ b/src/SixLabors.Fonts/Tables/TableNameAttribute.cs
@@ -8,9 +8,7 @@ namespace SixLabors.Fonts.Tables
     internal sealed class TableNameAttribute : Attribute
     {
         public TableNameAttribute(string name)
-        {
-            this.Name = name;
-        }
+            => this.Name = name;
 
         public string Name { get; }
     }

--- a/src/SixLabors.Fonts/Tables/TtcHeader.cs
+++ b/src/SixLabors.Fonts/Tables/TtcHeader.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace SixLabors.Fonts.Tables
 {
     /// <summary>

--- a/src/SixLabors.Fonts/Tables/UnknownTable.cs
+++ b/src/SixLabors.Fonts/Tables/UnknownTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.Tables
@@ -6,9 +6,7 @@ namespace SixLabors.Fonts.Tables
     internal sealed class UnknownTable : Table
     {
         internal UnknownTable(string name)
-        {
-            this.Name = name;
-        }
+            => this.Name = name;
 
         public string Name { get; }
     }

--- a/src/SixLabors.Fonts/Tables/WoffTableHeader.cs
+++ b/src/SixLabors.Fonts/Tables/WoffTableHeader.cs
@@ -9,9 +9,7 @@ namespace SixLabors.Fonts.Tables
     {
         public WoffTableHeader(string tag, uint offset, uint compressedLength, uint origLength, uint checkSum)
             : base(tag, checkSum, offset, origLength)
-        {
-            this.CompressedLength = compressedLength;
-        }
+            => this.CompressedLength = compressedLength;
 
         public uint CompressedLength { get; }
 

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -103,21 +103,21 @@ namespace SixLabors.Fonts
                     // get the larget lineheight thus far
                     unscaledLineHeight = fontHeight;
                     scale = glyph.Font.EmSize * 72;
-                    lineHeight = (unscaledLineHeight * spanStyle.PointSize) / scale;
+                    lineHeight = unscaledLineHeight * spanStyle.PointSize / scale;
                 }
 
                 if (glyph.Font.Ascender > unscaledLineMaxAscender)
                 {
                     unscaledLineMaxAscender = glyph.Font.Ascender;
                     scale = glyph.Font.EmSize * 72;
-                    lineMaxAscender = (unscaledLineMaxAscender * spanStyle.PointSize) / scale;
+                    lineMaxAscender = unscaledLineMaxAscender * spanStyle.PointSize / scale;
                 }
 
                 if (glyph.Font.Descender > unscaledLineMaxDescender)
                 {
                     unscaledLineMaxDescender = glyph.Font.Descender;
                     scale = glyph.Font.EmSize * 72;
-                    lineMaxDescender = (unscaledLineMaxDescender * spanStyle.PointSize) / scale;
+                    lineMaxDescender = unscaledLineMaxDescender * spanStyle.PointSize / scale;
                 }
 
                 if (firstLine)
@@ -148,8 +148,8 @@ namespace SixLabors.Fonts
                     }
                 }
 
-                float glyphWidth = (glyph.AdvanceWidth * spanStyle.PointSize) / scale;
-                float glyphHeight = (glyph.Height * spanStyle.PointSize) / scale;
+                float glyphWidth = glyph.AdvanceWidth * spanStyle.PointSize / scale;
+                float glyphHeight = glyph.Height * spanStyle.PointSize / scale;
 
                 if (hasFourBytes || (text[i] != '\r' && text[i] != '\n' && text[i] != '\t' && text[i] != ' '))
                 {
@@ -157,7 +157,7 @@ namespace SixLabors.Fonts
                     if (spanStyle.ApplyKerning && previousGlyph != null)
                     {
                         // if there is special instructions for this glyph pair use that width
-                        Vector2 scaledOffset = (spanStyle.GetOffset(glyph, previousGlyph) * spanStyle.PointSize) / scale;
+                        Vector2 scaledOffset = spanStyle.GetOffset(glyph, previousGlyph) * spanStyle.PointSize / scale;
 
                         glyphLocation += scaledOffset;
 
@@ -167,8 +167,8 @@ namespace SixLabors.Fonts
 
                     foreach (GlyphInstance? g in glyphs)
                     {
-                        float w = (g.AdvanceWidth * spanStyle.PointSize) / scale;
-                        float h = (g.Height * spanStyle.PointSize) / scale;
+                        float w = g.AdvanceWidth * spanStyle.PointSize / scale;
+                        float h = g.Height * spanStyle.PointSize / scale;
                         layout.Add(new GlyphLayout(codePoint, new Glyph(g, spanStyle.PointSize), glyphLocation, w, h, lineHeight, startOfLine, false, false));
 
                         if (w > glyphWidth)

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -169,9 +169,7 @@ namespace SixLabors.Fonts
             private readonly TextLayout layoutEngine;
 
             internal TextMeasurerInt(TextLayout layoutEngine)
-            {
-                this.layoutEngine = layoutEngine;
-            }
+                => this.layoutEngine = layoutEngine;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="TextMeasurerInt"/> class.

--- a/src/SixLabors.Fonts/TextRenderer.cs
+++ b/src/SixLabors.Fonts/TextRenderer.cs
@@ -37,9 +37,7 @@ namespace SixLabors.Fonts
         /// <param name="text">The text.</param>
         /// <param name="options">The style.</param>
         public static void RenderTextTo(IGlyphRenderer renderer, ReadOnlySpan<char> text, RendererOptions options)
-        {
-            new TextRenderer(renderer).RenderText(text, options);
-        }
+            => new TextRenderer(renderer).RenderText(text, options);
 
         /// <summary>
         /// Renders the text to the <paramref name="renderer"/>.
@@ -48,9 +46,7 @@ namespace SixLabors.Fonts
         /// <param name="text">The text.</param>
         /// <param name="options">The style.</param>
         public static void RenderTextTo(IGlyphRenderer renderer, string text, RendererOptions options)
-        {
-            new TextRenderer(renderer).RenderText(text, options);
-        }
+            => new TextRenderer(renderer).RenderText(text, options);
 
         /// <summary>
         /// Renders the text.
@@ -58,9 +54,7 @@ namespace SixLabors.Fonts
         /// <param name="text">The text.</param>
         /// <param name="options">The style.</param>
         public void RenderText(string text, RendererOptions options)
-        {
-            this.RenderText(text.AsSpan(), options);
-        }
+            => this.RenderText(text.AsSpan(), options);
 
         /// <summary>
         /// Renders the text.

--- a/src/SixLabors.Fonts/Utilities/EncodingIDExtensions.cs
+++ b/src/SixLabors.Fonts/Utilities/EncodingIDExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Text;

--- a/src/SixLabors.Fonts/Utilities/StringLoader.cs
+++ b/src/SixLabors.Fonts/Utilities/StringLoader.cs
@@ -24,18 +24,12 @@ namespace SixLabors.Fonts.Utilities
         public Encoding Encoding { get; }
 
         public static StringLoader Create(BinaryReader reader)
-        {
-            return Create(reader, Encoding.BigEndianUnicode);
-        }
+            => Create(reader, Encoding.BigEndianUnicode);
 
         public static StringLoader Create(BinaryReader reader, Encoding encoding)
-        {
-            return new StringLoader(reader.ReadUInt16(), reader.ReadUInt16(), encoding);
-        }
+            => new StringLoader(reader.ReadUInt16(), reader.ReadUInt16(), encoding);
 
         public void LoadValue(BinaryReader reader)
-        {
-            this.Value = reader.ReadString(this.Length, this.Encoding).Replace("\0", string.Empty);
-        }
+            => this.Value = reader.ReadString(this.Length, this.Encoding).Replace("\0", string.Empty);
     }
 }

--- a/src/SixLabors.Fonts/VerticalAlignment.cs
+++ b/src/SixLabors.Fonts/VerticalAlignment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts

--- a/src/SixLabors.Fonts/WellKnownIds/EncodingIDs.cs
+++ b/src/SixLabors.Fonts/WellKnownIds/EncodingIDs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.WellKnownIds

--- a/src/SixLabors.Fonts/WellKnownIds/NameIds.cs
+++ b/src/SixLabors.Fonts/WellKnownIds/NameIds.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.WellKnownIds

--- a/src/SixLabors.Fonts/WellKnownIds/PlatformIDs.cs
+++ b/src/SixLabors.Fonts/WellKnownIds/PlatformIDs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 namespace SixLabors.Fonts.WellKnownIds

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,33 +5,15 @@
     Directory.Build.props is automatically picked up and imported by
     Microsoft.Common.props. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly early and only Sdk.props will have been
+    instead. They import fairly early and only Sdk.props will have been
     imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.props</MSBuildAllProjects>
-    <ImageSharpProjectCategory>tests</ImageSharpProjectCategory>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+  <!-- Import the shared tests .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\shared-infrastructure\msbuild\props\SixLabors.Tests.props" />
 
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\shared-infrastructure\SixLabors.Tests.ruleset</CodeAnalysisRuleSet>
-    <!--TODO: We should remove all obsolete code from the solution-->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
-  </PropertyGroup>
-
+  <!-- Import the solution .props file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
-
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" IsImplicitlyDefined="true" />
-    <PackageReference Include="xunit" IsImplicitlyDefined="true" />
-    <PackageReference Include="xunit.runner.visualstudio" IsImplicitlyDefined="true" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(codecov)' == 'true' AND '$(IsTestProject)' == 'true'">
-    <PackageReference Include="coverlet.collector" IsImplicitlyDefined="true" />
-  </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -5,33 +5,21 @@
     Directory.Build.targets is automatically picked up and imported by
     Microsoft.Common.targets. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly late and most other props/targets will have
+    instead. They import fairly late and most other props/targets will have
     been imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.targets</MSBuildAllProjects>
-  </PropertyGroup>
+  <!-- Import the shared tests .targets file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\shared-infrastructure\msbuild\targets\SixLabors.Tests.targets" />
 
+  <!-- Import the solution .targets file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
-  <!-- Tool versions for tool references across all projects -->
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <!--dotnet tools does not have an x86 runner. You have to use separate SDKs-->
-    <!--https://github.com/actions/setup-dotnet/issues/72-->
-    <DotNetCliToolReference Update="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-
   <ItemGroup>
-    <!--Test Dependencies-->
-    <PackageReference Update="BenchmarkDotNet" Version="0.12.0" />
-    <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All"/>
-    <PackageReference Update="coverlet.msbuild" Version="2.8.0" PrivateAssets="All"/>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20200116-01" />
-    <PackageReference Update="Moq" Version="4.10.0" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
+    <!-- Test Dependencies -->
+    <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Update="Moq" Version="4.14.6" />
   </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -19,7 +19,7 @@
   <ItemGroup>
     <!-- Test Dependencies -->
     <!-- Since our src does not target NET 472 we need to explicitly target the reference pack -->
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" IsImplicitlyDefined="true"  />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" />
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="Moq" Version="4.14.6" />
   </ItemGroup>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <!-- Test Dependencies -->
+    <!-- Since our src does not target NET 472 we need to explicitly target the reference pack -->
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" IsImplicitlyDefined="true"  />
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="Moq" Version="4.14.6" />

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <!-- Test Dependencies -->
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" IsImplicitlyDefined="true"  />
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="Moq" Version="4.14.6" />
   </ItemGroup>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -18,8 +18,6 @@
 
   <ItemGroup>
     <!-- Test Dependencies -->
-    <!-- Since our src does not target NET 472 we need to explicitly target the reference pack -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" />
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="Moq" Version="4.14.6" />
   </ItemGroup>

--- a/tests/SixLabors.Fonts.Tests/Accents.cs
+++ b/tests/SixLabors.Fonts.Tests/Accents.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using Xunit;
 
 namespace SixLabors.Fonts.Tests

--- a/tests/SixLabors.Fonts.Tests/BinaryWriter.cs
+++ b/tests/SixLabors.Fonts.Tests/BinaryWriter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 using System.Buffers.Binary;
 using System.IO;
 using System.Text;
@@ -21,7 +24,6 @@ namespace SixLabors.Fonts.Tests
         /// Whether or not this writer has been disposed yet.
         /// </summary>
         private bool disposed;
-
 
         public BinaryWriter()
             : this(new MemoryStream())
@@ -51,10 +53,7 @@ namespace SixLabors.Fonts.Tests
         /// <summary>
         /// Closes the writer, including the underlying stream.
         /// </summary>
-        public void Close()
-        {
-            this.Dispose();
-        }
+        public void Close() => this.Dispose();
 
         /// <summary>
         /// Flushes the underlying stream.
@@ -65,11 +64,7 @@ namespace SixLabors.Fonts.Tests
             this.BaseStream.Flush();
         }
 
-
-        public BinaryReader GetReader()
-        {
-            return new BinaryReader(this.GetStream(), true);
-        }
+        public BinaryReader GetReader() => new BinaryReader(this.GetStream(), true);
 
         public MemoryStream GetStream()
         {
@@ -164,16 +159,9 @@ namespace SixLabors.Fonts.Tests
             this.WriteInternal(this.buffer, 8);
         }
 
-        public void WriteOffset32(uint? value)
-        {
-            this.WriteUInt32(value ?? 0);
-        }
+        public void WriteOffset32(uint? value) => this.WriteUInt32(value ?? 0);
 
-
-        public void WriteOffset16(ushort? value)
-        {
-            this.WriteUInt16(value ?? 0);
-        }
+        public void WriteOffset16(ushort? value) => this.WriteUInt16(value ?? 0);
 
         /// <summary>
         /// Writes a 32-bit unsigned integer to the stream.
@@ -318,7 +306,7 @@ namespace SixLabors.Fonts.Tests
             while (value >= 128)
             {
                 this.buffer[index++] = (byte)((value & 0x7f) | 0x80);
-                value = value >> 7;
+                value >>= 7;
                 index++;
             }
 
@@ -383,14 +371,8 @@ namespace SixLabors.Fonts.Tests
             this.WriteInternal(this.buffer, 1);
         }
 
-        public void WriteFWORD(short value)
-        {
-            this.WriteInt16(value);
-        }
+        public void WriteFWORD(short value) => this.WriteInt16(value);
 
-        public void WriteUFWORD(ushort value)
-        {
-            this.WriteUInt16(value);
-        }
+        public void WriteUFWORD(ushort value) => this.WriteUInt16(value);
     }
 }

--- a/tests/SixLabors.Fonts.Tests/ColorGlyphRenderer.cs
+++ b/tests/SixLabors.Fonts.Tests/ColorGlyphRenderer.cs
@@ -1,13 +1,14 @@
-﻿using System.Collections.Generic;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
 
 namespace SixLabors.Fonts.Tests
 {
     public class ColorGlyphRenderer : GlyphRenderer, IColorGlyphRenderer
     {
         public List<GlyphColor> Colors { get; } = new List<GlyphColor>();
-        public void SetColor(GlyphColor color)
-        {
-            this.Colors.Add(color);
-        }
+
+        public void SetColor(GlyphColor color) => this.Colors.Add(color);
     }
 }

--- a/tests/SixLabors.Fonts.Tests/ConstructorGuards.cs
+++ b/tests/SixLabors.Fonts.Tests/ConstructorGuards.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests
@@ -8,14 +11,18 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void FontClass_NullFontFamilyThrowsException()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new Font((FontFamily)null, 0f, FontStyle.Regular));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException
+                >(
+                () => new Font((FontFamily)null, 0f, FontStyle.Regular));
             Assert.Equal("family", ex.ParamName);
         }
 
         [Fact]
         public void FontClass_NullFontThrowsException()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new Font((Font)null, 0f, FontStyle.Regular));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(
+                () => new Font((Font)null, 0f, FontStyle.Regular));
+
             Assert.Equal("prototype", ex.ParamName);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/FakeFont.cs
+++ b/tests/SixLabors.Fonts.Tests/FakeFont.cs
@@ -1,7 +1,9 @@
-using Xunit;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
 
-using SixLabors.Fonts.Tests.Fakes;
 using System.Globalization;
+using SixLabors.Fonts.Tests.Fakes;
+using Xunit;
 
 namespace SixLabors.Fonts.Tests
 {
@@ -19,9 +21,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         public static Font CreateFont(string text)
-        {
-            return CreateFontWithInstance(text, out _);
-        }
+            => CreateFontWithInstance(text, out _);
 
         internal static Font CreateFontWithInstance(string text, out FakeFontInstance instance)
         {

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeCmapSubtable.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeCmapSubtable.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Generic;
 using SixLabors.Fonts.Tables.General.CMap;
 
@@ -8,9 +11,7 @@ namespace SixLabors.Fonts.Tests.Fakes
         private readonly List<FakeGlyphSource> glyphs;
 
         public FakeCmapSubtable(List<FakeGlyphSource> glyphs)
-        {
-            this.glyphs = glyphs;
-        }
+            => this.glyphs = glyphs;
 
         public override bool TryGetGlyphId(int codePoint, out ushort glyphId)
         {
@@ -22,6 +23,7 @@ namespace SixLabors.Fonts.Tests.Fakes
                     return true;
                 }
             }
+
             glyphId = 0;
             return false;
         }

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
@@ -1,6 +1,8 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using SixLabors.Fonts.Tables.General;
 
@@ -14,12 +16,13 @@ namespace SixLabors.Fonts.Tests.Fakes
         }
 
         internal FakeFontInstance(List<FakeGlyphSource> glyphs)
-            : base(GenerateNameTable(),
+            : base(
+                  GenerateNameTable(),
                   GenerateCMapTable(glyphs),
                   new FakeGlyphTable(glyphs),
                   GenerateOS2Table(),
                   GenerateHorizontalMetricsTable(glyphs),
-                  GenerateHeadTable(glyphs),
+                  GenerateHeadTable(),
                   new KerningTable(new Fonts.Tables.General.Kern.KerningSubTable[0]),
                   null,
                   null)
@@ -43,9 +46,9 @@ namespace SixLabors.Fonts.Tests.Fakes
                 new FakeGlyphTable(glyphs),
                 GenerateOS2TableWithVaryingVerticalFontMetrics(),
                 GenerateHorizontalMetricsTable(glyphs),
-                GenerateHeadTable(glyphs),
-                new KerningTable(new Fonts.Tables.General.Kern.KerningSubTable[0])
-            );
+                GenerateHeadTable(),
+                new KerningTable(new Fonts.Tables.General.Kern.KerningSubTable[0]));
+
             return result;
         }
 
@@ -55,37 +58,36 @@ namespace SixLabors.Fonts.Tests.Fakes
             return glyphs;
         }
 
-        static NameTable GenerateNameTable()
-        {
-            return new NameTable(new[] {
-                new Fonts.Tables.General.Name.NameRecord(WellKnownIds.PlatformIDs.Windows, 0, WellKnownIds.NameIds.FullFontName, "name"),
-                new Fonts.Tables.General.Name.NameRecord(WellKnownIds.PlatformIDs.Windows, 0, WellKnownIds.NameIds.FontFamilyName, "name")
-            }, new string[0]);
-        }
+        private static NameTable GenerateNameTable()
+            => new NameTable(
+                new[]
+                {
+                    new Fonts.Tables.General.Name.NameRecord(WellKnownIds.PlatformIDs.Windows, 0, WellKnownIds.NameIds.FullFontName, "name"),
+                    new Fonts.Tables.General.Name.NameRecord(WellKnownIds.PlatformIDs.Windows, 0, WellKnownIds.NameIds.FontFamilyName, "name")
+                },
+                Array.Empty<string>());
 
-        static CMapTable GenerateCMapTable(List<FakeGlyphSource> glyphs)
-        {
-            return new CMapTable(new[] { new FakeCmapSubtable(glyphs) });
-        }
+        private static CMapTable GenerateCMapTable(List<FakeGlyphSource> glyphs)
+            => new CMapTable(new[] { new FakeCmapSubtable(glyphs) });
 
-        static OS2Table GenerateOS2Table()
-        {
-            return new OS2Table(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, new byte[0], 1, 1, 1, 1, "", OS2Table.FontStyleSelection.ITALIC, 1, 1, 20, 10, 20, 1, 1);
-        }
+        private static OS2Table GenerateOS2Table()
+            => new OS2Table(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, new byte[0], 1, 1, 1, 1, string.Empty, OS2Table.FontStyleSelection.ITALIC, 1, 1, 20, 10, 20, 1, 1);
 
-        static OS2Table GenerateOS2TableWithVaryingVerticalFontMetrics()
-        {
-            return new OS2Table(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, new byte[0], 1, 1, 1, 1, "", OS2Table.FontStyleSelection.ITALIC, 1, 1, 35, 8, 12, 33, 11);
-        }
+        private static OS2Table GenerateOS2TableWithVaryingVerticalFontMetrics()
+            => new OS2Table(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, new byte[0], 1, 1, 1, 1, string.Empty, OS2Table.FontStyleSelection.ITALIC, 1, 1, 35, 8, 12, 33, 11);
 
-        static HorizontalMetricsTable GenerateHorizontalMetricsTable(List<FakeGlyphSource> glyphs)
-        {
-            return new HorizontalMetricsTable(glyphs.Select(x => (ushort)30).ToArray(), glyphs.Select(x => (short)10).ToArray());
-        }
+        private static HorizontalMetricsTable GenerateHorizontalMetricsTable(List<FakeGlyphSource> glyphs)
+            => new HorizontalMetricsTable(glyphs.Select(x => (ushort)30).ToArray(), glyphs.Select(x => (short)10).ToArray());
 
-        static HeadTable GenerateHeadTable(List<FakeGlyphSource> glyphs)
-        {
-            return new HeadTable(HeadTable.HeadFlags.ForcePPEMToInt, HeadTable.HeadMacStyle.None, 30, DateTime.Now, DateTime.Now, new Bounds(10, 10, 20, 20), 1, HeadTable.IndexLocationFormats.Offset16);
-        }
+        private static HeadTable GenerateHeadTable()
+            => new HeadTable(
+                HeadTable.HeadFlags.ForcePPEMToInt,
+                HeadTable.HeadMacStyle.None,
+                30,
+                DateTime.Now,
+                DateTime.Now,
+                new Bounds(10, 10, 20, 20),
+                1,
+                HeadTable.IndexLocationFormats.Offset16);
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeGlyphSource.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeGlyphSource.cs
@@ -1,4 +1,7 @@
-﻿using System.Numerics;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Numerics;
 using SixLabors.Fonts.Tables.General.Glyphs;
 
 namespace SixLabors.Fonts.Tests.Fakes
@@ -6,12 +9,14 @@ namespace SixLabors.Fonts.Tests.Fakes
     internal class FakeGlyphSource
     {
         public FakeGlyphSource(int codePoint, ushort index)
-            : this(codePoint,
+            : this(
+                  codePoint,
                   index,
-                  new GlyphVector(new Vector2[] { new Vector2(10, 10), new Vector2(10, 20), new Vector2(20, 20), new Vector2(20, 10) },
-                  new bool[] { true, true, true, true },
-                  new ushort[] { 3 },
-                  new Bounds(10, 10, 20, 20)))
+                  new GlyphVector(
+                      new Vector2[] { new Vector2(10, 10), new Vector2(10, 20), new Vector2(20, 20), new Vector2(20, 10) },
+                      new bool[] { true, true, true, true },
+                      new ushort[] { 3 },
+                      new Bounds(10, 10, 20, 20)))
         {
         }
 

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeGlyphTable.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeGlyphTable.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.Tables.General.Glyphs;
 
@@ -10,9 +13,7 @@ namespace SixLabors.Fonts.Tests.Fakes
 
         public FakeGlyphTable(List<FakeGlyphSource> glyphs)
             : base(new GlyphLoader[glyphs.Count])
-        {
-            this.glyphs = glyphs;
-        }
+            => this.glyphs = glyphs;
 
         internal override GlyphVector GetGlyph(int index)
         {
@@ -24,7 +25,7 @@ namespace SixLabors.Fonts.Tests.Fakes
                 }
             }
 
-            return default(GlyphVector);
+            return default;
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
@@ -21,13 +25,13 @@ namespace SixLabors.Fonts.Tests
         public void InstallViaPathInstallFontFileInstances()
         {
             var sut = new FontCollection();
-            var family = sut.Install(TestFonts.CarterOneFile, out var descriptions);
+            FontFamily family = sut.Install(TestFonts.CarterOneFile, out FontDescription descriptions);
 
-            var allInstances = sut.FindAll(family.Name, CultureInfo.InvariantCulture);
+            IEnumerable<IFontInstance> allInstances = sut.FindAll(family.Name, CultureInfo.InvariantCulture);
 
             Assert.All(allInstances, i =>
             {
-                var font = Assert.IsType<FileFontInstance>(i);
+                FileFontInstance font = Assert.IsType<FileFontInstance>(i);
             });
         }
 

--- a/tests/SixLabors.Fonts.Tests/FontDescriptionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontDescriptionTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
@@ -14,11 +17,11 @@ namespace SixLabors.Fonts.Tests
             writer.WriteTableHeader("name", 0, 28, 999);
             writer.WriteNameTable(
                 new Dictionary<WellKnownIds.NameIds, string>
-                    {
-                        { WellKnownIds.NameIds.FullFontName, "name" } ,
-                         { WellKnownIds.NameIds.FontSubfamilyName, "sub" },
-                         { WellKnownIds.NameIds.FontFamilyName, "fam" }
-                    });
+                {
+                    { WellKnownIds.NameIds.FullFontName, "name" },
+                    { WellKnownIds.NameIds.FontSubfamilyName, "sub" },
+                    { WellKnownIds.NameIds.FontFamilyName, "fam" }
+                });
 
             var description = FontDescription.LoadDescription(writer.GetStream());
             Assert.Equal("name", description.FontNameInvariantCulture);
@@ -42,8 +45,7 @@ namespace SixLabors.Fonts.Tests
                 (WellKnownIds.NameIds.FontFamilyName, "fam_c1", c1),
                 (WellKnownIds.NameIds.FullFontName, "name_c2", c2),
                 (WellKnownIds.NameIds.FontSubfamilyName, "sub_c2", c2),
-                (WellKnownIds.NameIds.FontFamilyName, "fam_c2", c2)
-                );
+                (WellKnownIds.NameIds.FontFamilyName, "fam_c2", c2));
 
             var description = FontDescription.LoadDescription(writer.GetStream());
 
@@ -72,8 +74,7 @@ namespace SixLabors.Fonts.Tests
                 (WellKnownIds.NameIds.FontFamilyName, "fam_c2", c2),
                 (WellKnownIds.NameIds.FullFontName, "name_us", usCulture),
                 (WellKnownIds.NameIds.FontSubfamilyName, "sub_us", usCulture),
-                (WellKnownIds.NameIds.FontFamilyName, "fam_us", usCulture)
-                );
+                (WellKnownIds.NameIds.FontFamilyName, "fam_us", usCulture));
 
             var description = FontDescription.LoadDescription(writer.GetStream());
 
@@ -102,8 +103,7 @@ namespace SixLabors.Fonts.Tests
                 (WellKnownIds.NameIds.FontFamilyName, "fam_c2", c2),
                 (WellKnownIds.NameIds.FullFontName, "name_us", usCulture),
                 (WellKnownIds.NameIds.FontSubfamilyName, "sub_us", usCulture),
-                (WellKnownIds.NameIds.FontFamilyName, "fam_us", usCulture)
-                );
+                (WellKnownIds.NameIds.FontFamilyName, "fam_us", usCulture));
 
             var description = FontDescription.LoadDescription(writer.GetStream());
 

--- a/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
@@ -1,9 +1,11 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Linq;
+using Xunit;
 
 namespace SixLabors.Fonts.Tests
 {
-    using Xunit;
-
     public class FontLoaderTests
     {
         [Fact]
@@ -43,6 +45,7 @@ namespace SixLabors.Fonts.Tests
             GlyphInstance glyph = font.GetGlyph('a');
             var r = new GlyphRenderer();
             glyph.RenderTo(r, 12, System.Numerics.Vector2.Zero, new System.Numerics.Vector2(72), 0);
+
             // the test font only has characters .notdef, 'a' & 'b' defined
             Assert.Equal(6, r.ControlPoints.Distinct().Count());
         }
@@ -58,6 +61,7 @@ namespace SixLabors.Fonts.Tests
             GlyphInstance glyph = font.GetGlyph('a');
             var r = new GlyphRenderer();
             glyph.RenderTo(r, 12, System.Numerics.Vector2.Zero, new System.Numerics.Vector2(72), 0);
+
             // the test font only has characters .notdef, 'a' & 'b' defined
             Assert.Equal(6, r.ControlPoints.Distinct().Count());
         }

--- a/tests/SixLabors.Fonts.Tests/FontReaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontReaderTests.cs
@@ -1,4 +1,6 @@
-﻿
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using SixLabors.Fonts.Tables;
 using SixLabors.Fonts.Tables.General;
 
@@ -50,9 +52,15 @@ namespace SixLabors.Fonts.Tests
 
             writer.WriteTrueTypeFileHeader(new TableHeader("cmap", 0, 0, 20));
 
-            writer.WriteCMapTable(new[] {
-                new Fonts.Tables.General.CMap.Format0SubTable(0, WellKnownIds.PlatformIDs.Macintosh, 1, new byte[] {2,9})
-            });
+            writer.WriteCMapTable(
+                new[]
+                {
+                    new Fonts.Tables.General.CMap.Format0SubTable(
+                        0,
+                        WellKnownIds.PlatformIDs.Macintosh,
+                        1,
+                        new byte[] { 2, 9 })
+                });
 
             var reader = new FontReader(writer.GetStream());
             CMapTable cmap = reader.GetTable<CMapTable>();

--- a/tests/SixLabors.Fonts.Tests/GlyphRenderer.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphRenderer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Generic;
 using System.Numerics;
 
@@ -5,7 +8,7 @@ namespace SixLabors.Fonts.Tests
 {
     public class GlyphRenderer : IGlyphRenderer
     {
-        public int FiguresCount = 0;
+        private int figuresCount = 0;
 
         public List<Vector2> ControlPoints { get; } = new List<Vector2>();
 
@@ -22,10 +25,7 @@ namespace SixLabors.Fonts.Tests
             return true;
         }
 
-        public void BeginFigure()
-        {
-            this.FiguresCount++;
-        }
+        public void BeginFigure() => this.figuresCount++;
 
         public void CubicBezierTo(Vector2 secondControlPoint, Vector2 thirdControlPoint, Vector2 point)
         {
@@ -37,12 +37,10 @@ namespace SixLabors.Fonts.Tests
 
         public void EndGlyph()
         {
-
         }
 
         public void EndFigure()
         {
-
         }
 
         public void LineTo(Vector2 point)

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -85,8 +88,8 @@ namespace SixLabors.Fonts.Tests
 
             // Get letter Grinning Face emoji
             var instance = font.Instance as FontInstance;
-            Assert.True(instance.TryGetGlyphIndex(this.AsCodePoint("😀"), out var idx));
-            Assert.True(instance.TryGetColoredVectors(idx, out var vectors));
+            Assert.True(instance.TryGetGlyphIndex(this.AsCodePoint("😀"), out ushort idx));
+            Assert.True(instance.TryGetColoredVectors(idx, out GlyphInstance[] vectors));
 
             Assert.Equal(3, vectors.Length);
         }
@@ -118,6 +121,7 @@ namespace SixLabors.Fonts.Tests
                 int codePoint = hasFourBytes ? char.ConvertToUtf32(text[i], text[i + 1]) : text[i];
                 return codePoint;
             }
+
             return 0;
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_104.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_104.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using SixLabors.Fonts.Tables.General.CMap;
 using Xunit;
 using static SixLabors.Fonts.Tables.General.CMap.Format4SubTable;
@@ -9,14 +12,21 @@ namespace SixLabors.Fonts.Tests.Issues
         [Fact]
         public void Format4SubTableWithSegmentsHasOffByOneWhenOverflowing()
         {
-            var tbl = new Format4SubTable(0, WellKnownIds.PlatformIDs.Windows, 0, new[] {
-                new Segment(0,
-                ushort.MaxValue, // end
-                ushort.MinValue, // start of range
-                (short)(short.MaxValue), //delta
-                0 // zero to force correctly tested codepath
-                )
-            }, null);
+            Segment[] segments = new[]
+            {
+                new Segment(
+                    0,
+                    ushort.MaxValue, // end
+                    ushort.MinValue, // start of range
+                    short.MaxValue, // delta
+                    0) // zero to force correctly tested codepath
+            };
+            var tbl = new Format4SubTable(
+                0,
+                WellKnownIds.PlatformIDs.Windows,
+                0,
+                segments,
+                null);
 
             const int delta = short.MaxValue + 2; // extra 2 to handle the difference between ushort and short when offsettings
 

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_23.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_23.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues
 {

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Globalization;
 using SixLabors.Fonts.Tests.Fakes;
 using Xunit;

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Globalization;
 using SixLabors.Fonts.Tests.Fakes;
 using Xunit;
@@ -16,9 +19,7 @@ namespace SixLabors.Fonts.Tests.Issues
         public void WhiteSpaceAtStartOfLineNotMeasured(string text, float width, float height)
         {
             Font font = CreateFont(text);
-            FontRectangle size = TextMeasurer.MeasureBounds(text, new RendererOptions(font, (72 * font.EmSize))
-            {
-            });
+            FontRectangle size = TextMeasurer.MeasureBounds(text, new RendererOptions(font, 72 * font.EmSize));
 
             Assert.Equal(height, size.Height, 2);
             Assert.Equal(width, size.Width, 2);

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Globalization;
 using SixLabors.Fonts.Tests.Fakes;
 using Xunit;
@@ -10,22 +13,21 @@ namespace SixLabors.Fonts.Tests.Issues
         public void RenderingTabAtStartOrLineTooShort()
         {
             Font font = CreateFont("\t x");
-            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle doublTabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle tabWithXWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, (72 * font.EmSize)));
+            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle doublTabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle tabWithXWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, 72 * font.EmSize));
 
             Assert.Equal(tabWidth.Width + xWidth.Width, tabWithXWidth.Width, 2);
         }
-
 
         [Fact]
         public void Rendering2TabsAtStartOfLineTooShort()
         {
             Font font = CreateFont("\t x");
-            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle tabWithXWidth = TextMeasurer.MeasureBounds("\t\tx", new RendererOptions(font, (72 * font.EmSize)));
+            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle tabWithXWidth = TextMeasurer.MeasureBounds("\t\tx", new RendererOptions(font, 72 * font.EmSize));
 
             Assert.Equal(tabWidth.Width + xWidth.Width, tabWithXWidth.Width, 2);
         }
@@ -34,21 +36,20 @@ namespace SixLabors.Fonts.Tests.Issues
         public void TwoTabsAreDoubleWidthOfOneTab()
         {
             Font font = CreateFont("\t x");
-            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle twoTabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, (72 * font.EmSize)));
+            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle twoTabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, 72 * font.EmSize));
 
             Assert.Equal(twoTabWidth.Width, tabWidth.Width * 2, 2);
         }
-
 
         [Fact]
         public void TwoTabsAreDoubleWidthOfOneTabMinusXWidth()
         {
             Font font = CreateFont("\t x");
-            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle twoTabWidth = TextMeasurer.MeasureBounds("\t\tx", new RendererOptions(font, (72 * font.EmSize)));
+            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle twoTabWidth = TextMeasurer.MeasureBounds("\t\tx", new RendererOptions(font, 72 * font.EmSize));
 
             Assert.Equal(twoTabWidth.Width - xWidth.Width, (tabWidth.Width - xWidth.Width) * 2, 2);
         }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Globalization;
 using SixLabors.Fonts.Tests.Fakes;
 using Xunit;
@@ -6,7 +9,6 @@ namespace SixLabors.Fonts.Tests.Issues
 {
     public class Issues_36
     {
-
         [Theory]
         [InlineData(1)]
         [InlineData(2)]
@@ -17,9 +19,9 @@ namespace SixLabors.Fonts.Tests.Issues
         {
             Font font = CreateFont("\t x");
 
-            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, (72 * font.EmSize)));
-            string tabString = "".PadRight(tabCount, '\t');
-            FontRectangle tabCountWidth = TextMeasurer.MeasureBounds(tabString, new RendererOptions(font, (72 * font.EmSize)));
+            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, 72 * font.EmSize));
+            string tabString = string.Empty.PadRight(tabCount, '\t');
+            FontRectangle tabCountWidth = TextMeasurer.MeasureBounds(tabString, new RendererOptions(font, 72 * font.EmSize));
 
             Assert.Equal(tabWidth.Width * tabCount, tabCountWidth.Width, 2);
         }
@@ -34,10 +36,10 @@ namespace SixLabors.Fonts.Tests.Issues
         {
             Font font = CreateFont("\t x");
 
-            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, (72 * font.EmSize)));
-            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, (72 * font.EmSize)));
+            FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, 72 * font.EmSize));
+            FontRectangle tabWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, 72 * font.EmSize));
             string tabString = "x".PadLeft(tabCount + 1, '\t');
-            FontRectangle tabCountWidth = TextMeasurer.MeasureBounds(tabString, new RendererOptions(font, (72 * font.EmSize)));
+            FontRectangle tabCountWidth = TextMeasurer.MeasureBounds(tabString, new RendererOptions(font, 72 * font.EmSize));
 
             float singleTabWidth = tabWidth.Width - xWidth.Width;
             float finalTabWidth = tabCountWidth.Width - xWidth.Width;

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_39.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_39.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Globalization;
 using SixLabors.Fonts.Tests.Fakes;
 using Xunit;
@@ -13,7 +16,7 @@ namespace SixLabors.Fonts.Tests.Issues
 
             var r = new GlyphRenderer();
 
-            new TextRenderer(r).RenderText("", new RendererOptions(new Font(font, 30), 72));
+            new TextRenderer(r).RenderText(string.Empty, new RendererOptions(new Font(font, 30), 72));
         }
 
         public static Font CreateFont(string text)

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_96.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_96.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.IO;
 using Xunit;
 
@@ -7,8 +10,6 @@ namespace SixLabors.Fonts.Tests.Issues
     {
         [Fact]
         public void ShouldNotThrowArgumentExceptionWhenFontContainsDuplicateTables()
-        {
-            Assert.Throws<EndOfStreamException>(() => FontDescription.LoadDescription(TestFonts.Issues.Issue96File));
-        }
+            => Assert.Throws<EndOfStreamException>(() => FontDescription.LoadDescription(TestFonts.Issues.Issue96File));
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_97.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_97.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using SixLabors.Fonts.Exceptions;
 using Xunit;
 
@@ -7,8 +10,6 @@ namespace SixLabors.Fonts.Tests.Issues
     {
         [Fact]
         public void ShouldNotThrowNullReferenceExceptionWhenReaderCannotBeCreatedForTable()
-        {
-            Assert.Throws<InvalidFontTableException>(() => FontDescription.LoadDescription(TestFonts.Issues.Issue97File));
-        }
+            => Assert.Throws<InvalidFontTableException>(() => FontDescription.LoadDescription(TestFonts.Issues.Issue97File));
     }
 }

--- a/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Linq;
 using System.Numerics;
@@ -20,7 +23,7 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontOnly()
         {
-            var font = FakeFont.CreateFont("ABC");
+            Font font = FakeFont.CreateFont("ABC");
             var options = new RendererOptions(font);
 
             Assert.Equal(72, options.DpiX);
@@ -34,7 +37,7 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontWithSingleDpi()
         {
-            var font = FakeFont.CreateFont("ABC");
+            Font font = FakeFont.CreateFont("ABC");
             float dpi = 123;
             var options = new RendererOptions(font, dpi);
 
@@ -49,7 +52,7 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontWithXandYDpis()
         {
-            var font = FakeFont.CreateFont("ABC");
+            Font font = FakeFont.CreateFont("ABC");
             float dpix = 123;
             float dpiy = 456;
             var options = new RendererOptions(font, dpix, dpiy);
@@ -62,12 +65,10 @@ namespace SixLabors.Fonts.Tests
             VerifyPropertyDefault(options);
         }
 
-
-
         [Fact]
         public void ContructorTest_FontWithOrigin()
         {
-            var font = FakeFont.CreateFont("ABC");
+            Font font = FakeFont.CreateFont("ABC");
             var origin = new Vector2(123, 345);
             var options = new RendererOptions(font, origin);
 
@@ -82,7 +83,7 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontWithSingleDpiWithOrigin()
         {
-            var font = FakeFont.CreateFont("ABC");
+            Font font = FakeFont.CreateFont("ABC");
             var origin = new Vector2(123, 345);
             float dpi = 123;
             var options = new RendererOptions(font, dpi, origin);
@@ -98,7 +99,7 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontWithXandYDpisWithOrigin()
         {
-            var font = FakeFont.CreateFont("ABC");
+            Font font = FakeFont.CreateFont("ABC");
             var origin = new Vector2(123, 345);
             float dpix = 123;
             float dpiy = 456;
@@ -115,11 +116,12 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontOnly_WithFallbackFonts()
         {
-            var font = FakeFont.CreateFont("ABC");
-            var fontFamilys = new[]{
-                    FakeFont.CreateFont("DEF").Family,
-                    FakeFont.CreateFont("GHI").Family
-                    };
+            Font font = FakeFont.CreateFont("ABC");
+            FontFamily[] fontFamilys = new[]
+            {
+                FakeFont.CreateFont("DEF").Family,
+                FakeFont.CreateFont("GHI").Family
+            };
 
             var options = new RendererOptions(font)
             {
@@ -137,11 +139,13 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontWithSingleDpi_WithFallbackFonts()
         {
-            var font = FakeFont.CreateFont("ABC");
-            var fontFamilys = new[]{
-                    FakeFont.CreateFont("DEF").Family,
-                    FakeFont.CreateFont("GHI").Family
-                    };
+            Font font = FakeFont.CreateFont("ABC");
+            FontFamily[] fontFamilys = new[]
+            {
+                FakeFont.CreateFont("DEF").Family,
+                FakeFont.CreateFont("GHI").Family
+            };
+
             float dpi = 123;
             var options = new RendererOptions(font, dpi)
             {
@@ -159,11 +163,13 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontWithXandYDpis_WithFallbackFonts()
         {
-            var font = FakeFont.CreateFont("ABC");
-            var fontFamilys = new[]{
-                    FakeFont.CreateFont("DEF").Family,
-                    FakeFont.CreateFont("GHI").Family
-                    };
+            Font font = FakeFont.CreateFont("ABC");
+            FontFamily[] fontFamilys = new[]
+            {
+                FakeFont.CreateFont("DEF").Family,
+                FakeFont.CreateFont("GHI").Family
+            };
+
             float dpix = 123;
             float dpiy = 456;
             var options = new RendererOptions(font, dpix, dpiy)
@@ -179,16 +185,16 @@ namespace SixLabors.Fonts.Tests
             VerifyPropertyDefault(options);
         }
 
-
-
         [Fact]
         public void ContructorTest_FontWithOrigin_WithFallbackFonts()
         {
-            var font = FakeFont.CreateFont("ABC");
-            var fontFamilys = new[]{
-                    FakeFont.CreateFont("DEF").Family,
-                    FakeFont.CreateFont("GHI").Family
-                    };
+            Font font = FakeFont.CreateFont("ABC");
+            FontFamily[] fontFamilys = new[]
+            {
+                FakeFont.CreateFont("DEF").Family,
+                FakeFont.CreateFont("GHI").Family
+            };
+
             var origin = new Vector2(123, 345);
             var options = new RendererOptions(font, origin)
             {
@@ -206,11 +212,13 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontWithSingleDpiWithOrigin_WithFallbackFonts()
         {
-            var font = FakeFont.CreateFont("ABC");
-            var fontFamilys = new[]{
-                    FakeFont.CreateFont("DEF").Family,
-                    FakeFont.CreateFont("GHI").Family
-                    };
+            Font font = FakeFont.CreateFont("ABC");
+            FontFamily[] fontFamilys = new[]
+            {
+                FakeFont.CreateFont("DEF").Family,
+                FakeFont.CreateFont("GHI").Family
+            };
+
             var origin = new Vector2(123, 345);
             float dpi = 123;
             var options = new RendererOptions(font, dpi, origin)
@@ -229,11 +237,13 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void ContructorTest_FontWithXandYDpisWithOrigin_WithFallbackFonts()
         {
-            var font = FakeFont.CreateFont("ABC");
-            var fontFamilys = new[]{
-                    FakeFont.CreateFont("DEF").Family,
-                    FakeFont.CreateFont("GHI").Family
-                    };
+            Font font = FakeFont.CreateFont("ABC");
+            FontFamily[] fontFamilys = new[]
+            {
+                FakeFont.CreateFont("DEF").Family,
+                FakeFont.CreateFont("GHI").Family
+            };
+
             var origin = new Vector2(123, 345);
             float dpix = 123;
             float dpiy = 456;
@@ -253,17 +263,19 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void GetStylePassesCorrectValues()
         {
-            var font = FakeFont.CreateFontWithInstance("ABC", out var abcFontInstance);
-            var fontFamilys = new[]{
-                    FakeFont.CreateFontWithInstance("DEF", out var defFontInstance).Family,
-                    FakeFont.CreateFontWithInstance("GHI", out var ghiFontInstance).Family
-                    };
+            Font font = FakeFont.CreateFontWithInstance("ABC", out Fakes.FakeFontInstance abcFontInstance);
+            FontFamily[] fontFamilys = new[]
+            {
+                FakeFont.CreateFontWithInstance("DEF", out Fakes.FakeFontInstance defFontInstance).Family,
+                FakeFont.CreateFontWithInstance("GHI", out Fakes.FakeFontInstance ghiFontInstance).Family
+            };
+
             var options = new RendererOptions(font)
             {
                 FallbackFontFamilies = fontFamilys
             };
 
-            var style = options.GetStyle(4, 10);
+            AppliedFontStyle style = options.GetStyle(4, 10);
 
             Assert.Equal(0, style.Start);
             Assert.Equal(9, style.End);
@@ -280,20 +292,21 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void GetMissingGlyphFromMainFont()
         {
-            var font = FakeFont.CreateFontWithInstance("ABC", out var abcFontInstance);
-            var fontFamilys = new[] {
-                    FakeFont.CreateFontWithInstance("DEF", out var defFontInstance).Family,
-                    FakeFont.CreateFontWithInstance("GHI", out var ghiFontInstance).Family
-             };
+            Font font = FakeFont.CreateFontWithInstance("ABC", out Fakes.FakeFontInstance abcFontInstance);
+            FontFamily[] fontFamilys = new[]
+            {
+                FakeFont.CreateFontWithInstance("DEF", out Fakes.FakeFontInstance defFontInstance).Family,
+                FakeFont.CreateFontWithInstance("GHI", out Fakes.FakeFontInstance ghiFontInstance).Family
+            };
 
             var options = new RendererOptions(font)
             {
                 FallbackFontFamilies = fontFamilys
             };
 
-            var style = options.GetStyle(4, 10);
+            AppliedFontStyle style = options.GetStyle(4, 10);
 
-            var glyph = Assert.Single(style.GetGlyphLayers('Z', ColorFontSupport.None));
+            GlyphInstance glyph = Assert.Single(style.GetGlyphLayers('Z', ColorFontSupport.None));
             Assert.Equal(GlyphType.Fallback, glyph.GlyphType);
             Assert.Equal(abcFontInstance, glyph.Font);
         }
@@ -304,22 +317,23 @@ namespace SixLabors.Fonts.Tests
         [InlineData('H', "efghiFontInstance")]
         public void GetGlyphFromFirstAvailableInstance(char character, string instance)
         {
-            var font = FakeFont.CreateFontWithInstance("ABC", out var abcFontInstance);
-            var fontFamilys = new[] {
-                    FakeFont.CreateFontWithInstance("DEF", out var defFontInstance).Family,
-                    FakeFont.CreateFontWithInstance("EFGHI", out var efghiFontInstance).Family
-             };
+            Font font = FakeFont.CreateFontWithInstance("ABC", out Fakes.FakeFontInstance abcFontInstance);
+            FontFamily[] fontFamilys = new[]
+            {
+                FakeFont.CreateFontWithInstance("DEF", out Fakes.FakeFontInstance defFontInstance).Family,
+                FakeFont.CreateFontWithInstance("EFGHI", out Fakes.FakeFontInstance efghiFontInstance).Family
+            };
 
             var options = new RendererOptions(font)
             {
                 FallbackFontFamilies = fontFamilys
             };
 
-            var style = options.GetStyle(4, 10);
+            AppliedFontStyle style = options.GetStyle(4, 10);
 
-            var glyph = Assert.Single(style.GetGlyphLayers(character, ColorFontSupport.None));
+            GlyphInstance glyph = Assert.Single(style.GetGlyphLayers(character, ColorFontSupport.None));
             Assert.Equal(GlyphType.Standard, glyph.GlyphType);
-            var expectedInstance = instance switch
+            Fakes.FakeFontInstance expectedInstance = instance switch
             {
                 "abcFontInstance" => abcFontInstance,
                 "defFontInstance" => defFontInstance,
@@ -329,6 +343,5 @@ namespace SixLabors.Fonts.Tests
 
             Assert.Equal(expectedInstance, glyph.Font);
         }
-
     }
 }

--- a/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
+++ b/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
@@ -2,15 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <DebugSymbols>True</DebugSymbols>
     <Platforms>AnyCPU;x64;x86</Platforms>
-    <!--Used to show test project to dotnet test-->
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-xunit" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\SixLabors.Fonts\SixLabors.Fonts.csproj" />
@@ -18,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" />
-    <PackageReference Include="System.Numerics.Vectors" />
   </ItemGroup>
+  
   <ItemGroup>
     <None Update="Fonts\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format0SubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format0SubTableTests.cs
@@ -1,7 +1,9 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Linq;
 using SixLabors.Fonts.Tables.General.CMap;
 using SixLabors.Fonts.WellKnownIds;
-
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Tables.General.CMap
@@ -13,25 +15,26 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
         {
             var writer = new BinaryWriter();
 
-            //int subtableCount = 1;
-            writer.WriteCMapSubTable(new Format0SubTable(0, PlatformIDs.Windows, 2, new byte[] {
-                1,2,3,4,5,6,7,8
-            }));
+            // int subtableCount = 1;
+            writer.WriteCMapSubTable(
+                new Format0SubTable(
+                    0,
+                    PlatformIDs.Windows,
+                    2,
+                    new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }));
 
             BinaryReader reader = writer.GetReader();
             ushort format = reader.ReadUInt16(); // read format before we pass along as thats whet the cmap table does
             Assert.Equal(0, format);
 
-            Format0SubTable table = Format0SubTable.Load(new[] {
-                new EncodingRecord(PlatformIDs.Windows, 2, 0)
-            }, reader).Single();
+            Format0SubTable table = Format0SubTable.Load(
+                new[] { new EncodingRecord(PlatformIDs.Windows, 2, 0) },
+                reader).Single();
 
             Assert.Equal(0, table.Language);
             Assert.Equal(PlatformIDs.Windows, table.Platform);
             Assert.Equal(2, table.Encoding);
-            Assert.Equal(new byte[] {
-                1,2,3,4,5,6,7,8
-            }, table.GlyphIds);
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }, table.GlyphIds);
         }
 
         [Fact]

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format4SubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format4SubTableTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Linq;
 using SixLabors.Fonts.Tables.General.CMap;
 using SixLabors.Fonts.WellKnownIds;
@@ -13,29 +16,27 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
         {
             var writer = new BinaryWriter();
 
-            //int subtableCount = 1;
-            writer.WriteCMapSubTable(new Format4SubTable(0, PlatformIDs.Windows, 2,
-                new[]
-                    {
-                        new Format4SubTable.Segment(0,1,2,3,4)
-                    }, new ushort[] {
-                1,2,3,4,5,6,7,8
-            }));
+            // int subtableCount = 1;
+            writer.WriteCMapSubTable(
+                new Format4SubTable(
+                    0,
+                    PlatformIDs.Windows,
+                    2,
+                    new[] { new Format4SubTable.Segment(0, 1, 2, 3, 4) },
+                    new ushort[] { 1, 2, 3, 4, 5, 6, 7, 8 }));
 
             BinaryReader reader = writer.GetReader();
             ushort format = reader.ReadUInt16(); // read format before we pass along as thats whet the cmap table does
             Assert.Equal(4, format);
 
-            Format4SubTable table = Format4SubTable.Load(new[] {
-                new EncodingRecord(PlatformIDs.Windows, 2, 0)
-            }, reader).Single();
+            Format4SubTable table = Format4SubTable.Load(
+                new[] { new EncodingRecord(PlatformIDs.Windows, 2, 0) },
+                reader).Single();
 
             Assert.Equal(0, table.Language);
             Assert.Equal(PlatformIDs.Windows, table.Platform);
             Assert.Equal(2, table.Encoding);
-            Assert.Equal(new ushort[] {
-                1,2,3,4,5,6,7,8
-            }, table.GlyphIds);
+            Assert.Equal(new ushort[] { 1, 2, 3, 4, 5, 6, 7, 8 }, table.GlyphIds);
 
             Assert.Single(table.Segments);
             Format4SubTable.Segment seg = table.Segments[0];
@@ -44,7 +45,6 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
             Assert.Equal(2, seg.Start);
             Assert.Equal(3, seg.Delta);
             Assert.Equal(4, seg.Offset);
-
         }
 
         [Theory]
@@ -52,8 +52,8 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
         [InlineData(20, 11, true)]
         [InlineData(30, 12, true)]
         [InlineData(90, 72, true)]
-        [InlineData(500, 0, false)] //not in range
-        public void GetCharcter(int src, int expected, bool expectedFound)
+        [InlineData(500, 0, false)] // not in range
+        public void GetCharacter(int src, int expected, bool expectedFound)
         {
             // segCountX2:    8
             // searchRange:   8
@@ -66,18 +66,21 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
             // idRangeOffset: 0   0   0    0
             ushort[] glyphs = Enumerable.Range(0, expected).Select(x => (ushort)x).ToArray();
 
+            Format4SubTable.Segment[] segments = new[]
+            {
+                new Format4SubTable.Segment(0, 20, 10, -9, 0),
+                new Format4SubTable.Segment(1, 90, 30, -18, 0),
+                new Format4SubTable.Segment(2, 480, 153, -27, 0),
+            };
+
             var table = new Format4SubTable(
                 0,
                 PlatformIDs.Windows,
                 0,
-                new[]
-                    {
-                        new Format4SubTable.Segment(0, 20, 10, -9, 0),
-                        new Format4SubTable.Segment(1, 90, 30, -18, 0),
-                        new Format4SubTable.Segment(2, 480, 153, -27, 0),
-                    },
+                segments,
                 glyphs);
-            //ushort id = table.GetGlyphId(src);
+
+            // ushort id = table.GetGlyphId(src);
             var found = table.TryGetGlyphId(src, out var id);
 
             Assert.Equal(expected, id);

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMapTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMapTableTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Linq;
 using SixLabors.Fonts.Exceptions;
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.Tables.General.CMap;
@@ -15,7 +18,8 @@ namespace SixLabors.Fonts.Tests.Tables.General
         {
             var writer = new BinaryWriter();
 
-            writer.WriteCMapTable(new[] {
+            writer.WriteCMapTable(new[]
+            {
                 new Format0SubTable(0, PlatformIDs.Windows, 9, new byte[] { 0, 1, 2 })
             });
 

--- a/tests/SixLabors.Fonts.Tests/Tables/General/ColrTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/ColrTableTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using SixLabors.Fonts.Tables.General;
 using Xunit;
 using static SixLabors.Fonts.Tests.WriterExtensions;
@@ -23,19 +26,24 @@ namespace SixLabors.Fonts.Tests.Tables.General
         {
             var writer = new BinaryWriter();
             writer.WriteTrueTypeFileHeader();
-            writer.WriteColrTable(new[] {
-                new ColrGlyphRecord{
+            writer.WriteColrTable(new[]
+            {
+                new ColrGlyphRecord
+                {
                     Glyph = 1,
-                    Layers = {
-                        new ColrLayerRecord{ Glyph = 10, Pallete = 1},
-                        new ColrLayerRecord{ Glyph = 11, Pallete = 2}
+                    Layers =
+                    {
+                        new ColrLayerRecord { Glyph = 10, Pallete = 1 },
+                        new ColrLayerRecord { Glyph = 11, Pallete = 2 }
                     }
                 },
-                new ColrGlyphRecord{
+                new ColrGlyphRecord
+                {
                     Glyph = 2,
-                    Layers = {
-                        new ColrLayerRecord{ Glyph = 12, Pallete = 1},
-                        new ColrLayerRecord{ Glyph = 13, Pallete = 2}
+                    Layers =
+                    {
+                        new ColrLayerRecord { Glyph = 12, Pallete = 1 },
+                        new ColrLayerRecord { Glyph = 13, Pallete = 2 }
                     }
                 }
             });
@@ -43,9 +51,9 @@ namespace SixLabors.Fonts.Tests.Tables.General
             using (System.IO.Stream stream = TestFonts.TwemojiMozillaData())
             {
                 var reader = new FontReader(stream);
-                var tbl = reader.GetTable<ColrTable>();
+                ColrTable tbl = reader.GetTable<ColrTable>();
 
-                var layers = tbl.GetLayers(15);
+                System.Span<Fonts.Tables.General.Colr.LayerRecord> layers = tbl.GetLayers(15);
                 Assert.Equal(2, layers.Length);
             }
         }

--- a/tests/SixLabors.Fonts.Tests/Tables/General/HeadTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/HeadTableTests.cs
@@ -1,7 +1,8 @@
-﻿using System;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
 
+using System;
 using SixLabors.Fonts.Tables.General;
-
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Tables.General
@@ -13,12 +14,15 @@ namespace SixLabors.Fonts.Tests.Tables.General
         {
             var writer = new BinaryWriter();
 
-            writer.WriteHeadTable(new HeadTable(HeadTable.HeadFlags.None,
+            writer.WriteHeadTable(new HeadTable(
+                HeadTable.HeadFlags.None,
                 HeadTable.HeadMacStyle.Italic | HeadTable.HeadMacStyle.Bold,
                 1024,
                 new DateTime(2017, 02, 06, 07, 47, 00),
                 new DateTime(2017, 02, 07, 07, 47, 00),
-                new Bounds(0, 0, 1024, 1022), 0, HeadTable.IndexLocationFormats.Offset16));
+                new Bounds(0, 0, 1024, 1022),
+                0,
+                HeadTable.IndexLocationFormats.Offset16));
 
             var head = HeadTable.Load(writer.GetReader());
 

--- a/tests/SixLabors.Fonts.Tests/Tables/General/HorizontalHeadTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/HorizontalHeadTableTests.cs
@@ -1,5 +1,7 @@
-﻿using SixLabors.Fonts.Tables.General;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
 
+using SixLabors.Fonts.Tables.General;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Tables.General

--- a/tests/SixLabors.Fonts.Tests/Tables/General/IndexLocationTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/IndexLocationTableTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using SixLabors.Fonts.Exceptions;
 using SixLabors.Fonts.Tables;
@@ -16,10 +19,8 @@ namespace SixLabors.Fonts.Tests.Tables.General
 
             using (System.IO.MemoryStream stream = writer.GetStream())
             {
-                MissingFontTableException exception = Assert.Throws<MissingFontTableException>(() =>
-                {
-                    IndexLocationTable.Load(new FontReader(stream));
-                });
+                MissingFontTableException exception = Assert.Throws<MissingFontTableException>(
+                        () => IndexLocationTable.Load(new FontReader(stream)));
 
                 Assert.Equal("head", exception.Table);
             }
@@ -31,19 +32,20 @@ namespace SixLabors.Fonts.Tests.Tables.General
             var writer = new BinaryWriter();
             writer.WriteTrueTypeFileHeader(new TableHeader("head", 0, 0, 0));
 
-            writer.WriteHeadTable(new HeadTable(HeadTable.HeadFlags.None,
+            writer.WriteHeadTable(new HeadTable(
+                HeadTable.HeadFlags.None,
                 HeadTable.HeadMacStyle.Italic | HeadTable.HeadMacStyle.Bold,
                 1024,
                 new DateTime(2017, 02, 06, 07, 47, 00),
                 new DateTime(2017, 02, 07, 07, 47, 00),
-                new Bounds(0, 0, 1024, 1022), 0, HeadTable.IndexLocationFormats.Offset16));
+                new Bounds(0, 0, 1024, 1022),
+                0,
+                HeadTable.IndexLocationFormats.Offset16));
 
             using (System.IO.MemoryStream stream = writer.GetStream())
             {
-                InvalidFontTableException exception = Assert.Throws<InvalidFontTableException>(() =>
-                {
-                    IndexLocationTable.Load(new FontReader(stream));
-                });
+                InvalidFontTableException exception = Assert.Throws<InvalidFontTableException>(
+                    () => IndexLocationTable.Load(new FontReader(stream)));
 
                 Assert.Equal("maxp", exception.Table);
             }
@@ -55,12 +57,15 @@ namespace SixLabors.Fonts.Tests.Tables.General
             var writer = new BinaryWriter();
             writer.WriteTrueTypeFileHeader(new TableHeader("head", 0, 0, 0), new TableHeader("maxp", 0, 0, 0));
 
-            writer.WriteHeadTable(new HeadTable(HeadTable.HeadFlags.None,
+            writer.WriteHeadTable(new HeadTable(
+                HeadTable.HeadFlags.None,
                 HeadTable.HeadMacStyle.Italic | HeadTable.HeadMacStyle.Bold,
                 1024,
                 new DateTime(2017, 02, 06, 07, 47, 00),
                 new DateTime(2017, 02, 07, 07, 47, 00),
-                new Bounds(0, 0, 1024, 1022), 0, HeadTable.IndexLocationFormats.Offset16));
+                new Bounds(0, 0, 1024, 1022),
+                0,
+                HeadTable.IndexLocationFormats.Offset16));
 
             using (System.IO.MemoryStream stream = writer.GetStream())
             {

--- a/tests/SixLabors.Fonts.Tests/Tables/General/KerningTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/KerningTableTests.cs
@@ -1,4 +1,7 @@
-﻿using SixLabors.Fonts.Tables.General;
+﻿// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.Fonts.Tables.General;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Tables.General

--- a/tests/SixLabors.Fonts.Tests/Tables/General/MaximumProfileTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/MaximumProfileTableTests.cs
@@ -1,4 +1,8 @@
-﻿using SixLabors.Fonts.Exceptions;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.IO;
+using SixLabors.Fonts.Exceptions;
 using SixLabors.Fonts.Tables.General;
 using Xunit;
 
@@ -12,9 +16,10 @@ namespace SixLabors.Fonts.Tests.Tables.General
             var writer = new BinaryWriter();
             writer.WriteTrueTypeFileHeader();
 
-            using (System.IO.MemoryStream stream = writer.GetStream())
+            using (MemoryStream stream = writer.GetStream())
             {
-                InvalidFontTableException exception = Assert.Throws<InvalidFontTableException>(() => MaximumProfileTable.Load(new FontReader(stream)));
+                InvalidFontTableException exception = Assert.Throws<InvalidFontTableException>(
+                    () => MaximumProfileTable.Load(new FontReader(stream)));
 
                 Assert.Equal("maxp", exception.Table);
             }

--- a/tests/SixLabors.Fonts.Tests/Tables/General/NameTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/NameTableTests.cs
@@ -1,9 +1,11 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Collections.Generic;
 using System.Globalization;
 using SixLabors.Fonts.Exceptions;
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.WellKnownIds;
-
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Tables.General
@@ -15,16 +17,17 @@ namespace SixLabors.Fonts.Tests.Tables.General
         {
             var writer = new BinaryWriter();
 
-            writer.WriteNameTable(new Dictionary<NameIds, string>
-                                      {
-                { NameIds.CopyrightNotice, "copyright"},
-                { NameIds.FullFontName, "fullname" },
-                { NameIds.FontFamilyName, "family" },
-                { NameIds.FontSubfamilyName, "subfamily" },
-                { NameIds.UniqueFontID, "id" },
-                { (NameIds)90, "other1" },
-                { (NameIds)91, "other2" }
-                                      });
+            writer.WriteNameTable(
+                new Dictionary<NameIds, string>
+                {
+                    { NameIds.CopyrightNotice, "copyright" },
+                    { NameIds.FullFontName, "fullname" },
+                    { NameIds.FontFamilyName, "family" },
+                    { NameIds.FontSubfamilyName, "subfamily" },
+                    { NameIds.UniqueFontID, "id" },
+                    { (NameIds)90, "other1" },
+                    { (NameIds)91, "other2" }
+                });
 
             var table = NameTable.Load(writer.GetReader());
 
@@ -42,20 +45,22 @@ namespace SixLabors.Fonts.Tests.Tables.General
         {
             var writer = new BinaryWriter();
 
-            writer.WriteNameTable(new Dictionary<NameIds, string>
-                                      {
-                { NameIds.CopyrightNotice, "copyright"},
-                { NameIds.FullFontName, "fullname" },
-                { NameIds.FontFamilyName, "family" },
-                { NameIds.FontSubfamilyName, "subfamily" },
-                { NameIds.UniqueFontID, "id" },
-                { (NameIds)90, "other1" },
-                { (NameIds)91, "other2" }
-                                      }, new List<string>
-                                             {
-                                                 "lang1",
-                                                 "lang2"
-                                             });
+            writer.WriteNameTable(
+                new Dictionary<NameIds, string>
+                {
+                    { NameIds.CopyrightNotice, "copyright" },
+                    { NameIds.FullFontName, "fullname" },
+                    { NameIds.FontFamilyName, "family" },
+                    { NameIds.FontSubfamilyName, "subfamily" },
+                    { NameIds.UniqueFontID, "id" },
+                    { (NameIds)90, "other1" },
+                    { (NameIds)91, "other2" }
+                },
+                new List<string>
+                {
+                    "lang1",
+                    "lang2"
+                });
 
             var table = NameTable.Load(writer.GetReader());
 
@@ -76,7 +81,8 @@ namespace SixLabors.Fonts.Tests.Tables.General
 
             using (System.IO.MemoryStream stream = writer.GetStream())
             {
-                InvalidFontTableException exception = Assert.Throws<InvalidFontTableException>(() => NameTable.Load(new FontReader(stream)));
+                InvalidFontTableException exception = Assert.Throws<InvalidFontTableException>(
+                    () => NameTable.Load(new FontReader(stream)));
 
                 Assert.Equal("name", exception.Table);
             }

--- a/tests/SixLabors.Fonts.Tests/Tables/General/Os2TableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/Os2TableTests.cs
@@ -1,4 +1,7 @@
-﻿using SixLabors.Fonts.Tables.General;
+﻿// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.Fonts.Tables.General;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Tables.General

--- a/tests/SixLabors.Fonts.Tests/Tables/TableHeaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/TableHeaderTests.cs
@@ -1,4 +1,7 @@
-﻿using SixLabors.Fonts.Tables;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.Fonts.Tables;
 
 using Xunit;
 
@@ -6,12 +9,12 @@ namespace SixLabors.Fonts.Tests.Tables
 {
     public class TableHeaderTests
     {
-        public static TheoryData<string, uint, uint?, uint> ReadAllValuesData =
+        public static TheoryData<string, uint, uint?, uint> ReadAllValuesData { get; } =
             new TheoryData<string, uint, uint?, uint>
-                {
+            {
                 { "TAG1", 98, 18, 1218 },
                 { "TAG2", 198, 0, 121 },
-        };
+            };
 
         [Theory]
         [MemberData(nameof(ReadAllValuesData))]

--- a/tests/SixLabors.Fonts.Tests/Tables/TableLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/TableLoaderTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -36,10 +39,7 @@ namespace SixLabors.Fonts.Tests.Tables
         }
 
         [Fact]
-        public void DefaultIsnotNull()
-        {
-            Assert.NotNull(TableLoader.Default);
-        }
+        public void DefaultIsnotNull() => Assert.NotNull(TableLoader.Default);
 
         [Fact]
         public void TryingToLoadUnregisteredTagReturnsUnknownTable()
@@ -52,7 +52,6 @@ namespace SixLabors.Fonts.Tests.Tables
             UnknownTable table = Assert.IsType<UnknownTable>(result);
             Assert.Equal(tag, table.Name);
         }
-
 
         [Fact]
         public void NullForUnknownTypes()

--- a/tests/SixLabors.Fonts.Tests/TestFonts.cs
+++ b/tests/SixLabors.Fonts.Tests/TestFonts.cs
@@ -1,60 +1,72 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
+using Xunit;
 
 namespace SixLabors.Fonts.Tests
 {
-    using System.IO;
-    using System.Reflection;
-
-    using Xunit;
-
     public static class TestFonts
     {
-        private static Dictionary<string, Stream> cache = new Dictionary<string, Stream>();
+        private static readonly Dictionary<string, Stream> Cache = new Dictionary<string, Stream>();
 
         public static string TwemojiMozillaFile => GetFullPath("Twemoji Mozilla.ttf");
 
         public static string CarterOneFile => GetFullPath("Carter_One/CarterOne.ttf");
+
         public static string WendyOneFile => GetFullPath("Wendy_One/WendyOne-Regular.ttf");
+
         public static string OpenSansFile => GetFullPath("OpenSans-Regular.ttf");
+
         public static string SimpleFontFile => GetFullPath("SixLaborsSampleAB.ttf");
+
         public static string SimpleFontFileWoff => GetFullPath("SixLaborsSampleAB.woff");
 
         public static string SimpleTrueTypeCollection => GetFullPath("Sample.ttc");
 
         public static Stream TwemojiMozillaData() => OpenStream(TwemojiMozillaFile);
+
         public static Stream WendyOneFileData() => OpenStream(WendyOneFile);
+
         public static Stream CarterOneFileData() => OpenStream(CarterOneFile);
+
         public static Stream SimpleFontFileData() => OpenStream(SimpleFontFile);
+
         public static Stream OpenSansData() => OpenStream(OpenSansFile);
+
         public static Stream SimpleFontFileWoffData() => OpenStream(SimpleFontFileWoff);
+
         public static Stream SSimpleTrueTypeCollectionData() => OpenStream(SimpleTrueTypeCollection);
 
         public static class Issues
         {
             public static string Issue96File => GetFullPath("Issues/Issue96.fuzz");
+
             public static string Issue97File => GetFullPath("Issues/Issue97.fuzz");
         }
 
         private static Stream OpenStream(string path)
         {
-            if (cache.ContainsKey(path))
+            if (Cache.ContainsKey(path))
             {
-                return cache[path].Clone();
+                return Cache[path].Clone();
             }
 
-            lock (cache)
+            lock (Cache)
             {
-                if (cache.ContainsKey(path))
+                if (Cache.ContainsKey(path))
                 {
-                    return cache[path].Clone();
+                    return Cache[path].Clone();
                 }
 
                 using (FileStream fs = File.OpenRead(path))
                 {
-                    cache.Add(path, fs.Clone());
-                    return cache[path].Clone();
+                    Cache.Add(path, fs.Clone());
+                    return Cache[path].Clone();
                 }
             }
         }

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -14,7 +17,7 @@ namespace SixLabors.Fonts.Tests
         {
             Font font = CreateFont("hello world");
             Glyph glyph = font.GetGlyph('h');
-            Assert.NotEqual(default(Glyph), glyph);
+            Assert.NotEqual(default, glyph);
         }
 
         [Theory]
@@ -66,12 +69,13 @@ namespace SixLabors.Fonts.Tests
         public void VerticalAlignmentTests(
             VerticalAlignment vertical,
             HorizontalAlignment horizental,
-            float top, float left)
+            float top,
+            float left)
         {
             string text = "hello world\nhello";
             Font font = CreateFont(text);
 
-            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
+            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px
             var span = new RendererOptions(font, scaleFactor)
             {
                 HorizontalAlignment = horizental,
@@ -80,7 +84,7 @@ namespace SixLabors.Fonts.Tests
 
             IReadOnlyList<GlyphLayout> glyphsToRender = new TextLayout().GenerateLayout(text.AsSpan(), span);
             IFontInstance fontInst = span.Font.Instance;
-            float lineHeight = (fontInst.LineHeight * span.Font.Size) / (fontInst.EmSize * 72);
+            float lineHeight = fontInst.LineHeight * span.Font.Size / (fontInst.EmSize * 72);
             lineHeight *= scaleFactor;
             FontRectangle bound = TextMeasurer.GetBounds(glyphsToRender, new Vector2(span.DpiX, span.DpiY));
 
@@ -90,15 +94,21 @@ namespace SixLabors.Fonts.Tests
             Assert.Equal(top, bound.Top, 3);
         }
 
-
         [Fact]
         public unsafe void MeasureTextWithSpan()
         {
             Font font = CreateFont("hello");
 
-            Span<char> text = stackalloc char[] { 'h', 'e', 'l', 'l', 'o' };
+            Span<char> text = stackalloc char[]
+            {
+                'h',
+                'e',
+                'l',
+                'l',
+                'o'
+            };
 
-            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
+            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px
 
             FontRectangle size = TextMeasurer.MeasureBounds(text, new RendererOptions(font, 72 * font.EmSize));
 
@@ -118,7 +128,7 @@ namespace SixLabors.Fonts.Tests
         {
             Font font = CreateFont(text);
 
-            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
+            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px
             FontRectangle size = TextMeasurer.MeasureBounds(text, new RendererOptions(font, 72 * font.EmSize));
 
             Assert.Equal(height, size.Height, 4);
@@ -129,7 +139,8 @@ namespace SixLabors.Fonts.Tests
         public void TryMeasureCharacterBounds()
         {
             string text = "a b\nc";
-            var expectedGlyphMetrics = new GlyphMetric[] {
+            var expectedGlyphMetrics = new GlyphMetric[]
+            {
                 new GlyphMetric('a', new FontRectangle(10, 0, 10, 10), false),
                 new GlyphMetric(' ', new FontRectangle(40, 0, 30, 10), false),
                 new GlyphMetric('b', new FontRectangle(70, 0, 10, 10), false),
@@ -138,7 +149,7 @@ namespace SixLabors.Fonts.Tests
             };
             Font font = CreateFont(text);
 
-            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
+            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px
             Assert.True(TextMeasurer.TryMeasureCharacterBounds(text.AsSpan(), new RendererOptions(font, 72 * font.EmSize), out GlyphMetric[] glyphMetrics));
 
             Assert.Equal(text.Length, glyphMetrics.Length);
@@ -148,6 +159,7 @@ namespace SixLabors.Fonts.Tests
                 GlyphMetric actual = glyphMetrics[i];
                 Assert.Equal(expected.Character, actual.Character);
                 Assert.Equal(expected.IsControlCharacter, actual.IsControlCharacter);
+
                 // 4 dp as there is minor offset difference in the float values
                 Assert.Equal(expected.Bounds.X, actual.Bounds.X, 4);
                 Assert.Equal(expected.Bounds.Y, actual.Bounds.Y, 4);
@@ -158,14 +170,15 @@ namespace SixLabors.Fonts.Tests
 
         [Theory]
         [InlineData("hello world", 10, 310)]
-        [InlineData("hello world hello world hello world",
+        [InlineData(
+            "hello world hello world hello world",
             70, // 30 actual line height * 2 + 10 actual height
             310)]
         public void MeasureTextWordWrapping(string text, float height, float width)
         {
             Font font = CreateFont(text);
 
-            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
+            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px
             FontRectangle size = TextMeasurer.MeasureBounds(text, new RendererOptions(font, 72 * font.EmSize)
             {
                 WrappingWidth = 350
@@ -185,7 +198,7 @@ namespace SixLabors.Fonts.Tests
             var c = new FontCollection();
             Font font = c.Install(TestFonts.SimpleFontFileData()).CreateFont(12);
 
-            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
+            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px
             FontRectangle size = TextMeasurer.MeasureBounds(text, new RendererOptions(new Font(font, 1), 72 * font.EmSize) { ApplyKerning = enableKerning });
 
             Assert.Equal(height, size.Height, 4);
@@ -199,7 +212,7 @@ namespace SixLabors.Fonts.Tests
             var c = new FontCollection();
             Font font = c.Install(TestFonts.SimpleFontFileData()).CreateFont(12);
 
-            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px 
+            int scaleFactor = 72 * font.EmSize; // 72 * emSize means 1 point = 1px
             var glyphRenderer = new GlyphRenderer();
             var renderer = new TextRenderer(glyphRenderer);
             renderer.RenderText(text, new RendererOptions(new Font(font, 1), 72 * font.EmSize, new Vector2(x, y)));

--- a/tests/SixLabors.Fonts.Tests/TrueTypeCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TrueTypeCollectionTests.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Xunit;
@@ -9,45 +13,45 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void InstallViaPathReturnsDecription()
         {
-            var sut = new FontCollection();
-            var collectionFromPath = sut.InstallCollection(TestFonts.SimpleTrueTypeCollection, out var descriptions);
+            var suit = new FontCollection();
+            IEnumerable<FontFamily> collectionFromPath = suit.InstallCollection(TestFonts.SimpleTrueTypeCollection, out IEnumerable<FontDescription> descriptions);
 
             Assert.Equal(2, descriptions.Count());
-            var openSans = Assert.Single(collectionFromPath, x => x.Name == "Open Sans");
-            var abFont = Assert.Single(collectionFromPath, x => x.Name == "SixLaborsSampleAB");
+            FontFamily openSans = Assert.Single(collectionFromPath, x => x.Name == "Open Sans");
+            FontFamily abFont = Assert.Single(collectionFromPath, x => x.Name == "SixLaborsSampleAB");
 
             Assert.Equal(2, descriptions.Count());
-            var openSansDescription = Assert.Single(descriptions, x => x.FontNameInvariantCulture == "Open Sans");
-            var abFontDescription = Assert.Single(descriptions, x => x.FontNameInvariantCulture == "SixLaborsSampleAB regular");
+            FontDescription openSansDescription = Assert.Single(descriptions, x => x.FontNameInvariantCulture == "Open Sans");
+            FontDescription abFontDescription = Assert.Single(descriptions, x => x.FontNameInvariantCulture == "SixLaborsSampleAB regular");
         }
 
         [Fact]
         public void InstallViaPathInstallFontFileInstances()
         {
             var sut = new FontCollection();
-            var collectionFromPath = sut.InstallCollection(TestFonts.SimpleTrueTypeCollection, out var descriptions);
+            IEnumerable<FontFamily> collectionFromPath = sut.InstallCollection(TestFonts.SimpleTrueTypeCollection, out IEnumerable<FontDescription> descriptions);
 
-            var allInstances = sut.Families.SelectMany(x => sut.FindAll(x.Name, CultureInfo.InvariantCulture));
+            IEnumerable<IFontInstance> allInstances = sut.Families.SelectMany(x => sut.FindAll(x.Name, CultureInfo.InvariantCulture));
 
             Assert.All(allInstances, i =>
             {
-                var font = Assert.IsType<FileFontInstance>(i);
+                FileFontInstance font = Assert.IsType<FileFontInstance>(i);
             });
         }
 
         [Fact]
         public void InstallViaStreamhReturnsDecription()
         {
-            var sut = new FontCollection();
-            var collectionFromPath = sut.InstallCollection(TestFonts.SSimpleTrueTypeCollectionData(), out var descriptions);
+            var suit = new FontCollection();
+            IEnumerable<FontFamily> collectionFromPath = suit.InstallCollection(TestFonts.SSimpleTrueTypeCollectionData(), out IEnumerable<FontDescription> descriptions);
 
             Assert.Equal(2, collectionFromPath.Count());
-            var openSans = Assert.Single(collectionFromPath, x => x.Name == "Open Sans");
-            var abFont = Assert.Single(collectionFromPath, x => x.Name == "SixLaborsSampleAB");
+            FontFamily openSans = Assert.Single(collectionFromPath, x => x.Name == "Open Sans");
+            FontFamily abFont = Assert.Single(collectionFromPath, x => x.Name == "SixLaborsSampleAB");
 
             Assert.Equal(2, descriptions.Count());
-            var openSansDescription = Assert.Single(descriptions, x => x.FontNameInvariantCulture == "Open Sans");
-            var abFontDescription = Assert.Single(descriptions, x => x.FontNameInvariantCulture == "SixLaborsSampleAB regular");
+            FontDescription openSansDescription = Assert.Single(descriptions, x => x.FontNameInvariantCulture == "Open Sans");
+            FontDescription abFontDescription = Assert.Single(descriptions, x => x.FontNameInvariantCulture == "SixLaborsSampleAB regular");
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- Migrates to new props/targets setup
- Cleanup of src/tests/samples
- Add macOS to CI builds.

Contains no functional changes.
<!-- Thanks for contributing to SixLabors.Fonts! -->
