### PR TITLE
Fix transform for signed bytes loading composite glyphs

### DIFF
--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -40,7 +40,6 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             RenderText(font2, "😀 Hello World! 😀", pointSize: 72, fallbackFonts: new[] { emojiFont });
 
             //// general
-
             RenderText(font, "abc", 72);
             RenderText(font, "ABd", 72);
             RenderText(fontWoff, "abe", 72);
@@ -107,6 +106,9 @@ namespace SixLabors.Fonts.DrawWithImageSharp
 
             FontFamily simsum = SystemFonts.Find("SimSun");
             RenderText(simsum, "这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 16);
+
+            FontFamily arial = SystemFonts.Find("Arial");
+            RenderText(arial, "ìíîï", 72);
         }
 
         public static void RenderText(Font font, string text, int width, int height)

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
@@ -19,6 +19,25 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
             this.bounds = bounds;
         }
 
+        /*
+         ## Composite Glyph Flags
+
+        | Mask   | Name                     | Description
+        |--------|--------------------------|--------------------
+        | 0x0001 | ARG_1_AND_2_ARE_WORDS    | Bit 0: If this is set, the arguments are 16-bit (uint16 or int16); otherwise, they are bytes (uint8 or int8). 
+        | 0x0002 | ARGS_ARE_XY_VALUES       | Bit 1: If this is set, the arguments are signed xy values; otherwise, they are unsigned point numbers.
+        | 0x0004 | ROUND_XY_TO_GRID         | Bit 2: For the xy values if the preceding is true.
+        | 0x0008 | WE_HAVE_A_SCALE          | Bit 3: This indicates that there is a simple scale for the component. Otherwise, scale = 1.0.
+        | 0x0020 | MORE_COMPONENTS          | Bit 5: Indicates at least one more glyph after this one.
+        | 0x0040 | WE_HAVE_AN_X_AND_Y_SCALE | Bit 6: The x direction will use a different scale from the y direction.
+        | 0x0080 | WE_HAVE_A_TWO_BY_TWO     | Bit 7: There is a 2 by 2 transformation that will be used to scale the component.
+        | 0x0100 | WE_HAVE_INSTRUCTIONS     | Bit 8: Following the last component are instructions for the composite character.
+        | 0x0200 | USE_MY_METRICS           | Bit 9: If set, this forces the aw and lsb (and rsb) for the composite to be equal to those from this original glyph. This works for hinted and unhinted characters.
+        | 0x0400 | OVERLAP_COMPOUND         | Bit 10: If set, the components of the compound glyph overlap. Use of this flag is not required in OpenType — that is, it is valid to have components overlap without having this flag set. It may affect behaviors in some platforms, however. (See Apple’s specification for details regarding behavior in Apple platforms.) When used, it must be set on the flag word for the first component. See additional remarks, above, for the similar OVERLAP_SIMPLE flag used in simple-glyph descriptions.
+        | 0x0800 | SCALED_COMPONENT_OFFSET  | Bit 11: The composite is designed to have the component offset scaled.
+        | 0x1000 | UNSCALED_COMPONENT_OFFSET| Bit 12: The composite is designed not to have the component offset scaled.
+        | 0xE010 | Reserved                 | Bits 4, 13, 14 and 15 are reserved: set to 0.
+         */
         [Flags]
         private enum CompositeFlags : ushort
         {
@@ -78,34 +97,7 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
                 flags = (CompositeFlags)reader.ReadUInt16();
                 glyphIndex = reader.ReadUInt16();
 
-                short dx;
-                short dy;
-                if (flags.HasFlag(CompositeFlags.ArgsAreWords))
-                {
-                    if (flags.HasFlag(CompositeFlags.ArgsAreXYValues))
-                    {
-                        dx = reader.ReadInt16();
-                        dy = reader.ReadInt16();
-                    }
-                    else
-                    {
-                        dx = (short)reader.ReadUInt16();
-                        dy = (short)reader.ReadUInt16();
-                    }
-                }
-                else
-                {
-                    if (flags.HasFlag(CompositeFlags.ArgsAreXYValues))
-                    {
-                        dx = reader.ReadSByte();
-                        dy = reader.ReadSByte();
-                    }
-                    else
-                    {
-                        dx = reader.ReadByte();
-                        dy = reader.ReadByte();
-                    }
-                }
+                LoadArguments(reader, flags, out short dx, out short dy);
 
                 Matrix3x2 transform = Matrix3x2.Identity;
                 transform.Translation = new Vector2(dx, dy);
@@ -138,6 +130,45 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
             }
 
             return new CompositeGlyphLoader(result, bounds);
