### PR TITLE
Fix FontFamily Equality checks 

### DIFF
--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using SixLabors.Fonts.Exceptions;
 using SixLabors.Fonts.Tables;
 
@@ -172,9 +171,7 @@ namespace SixLabors.Fonts
 #endif
 
         private FontFamily InstallInternal(string path, CultureInfo culture)
-        {
-            return this.InstallInternal(path, culture, out _);
-        }
+            => this.InstallInternal(path, culture, out _);
 
         private FontFamily InstallInternal(string path, CultureInfo culture, out FontDescription fontDescription)
         {
@@ -184,9 +181,7 @@ namespace SixLabors.Fonts
         }
 
         private FontFamily InstallInternal(Stream fontStream, CultureInfo culture)
-        {
-            return this.InstallInternal(fontStream, culture, out _);
-        }
+            => this.InstallInternal(fontStream, culture, out _);
 
         private FontFamily InstallInternal(Stream fontStream, CultureInfo culture, out FontDescription fontDescription)
         {
@@ -197,9 +192,7 @@ namespace SixLabors.Fonts
         }
 
         private IEnumerable<FontFamily> InstallCollectionInternal(string fontCollectionPath, CultureInfo culture)
-        {
-            return this.InstallCollectionInternal(fontCollectionPath, culture, out _);
-        }
+            => this.InstallCollectionInternal(fontCollectionPath, culture, out _);
 
         private IEnumerable<FontFamily> InstallCollectionInternal(string fontCollectionPath, CultureInfo culture, out IEnumerable<FontDescription> fontDescriptions)
         {
@@ -244,13 +237,13 @@ namespace SixLabors.Fonts
             => this.FindInternal(fontFamily, culture);
 
         /// <inheritdoc />
-        public bool TryFind(string fontFamily, CultureInfo culture, [NotNullWhen(true)]out FontFamily? family)
+        public bool TryFind(string fontFamily, CultureInfo culture, [NotNullWhen(true)] out FontFamily? family)
             => this.TryFindInternal(fontFamily, culture, out family);
 #endif
 
         private FontFamily FindInternal(string fontFamily, CultureInfo culture)
         {
-            if (this.TryFindInternal(fontFamily, culture, out var result))
+            if (this.TryFindInternal(fontFamily, culture, out FontFamily? result))
             {
                 return result;
             }
@@ -258,12 +251,12 @@ namespace SixLabors.Fonts
             throw new FontFamilyNotFoundException(fontFamily);
         }
 
-        private bool TryFindInternal(string fontFamily, CultureInfo culture, [NotNullWhen(true)]out FontFamily? family)
+        private bool TryFindInternal(string fontFamily, CultureInfo culture, [NotNullWhen(true)] out FontFamily? family)
         {
-            var comparer = StringComparerHelpers.GetCaseInsenativeStringComparer(culture);
+            StringComparer? comparer = StringComparerHelpers.GetCaseInsensitiveStringComparer(culture);
             family = null!; // make the compiler shutup
 
-            var familyName = this.instances
+            string? familyName = this.instances
                 .Select(x => x.Description.FontFamily(culture))
                 .FirstOrDefault(x => comparer.Equals(x, fontFamily));
             if (familyName == null)
@@ -280,13 +273,11 @@ namespace SixLabors.Fonts
             => this.FindInternal(fontFamily, CultureInfo.InvariantCulture);
 
         /// <inheritdoc />
-        public bool TryFind(string fontFamily, [NotNullWhen(true)]out FontFamily? family)
+        public bool TryFind(string fontFamily, [NotNullWhen(true)] out FontFamily? family)
             => this.TryFindInternal(fontFamily, CultureInfo.InvariantCulture, out family);
 
         internal IEnumerable<FontStyle> AvailableStyles(string fontFamily, CultureInfo culture)
-        {
-            return this.FindAll(fontFamily, culture).Select(x => x.Description.Style).ToArray();
-        }
+            => this.FindAll(fontFamily, culture).Select(x => x.Description.Style).ToArray();
 
         internal FontFamily Install(IFontInstance instance, CultureInfo culture)
         {
@@ -309,20 +300,16 @@ namespace SixLabors.Fonts
         }
 
         internal IFontInstance? Find(string fontFamily, CultureInfo culture, FontStyle style)
-        {
-            return this.FindAll(fontFamily, culture)
-                        .FirstOrDefault(x => x.Description.Style == style);
-        }
+            => this.FindAll(fontFamily, culture)
+            .FirstOrDefault(x => x.Description.Style == style);
 
         internal IEnumerable<IFontInstance> FindAll(string name, CultureInfo culture)
         {
-            var comparer = StringComparerHelpers.GetCaseInsenativeStringComparer(culture);
+            StringComparer? comparer = StringComparerHelpers.GetCaseInsensitiveStringComparer(culture);
 
-            var instances = this.instances
-                                .Where(x => comparer.Equals(x.Description.FontFamily(culture), name))
-                                .ToArray();
-
-            return instances;
+            return this.instances
+                .Where(x => comparer.Equals(x.Description.FontFamily(culture), name))
+                .ToArray();
         }
     }
 }