+        }
+
+        private static void LoadArguments(BigEndianBinaryReader reader, CompositeFlags flags, out short dx, out short dy)
+        {
+            // are we 16 or 8 bits values?
+            if (flags.HasFlag(CompositeFlags.ArgsAreWords))
+            {
+                // 16 bit
+                // are we int or unit?
+                if (flags.HasFlag(CompositeFlags.ArgsAreXYValues))
+                {
+                    // signed
+                    dx = reader.ReadInt16();
+                    dy = reader.ReadInt16();
+                }
+                else
+                {
+                    // unsigned
+                    dx = (short)reader.ReadUInt16();
+                    dy = (short)reader.ReadUInt16();
+                }
+            }
+            else
+            {
+                // 8 bit
+                // are we sbyte or byte?
+                if (flags.HasFlag(CompositeFlags.ArgsAreXYValues))
+                {
+                    // signed
+                    dx = reader.ReadSByte();
+                    dy = reader.ReadSByte();
+                }
+                else
+                {
+                    // unsigned
+                    dx = reader.ReadByte();
+                    dy = reader.ReadByte();
+                }
+            }
         }
 
         public readonly struct Composite

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
@@ -24,7 +24,7 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
 
         | Mask   | Name                     | Description
         |--------|--------------------------|--------------------
-        | 0x0001 | ARG_1_AND_2_ARE_WORDS    | Bit 0: If this is set, the arguments are 16-bit (uint16 or int16); otherwise, they are bytes (uint8 or int8). 
+        | 0x0001 | ARG_1_AND_2_ARE_WORDS    | Bit 0: If this is set, the arguments are 16-bit (uint16 or int16); otherwise, they are bytes (uint8 or int8).
         | 0x0002 | ARGS_ARE_XY_VALUES       | Bit 1: If this is set, the arguments are signed xy values; otherwise, they are unsigned point numbers.
         | 0x0004 | ROUND_XY_TO_GRID         | Bit 2: For the xy values if the preceding is true.
         | 0x0008 | WE_HAVE_A_SCALE          | Bit 3: This indicates that there is a simple scale for the component. Otherwise, scale = 1.0.

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
@@ -78,32 +78,33 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
                 flags = (CompositeFlags)reader.ReadUInt16();
                 glyphIndex = reader.ReadUInt16();
 
-                short arg1;
-                short arg2;
-                if (flags.HasFlag(CompositeFlags.ArgsAreWords))
-                {
-                    arg1 = reader.ReadInt16();
-                    arg2 = reader.ReadInt16();
-                }
-                else
-                {
-                    arg1 = reader.ReadByte();
-                    arg2 = reader.ReadByte();
-                }
-
                 short dx;
                 short dy;
-                if (flags.HasFlag(CompositeFlags.ArgsAreXYValues))
+                if (flags.HasFlag(CompositeFlags.ArgsAreWords))
                 {
-                    dx = arg1;
-                    dy = arg2;
+                    if (flags.HasFlag(CompositeFlags.ArgsAreXYValues))
+                    {
+                        dx = reader.ReadInt16();
+                        dy = reader.ReadInt16();
+                    }
+                    else
+                    {
+                        dx = (short)reader.ReadUInt16();
+                        dy = (short)reader.ReadUInt16();
+                    }
                 }
                 else
                 {
-                    // args are points to be matched
-                    // TODO: Implement
-                    dx = 0;
-                    dy = 0;
+                    if (flags.HasFlag(CompositeFlags.ArgsAreXYValues))
+                    {
+                        dx = reader.ReadSByte();
+                        dy = reader.ReadSByte();
+                    }
+                    else
+                    {
+                        dx = reader.ReadByte();
+                        dy = reader.ReadByte();
+                    }
                 }
 
                 Matrix3x2 transform = Matrix3x2.Identity;

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/CompositeGlyphLoader.cs
@@ -39,7 +39,7 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
         | 0xE010 | Reserved                 | Bits 4, 13, 14 and 15 are reserved: set to 0.
          */
         [Flags]
-        private enum CompositeFlags : ushort
+        internal enum CompositeFlags : ushort
         {
             ArgsAreWords = 1,    // If this is set, the arguments are words; otherwise, they are bytes.
             ArgsAreXYValues = 2, // If this is set, the arguments are xy values; otherwise, they are points.
@@ -97,10 +97,11 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
                 flags = (CompositeFlags)reader.ReadUInt16();
                 glyphIndex = reader.ReadUInt16();
 
-                LoadArguments(reader, flags, out short dx, out short dy);
+                LoadArguments(reader, flags, out int dx, out int dy);
 
                 Matrix3x2 transform = Matrix3x2.Identity;
                 transform.Translation = new Vector2(dx, dy);
+
                 if (flags.HasFlag(CompositeFlags.WeHaveAScale))
                 {
                     float scale = reader.ReadF2dot14(); // Format 2.14
@@ -132,7 +133,7 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
             return new CompositeGlyphLoader(result, bounds);
         }
 
-        private static void LoadArguments(BigEndianBinaryReader reader, CompositeFlags flags, out short dx, out short dy)
+        private static void LoadArguments(BigEndianBinaryReader reader, CompositeFlags flags, out int dx, out int dy)
         {
             // are we 16 or 8 bits values?
             if (flags.HasFlag(CompositeFlags.ArgsAreWords))
@@ -148,8 +149,8 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
                 else
                 {
                     // unsigned
-                    dx = (short)reader.ReadUInt16();
-                    dy = (short)reader.ReadUInt16();
+                    dx = reader.ReadUInt16();
+                    dy = reader.ReadUInt16();
                 }
             }
             else

--- a/tests/SixLabors.Fonts.Tests/BigEndianBinaryWriter.cs
+++ b/tests/SixLabors.Fonts.Tests/BigEndianBinaryWriter.cs
@@ -371,6 +371,12 @@ namespace SixLabors.Fonts.Tests
             this.WriteInternal(this.buffer, 1);
         }
 
+        public void WriteInt8(sbyte value)
+        {
+            this.buffer[0] = unchecked((byte)value);
+            this.WriteInternal(this.buffer, 1);
+        }
+
         public void WriteFWORD(short value) => this.WriteInt16(value);
 
         public void WriteUFWORD(ushort value) => this.WriteUInt16(value);