--- a/src/SixLabors.Fonts/FontFamily.cs
+++ b/src/SixLabors.Fonts/FontFamily.cs
@@ -98,7 +98,7 @@ namespace SixLabors.Fonts
         public override int GetHashCode()
         {
             StringComparer? comparer = StringComparerHelpers.GetCaseInsensitiveStringComparer(this.Culture);
-            return HashCode.Combine(this.collection, this.Culture) ^ comparer.GetHashCode(this.Name);
+            return HashCode.Combine(this.collection, this.Culture, this.DefaultStyle, this.AvailableStyles) ^ comparer.GetHashCode(this.Name);
         }
     }
 }

--- a/src/SixLabors.Fonts/FontFamily.cs
+++ b/src/SixLabors.Fonts/FontFamily.cs
@@ -11,7 +11,7 @@ namespace SixLabors.Fonts
     /// <summary>
     /// Defines a group of type faces having a similar basic design and certain variations in styles. This class cannot be inherited.
     /// </summary>
-    public sealed class FontFamily
+    public sealed class FontFamily : IEquatable<FontFamily?>
     {
         private readonly FontCollection collection;
 
@@ -58,6 +58,30 @@ namespace SixLabors.Fonts
             ? FontStyle.Regular
             : this.AvailableStyles.First();
 
+        /// <summary>
+        /// Compares two <see cref="FontFamily"/> objects for equality.
+        /// </summary>
+        /// <param name="left">The <see cref="FontFamily"/> on the left side of the operand.</param>
+        /// <param name="right">The <see cref="FontFamily"/> on the right side of the operand.</param>
+        /// <returns>
+        /// <see langword="true"/> if the current left is equal to the <paramref name="right"/>
+        /// parameter; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator ==(FontFamily? left, FontFamily? right)
+            => EqualityComparer<FontFamily?>.Default.Equals(left, right);
+
+        /// <summary>
+        /// Compares two <see cref="FontFamily"/> objects for inequality.
+        /// </summary>
+        /// <param name="left">The <see cref="FontFamily"/> on the left side of the operand.</param>
+        /// <param name="right">The <see cref="FontFamily"/> on the right side of the operand.</param>
+        /// <returns>
+        /// <see langword="true"/> if the current left is unequal to the <paramref name="right"/>
+        /// parameter; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator !=(FontFamily? left, FontFamily? right)
+            => !(left == right);
+
         internal IFontInstance? Find(FontStyle style)
             => this.collection.Find(this.Name, this.Culture, style);
 
@@ -79,26 +103,30 @@ namespace SixLabors.Fonts
         public override string ToString() => this.Name;
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
-        {
-            if (obj is FontFamily other)
-            {
-                StringComparer? comparer = StringComparerHelpers.GetCaseInsensitiveStringComparer(this.Culture);
-                return this.collection == other.collection
-                    && this.Culture == other.Culture
-                    && this.DefaultStyle == other.DefaultStyle
-                    && this.AvailableStyles.SequenceEqual(other.AvailableStyles)
-                    && comparer.Equals(this.Name, other.Name);
-            }
-
-            return base.Equals(obj);
-        }
-
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             StringComparer? comparer = StringComparerHelpers.GetCaseInsensitiveStringComparer(this.Culture);
             return HashCode.Combine(this.collection, this.Culture, this.DefaultStyle, this.AvailableStyles) ^ comparer.GetHashCode(this.Name);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+            => this.Equals(obj as FontFamily);
+
+        /// <inheritdoc/>
+        public bool Equals(FontFamily? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            StringComparer? comparer = StringComparerHelpers.GetCaseInsensitiveStringComparer(this.Culture);
+            return this.collection == other.collection
+                && this.Culture == other.Culture
+                && this.DefaultStyle == other.DefaultStyle
+                && this.AvailableStyles.SequenceEqual(other.AvailableStyles)
+                && comparer.Equals(this.Name, other.Name);
         }
     }
 }