--- a/tests/SixLabors.Fonts.Tests/Tables/General/Glyphs/CompositeGlyphLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/Glyphs/CompositeGlyphLoaderTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+using SixLabors.Fonts.Tables.General;
+using SixLabors.Fonts.Tables.General.Glyphs;
+using Xunit;
+using static SixLabors.Fonts.Tables.General.Glyphs.CompositeGlyphLoader;
+
+namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
+{
+    public class CompositeGlyphLoaderTests
+    {
+        [Fact]
+        public void LoadSingleGlyphWithUInt16Offset_unsignd_short()
+        {
+            var writer = new BigEndianBinaryWriter();
+            writer.WriteUInt16((ushort)
+                CompositeFlags.ArgsAreWords // 16bit unsigned
+                ); // flags
+            writer.WriteUInt16(1); // glyph id
+
+            writer.WriteUInt16(short.MaxValue + 1); // dx
+            writer.WriteUInt16(short.MaxValue + 2); // dy
+            writer.GetReader();
+
+            var bounds = new Bounds(0, 0, 100, 100);
+            var glyph = CompositeGlyphLoader.LoadCompositeGlyph(writer.GetReader(), in bounds);
+
+            var tbl = new GlyphTable(new[] {
+                new SimpleGlyphLoader(bounds), // padding
+                new SimpleGlyphLoader(new short[] { 20 }, new short[] { 21 }, new[] { true }, new ushort[] { 1 }, bounds)
+            });
+
+            GlyphVector finalGlyph = glyph.CreateGlyph(tbl);
+
+            Vector2 point = Assert.Single(finalGlyph.ControlPoints);
+            Assert.Equal(new Vector2(short.MaxValue + 1 + 20, short.MaxValue + 2 + 21), point);
+        }
+
+        [Fact]
+        public void LoadSingleGlyphWithInt16Offset_signed_short()
+        {
+            var writer = new BigEndianBinaryWriter();
+            writer.WriteUInt16((ushort)(
+                CompositeFlags.ArgsAreWords // 16bit
+                | CompositeFlags.ArgsAreXYValues // signed
+                )); // flags
+            writer.WriteUInt16(1); // glyph id
+
+            writer.WriteInt16(short.MinValue + 1); // dx
+            writer.WriteInt16(short.MinValue + 2); // dy
+            writer.GetReader();
+
+            var bounds = new Bounds(0, 0, 100, 100);
+            var glyph = CompositeGlyphLoader.LoadCompositeGlyph(writer.GetReader(), in bounds);
+
+            var tbl = new GlyphTable(new[] {
+                new SimpleGlyphLoader(bounds), // padding
+                new SimpleGlyphLoader(new short[] { 20 }, new short[] { 21 }, new[] { true }, new ushort[] { 1 }, bounds)
+            });
+
+            GlyphVector finalGlyph = glyph.CreateGlyph(tbl);
+
+            Vector2 point = Assert.Single(finalGlyph.ControlPoints);
+            Assert.Equal(new Vector2(short.MinValue + 1 + 20, short.MinValue + 2 + 21), point);
+        }
+
+        [Fact]
+        public void LoadSingleGlyphWithUInt8Offset_unsignd_byte()
+        {
+            var writer = new BigEndianBinaryWriter();
+            writer.WriteUInt16(
+                    0 // 8bit unsigned
+                ); // flags
+            writer.WriteUInt16(1); // glyph id
+
+            writer.WriteUInt8(sbyte.MaxValue + 1); // dx
+            writer.WriteUInt8(sbyte.MaxValue + 2); // dy
+            writer.GetReader();
+
+            var bounds = new Bounds(0, 0, 100, 100);
+            var glyph = CompositeGlyphLoader.LoadCompositeGlyph(writer.GetReader(), in bounds);
+
+            var tbl = new GlyphTable(new[] {
+                new SimpleGlyphLoader(bounds), // padding
+                new SimpleGlyphLoader(new short[] { 20 }, new short[] { 21 }, new[] { true }, new ushort[] { 1 }, bounds)
+            });
+
+            GlyphVector finalGlyph = glyph.CreateGlyph(tbl);
+
+            Vector2 point = Assert.Single(finalGlyph.ControlPoints);
+            Assert.Equal(new Vector2(sbyte.MaxValue + 1 + 20, sbyte.MaxValue + 2 + 21), point);
+        }
+
+        [Fact]
+        public void LoadSingleGlyphWithInt8Offset_signed_byte()
+        {
+            var writer = new BigEndianBinaryWriter();
+            writer.WriteUInt16((ushort)
+                CompositeFlags.ArgsAreXYValues // signed byte
+                ); // flags
+            writer.WriteUInt16(1); // glyph id
+
+            writer.WriteInt8(sbyte.MinValue + 1); // dx
+            writer.WriteInt8(sbyte.MinValue + 2); // dy
+            writer.GetReader();
+
+            var bounds = new Bounds(0, 0, 100, 100);
+            var glyph = CompositeGlyphLoader.LoadCompositeGlyph(writer.GetReader(), in bounds);
+
+            var tbl = new GlyphTable(new[] {
+                new SimpleGlyphLoader(bounds), // padding
+                new SimpleGlyphLoader(new short[] { 20 }, new short[] { 21 }, new[] { true }, new ushort[] { 1 }, bounds)
+            });
+
+            GlyphVector finalGlyph = glyph.CreateGlyph(tbl);
+
+            Vector2 point = Assert.Single(finalGlyph.ControlPoints);
+            Assert.Equal(new Vector2(sbyte.MinValue + 1 + 20, sbyte.MinValue + 2 + 21), point);
+        }
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/Tables/General/Glyphs/CompositeGlyphLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/Glyphs/CompositeGlyphLoaderTests.cs
@@ -1,7 +1,7 @@
-using System;
-using System.Collections.Generic;
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
 using System.Numerics;
-using System.Text;
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.Tables.General.Glyphs;
 using Xunit;
@@ -15,9 +15,7 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
         public void LoadSingleGlyphWithUInt16Offset_unsignd_short()
         {
             var writer = new BigEndianBinaryWriter();
-            writer.WriteUInt16((ushort)
-                CompositeFlags.ArgsAreWords // 16bit unsigned
-                ); // flags
+            writer.WriteUInt16((ushort)CompositeFlags.ArgsAreWords); // 16bit unsigned
             writer.WriteUInt16(1); // glyph id
 
             writer.WriteUInt16(short.MaxValue + 1); // dx
@@ -27,7 +25,8 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
             var bounds = new Bounds(0, 0, 100, 100);
             var glyph = CompositeGlyphLoader.LoadCompositeGlyph(writer.GetReader(), in bounds);
 
-            var tbl = new GlyphTable(new[] {
+            var tbl = new GlyphTable(new[]
+            {
                 new SimpleGlyphLoader(bounds), // padding
                 new SimpleGlyphLoader(new short[] { 20 }, new short[] { 21 }, new[] { true }, new ushort[] { 1 }, bounds)
             });
@@ -42,10 +41,7 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
         public void LoadSingleGlyphWithInt16Offset_signed_short()
         {
             var writer = new BigEndianBinaryWriter();
-            writer.WriteUInt16((ushort)(
-                CompositeFlags.ArgsAreWords // 16bit
-                | CompositeFlags.ArgsAreXYValues // signed
-                )); // flags
+            writer.WriteUInt16((ushort)(CompositeFlags.ArgsAreWords /* 16bit */ | CompositeFlags.ArgsAreXYValues /* signed */)); // flags
             writer.WriteUInt16(1); // glyph id
 
             writer.WriteInt16(short.MinValue + 1); // dx
@@ -55,7 +51,8 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
             var bounds = new Bounds(0, 0, 100, 100);
             var glyph = CompositeGlyphLoader.LoadCompositeGlyph(writer.GetReader(), in bounds);
 
-            var tbl = new GlyphTable(new[] {
+            var tbl = new GlyphTable(new[]
+            {
                 new SimpleGlyphLoader(bounds), // padding
                 new SimpleGlyphLoader(new short[] { 20 }, new short[] { 21 }, new[] { true }, new ushort[] { 1 }, bounds)
             });
@@ -70,9 +67,7 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
         public void LoadSingleGlyphWithUInt8Offset_unsignd_byte()
         {
             var writer = new BigEndianBinaryWriter();
-            writer.WriteUInt16(
-                    0 // 8bit unsigned
-                ); // flags
+            writer.WriteUInt16(0); // 8bit unsigned
             writer.WriteUInt16(1); // glyph id
 
             writer.WriteUInt8(sbyte.MaxValue + 1); // dx
@@ -82,7 +77,8 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
             var bounds = new Bounds(0, 0, 100, 100);
             var glyph = CompositeGlyphLoader.LoadCompositeGlyph(writer.GetReader(), in bounds);
 
-            var tbl = new GlyphTable(new[] {
+            var tbl = new GlyphTable(new[]
+            {
                 new SimpleGlyphLoader(bounds), // padding
                 new SimpleGlyphLoader(new short[] { 20 }, new short[] { 21 }, new[] { true }, new ushort[] { 1 }, bounds)
             });
@@ -97,9 +93,7 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
         public void LoadSingleGlyphWithInt8Offset_signed_byte()
         {
             var writer = new BigEndianBinaryWriter();
-            writer.WriteUInt16((ushort)
-                CompositeFlags.ArgsAreXYValues // signed byte
-                ); // flags
+            writer.WriteUInt16((ushort)CompositeFlags.ArgsAreXYValues); // signed byte
             writer.WriteUInt16(1); // glyph id
 
             writer.WriteInt8(sbyte.MinValue + 1); // dx
@@ -109,7 +103,8 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
             var bounds = new Bounds(0, 0, 100, 100);
             var glyph = CompositeGlyphLoader.LoadCompositeGlyph(writer.GetReader(), in bounds);
 
-            var tbl = new GlyphTable(new[] {
+            var tbl = new GlyphTable(new[]
+            {
                 new SimpleGlyphLoader(bounds), // padding
                 new SimpleGlyphLoader(new short[] { 20 }, new short[] { 21 }, new[] { true }, new ushort[] { 1 }, bounds)
             });


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)


### Description

Correctly read both signs and unsinged transform arguments to apply to glyph parts of composite glyphs.

resolves #158 
where the offset of the accent was supposed to be a singed byte but instead of being read as a byte causing it instead of being offset to the left by a little bit it ended up be moved to the right by a lot instead.

!["ìíîï" rendered using ImageSharp](https://user-images.githubusercontent.com/166440/104138437-fa576580-539b-11eb-91ce-00477a69ed0d.png)