--- a/src/SixLabors.Fonts/FontFamily.cs
+++ b/src/SixLabors.Fonts/FontFamily.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace SixLabors.Fonts
 {
@@ -51,36 +50,16 @@ namespace SixLabors.Fonts
         /// <value>
         /// The available styles.
         /// </value>
-        public IEnumerable<FontStyle> AvailableStyles => this.collection.AvailableStyles(this.Name, this.Culture);
+        public IEnumerable<FontStyle> AvailableStyles
+            => this.collection.AvailableStyles(this.Name, this.Culture);
 
-        internal FontStyle DefaultStyle => this.IsStyleAvailable(FontStyle.Regular) ? FontStyle.Regular : this.AvailableStyles.First();
-
-        /// <summary>
-        /// Compares two <see cref="FontFamily"/> objects for equality.
-        /// </summary>
-        /// <param name="left">The <see cref="FontFamily"/> on the left side of the operand.</param>
-        /// <param name="right">The <see cref="FontFamily"/> on the right side of the operand.</param>
-        /// <returns>
-        /// True if the current left is equal to the <paramref name="right"/> parameter; otherwise, false.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator ==(FontFamily left, FontFamily right) => left.Equals(right);
-
-        /// <summary>
-        /// Compares two <see cref="FontRectangle"/> objects for inequality.
-        /// </summary>
-        /// <param name="left">The <see cref="FontRectangle"/> on the left side of the operand.</param>
-        /// <param name="right">The <see cref="FontRectangle"/> on the right side of the operand.</param>
-        /// <returns>
-        /// True if the current left is unequal to the <paramref name="right"/> parameter; otherwise, false.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator !=(FontFamily left, FontFamily right) => !left.Equals(right);
+        internal FontStyle DefaultStyle
+            => this.IsStyleAvailable(FontStyle.Regular)
+            ? FontStyle.Regular
+            : this.AvailableStyles.First();
 
         internal IFontInstance? Find(FontStyle style)
-        {
-            return this.collection.Find(this.Name, this.Culture, style);
-        }
+            => this.collection.Find(this.Name, this.Culture, style);
 
         /// <summary>
         /// Determines whether the specified <see cref="FontStyle"/> is available.
@@ -104,17 +83,21 @@ namespace SixLabors.Fonts
         {
             if (obj is FontFamily other)
             {
-                var comparer = StringComparerHelpers.GetCaseInsenativeStringComparer(this.Culture);
-                return this.collection == other?.collection && this.Culture == other?.Culture && comparer.Equals(this.Name, other?.Name);
+                StringComparer? comparer = StringComparerHelpers.GetCaseInsensitiveStringComparer(this.Culture);
+                return this.collection == other.collection
+                    && this.Culture == other.Culture
+                    && this.DefaultStyle == other.DefaultStyle
+                    && this.AvailableStyles.SequenceEqual(other.AvailableStyles)
+                    && comparer.Equals(this.Name, other.Name);
             }
 
-            return false;
+            return base.Equals(obj);
         }
 
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            var comparer = StringComparerHelpers.GetCaseInsenativeStringComparer(this.Culture);
+            StringComparer? comparer = StringComparerHelpers.GetCaseInsensitiveStringComparer(this.Culture);
             return HashCode.Combine(this.collection, this.Culture) ^ comparer.GetHashCode(this.Name);
         }
     }

--- a/src/SixLabors.Fonts/StringComparerHelpers.cs
+++ b/src/SixLabors.Fonts/StringComparerHelpers.cs
@@ -2,21 +2,18 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 
 namespace SixLabors.Fonts
 {
-    internal class StringComparerHelpers
+    internal static class StringComparerHelpers
     {
-        public static StringComparer GetCaseInsenativeStringComparer(CultureInfo culture)
-        {
+        public static StringComparer GetCaseInsensitiveStringComparer(CultureInfo culture)
 #if SUPPORTS_CULTUREINFO_LCID
-            return StringComparer.Create(culture, true);
+        => StringComparer.Create(culture, true);
 #else
-            return StringComparer.OrdinalIgnoreCase;
+        => StringComparer.OrdinalIgnoreCase;
 #endif
-        }
+
     }
 }

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -82,19 +82,22 @@ namespace SixLabors.Fonts
         /// </value>
         public IEnumerable<FontFamily> Families => this.collection.Families;
 
-        /// <inheritdocs />
+        /// <inheritdoc />
         public FontFamily Find(string fontFamily) => this.collection.Find(fontFamily);
 
-        /// <inheritdocs />
+        /// <inheritdoc />
         public bool TryFind(string fontFamily, [NotNullWhen(true)] out FontFamily? family) => this.collection.TryFind(fontFamily, out family);
 
 #if SUPPORTS_CULTUREINFO_LCID
+        /// <inheritdoc />
         public IEnumerable<FontFamily> FamiliesByCulture(CultureInfo culture)
             => this.collection.FamiliesByCulture(culture);
 
+        /// <inheritdoc />
         public FontFamily Find(string fontFamily, CultureInfo culture)
             => this.collection.Find(fontFamily, culture);
 
+        /// <inheritdoc />
         public bool TryFind(string fontFamily, CultureInfo culture, [NotNullWhen(true)] out FontFamily? family)
             => this.collection.TryFind(fontFamily, culture, out family);
 #endif

--- a/tests/SixLabors.Fonts.Tests/FontFamilyTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontFamilyTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Linq;
+using Xunit;
+
+namespace SixLabors.Fonts.Tests
+{
+    public class FontFamilyTests
+    {
+        private readonly FontFamily[] families = new SystemFontCollection().Families.ToArray();
+
+        [Fact]
+        public void EqualNullTests()
+        {
+            FontFamily fontFamily = null;
+            Assert.True(fontFamily == null);
+            Assert.False(fontFamily != null);
+
+            fontFamily = this.families[0];
+            Assert.True(fontFamily != null);
+            Assert.False(fontFamily == null);
+            Assert.False(fontFamily.Equals(null));
+        }
+
+        [Fact]
+        public void EqualTests()
+        {
+            FontFamily fontFamily = this.families[0];
+            FontFamily fontFamily2 = this.families[0];
+
+            Assert.True(fontFamily == fontFamily2);
+            Assert.False(fontFamily != fontFamily2);
+            Assert.True(fontFamily.Equals(fontFamily2));
+        }
+
+        [Fact]
+        public void NotEqualTests()
+        {
+            FontFamily fontFamily = this.families[0];
+            FontFamily fontFamily2 = this.families[1];
+
+            Assert.False(fontFamily == fontFamily2);
+            Assert.True(fontFamily != fontFamily2);
+            Assert.False(fontFamily.Equals(fontFamily2));
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Removes the custom equality operators ([_Not recommended for reference types_](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1046)), adds some missing value type checks to `Equals(object)` and `GetHashCode` + minor style cleanup.

Fixes #143

<!-- Thanks for contributing to SixLabors.Fonts! -->
