### PR TITLE
Ensure Consistent Vertical Alignment Across Different Font Types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 #   normalize to Unix-style line endings
 ###############################################################################
 *           text        eol=lf
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as text and
@@ -54,7 +53,6 @@
 *.txt               text        eol=lf
 *.vb                text        eol=lf
 *.yml               text        eol=lf
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as text
@@ -62,7 +60,6 @@
 #   diff as csharp
 ###############################################################################
 *.cs                text        eol=lf          diff=csharp
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as text
@@ -74,7 +71,6 @@
 *.fsproj            text        eol=lf          merge=union
 *.ncrunchproject    text        eol=lf          merge=union
 *.vbproj            text        eol=lf          merge=union
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as text
@@ -82,40 +78,29 @@
 #   use a union merge when resoling conflicts
 ###############################################################################
 *.sln               text        eol=crlf        merge=union
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as binary
 ###############################################################################
 *.basis             binary
-*.bmp               binary
-*.dds               binary
 *.dll               binary
 *.eot               binary
 *.exe               binary
-*.gif               binary
-*.jpg               binary
 *.ktx               binary
 *.otf               binary
 *.pbm               binary
 *.pdf               binary
-*.png               binary
 *.ppt               binary
 *.pptx              binary
 *.pvr               binary
 *.snk               binary
-*.tga               binary
-*.tif               binary
-*.tiff              binary
 *.ttc               binary
 *.ttf               binary
 *.wbmp              binary
-*.webp              binary
 *.woff              binary
 *.woff2             binary
 *.xls               binary
 *.xlsx              binary
-
 ###############################################################################
 # Set explicit file behavior to:
 #   diff as plain text
@@ -127,3 +112,16 @@
 *.pptx              diff=astextplain
 *.rtf               diff=astextplain
 *.svg               diff=astextplain
+###############################################################################
+# Handle image files by git lfs
+###############################################################################
+*.jpg               filter=lfs diff=lfs merge=lfs -text
+*.jpeg              filter=lfs diff=lfs merge=lfs -text
+*.bmp               filter=lfs diff=lfs merge=lfs -text
+*.gif               filter=lfs diff=lfs merge=lfs -text
+*.png               filter=lfs diff=lfs merge=lfs -text
+*.tif               filter=lfs diff=lfs merge=lfs -text
+*.tiff              filter=lfs diff=lfs merge=lfs -text
+*.tga               filter=lfs diff=lfs merge=lfs -text
+*.webp              filter=lfs diff=lfs merge=lfs -text
+*.dds               filter=lfs diff=lfs merge=lfs -text

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
@@ -21,6 +21,7 @@ namespace SixLabors.Fonts.Tests.Fakes
                   GenerateCMapTable(glyphs),
                   new FakeGlyphTable(glyphs),
                   GenerateOS2Table(),
+                  GenerateHorizontalHeadTable(),
                   GenerateHorizontalMetricsTable(glyphs),
                   GenerateHeadTable(),
                   new KerningTable(new Fonts.Tables.General.Kern.KerningSubTable[0]),
@@ -29,8 +30,16 @@ namespace SixLabors.Fonts.Tests.Fakes
         {
         }
 
-        internal FakeFontInstance(NameTable nameTable, CMapTable cmap, GlyphTable glyphs, OS2Table os2, HorizontalMetricsTable horizontalMetrics, HeadTable head, KerningTable kern)
-            : base(nameTable, cmap, glyphs, os2, horizontalMetrics, head, kern, null, null)
+        internal FakeFontInstance(
+            NameTable nameTable,
+            CMapTable cmap,
+            GlyphTable glyphs,
+            OS2Table os2,
+            HorizontalHeadTable horizontalHeadTable,
+            HorizontalMetricsTable horizontalMetrics,
+            HeadTable head,
+            KerningTable kern)
+            : base(nameTable, cmap, glyphs, os2, horizontalHeadTable, horizontalMetrics, head, kern, null, null)
         {
         }
 
@@ -40,23 +49,20 @@ namespace SixLabors.Fonts.Tests.Fakes
         public static FakeFontInstance CreateFontWithVaryingVerticalFontMetrics(string text)
         {
             List<FakeGlyphSource> glyphs = GetGlyphs(text);
-            var result = new FakeFontInstance(
+
+            return new FakeFontInstance(
                 GenerateNameTable(),
                 GenerateCMapTable(glyphs),
                 new FakeGlyphTable(glyphs),
                 GenerateOS2TableWithVaryingVerticalFontMetrics(),
+                GenerateHorizontalHeadTable(),
                 GenerateHorizontalMetricsTable(glyphs),
                 GenerateHeadTable(),
                 new KerningTable(new Fonts.Tables.General.Kern.KerningSubTable[0]));
-
-            return result;
         }
 
         private static List<FakeGlyphSource> GetGlyphs(string text)
-        {
-            var glyphs = text.Distinct().Select((x, i) => new FakeGlyphSource(x, (ushort)i)).ToList();
-            return glyphs;
-        }
+            => text.Distinct().Select((x, i) => new FakeGlyphSource(x, (ushort)i)).ToList();
 
         private static NameTable GenerateNameTable()
             => new NameTable(
@@ -70,14 +76,17 @@ namespace SixLabors.Fonts.Tests.Fakes
         private static CMapTable GenerateCMapTable(List<FakeGlyphSource> glyphs)
             => new CMapTable(new[] { new FakeCmapSubtable(glyphs) });
 
+        private static HorizontalHeadTable GenerateHorizontalHeadTable()
+            => new HorizontalHeadTable(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+
         private static OS2Table GenerateOS2Table()
-            => new OS2Table(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, new byte[0], 1, 1, 1, 1, string.Empty, OS2Table.FontStyleSelection.ITALIC, 1, 1, 20, 10, 20, 1, 1);
+            => new OS2Table(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, new byte[0], 1, 1, 1, 1, string.Empty, OS2Table.FontStyleSelection.USE_TYPO_METRICS, 1, 1, 20, 10, 20, 1, 1);
 
         private static OS2Table GenerateOS2TableWithVaryingVerticalFontMetrics()
-            => new OS2Table(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, new byte[0], 1, 1, 1, 1, string.Empty, OS2Table.FontStyleSelection.ITALIC, 1, 1, 35, 8, 12, 33, 11);
+            => new OS2Table(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, new byte[0], 1, 1, 1, 1, string.Empty, OS2Table.FontStyleSelection.USE_TYPO_METRICS, 1, 1, 35, 8, 12, 33, 11);
 
         private static HorizontalMetricsTable GenerateHorizontalMetricsTable(List<FakeGlyphSource> glyphs)
-            => new HorizontalMetricsTable(glyphs.Select(x => (ushort)30).ToArray(), glyphs.Select(x => (short)10).ToArray());
+            => new HorizontalMetricsTable(glyphs.Select(_ => (ushort)30).ToArray(), glyphs.Select(_ => (short)10).ToArray());
 
         private static HeadTable GenerateHeadTable()
             => new HeadTable(

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
@@ -18,7 +18,7 @@ namespace SixLabors.Fonts.Tests.Issues
             FontRectangle size = TextMeasurer.MeasureBounds("          ", new RendererOptions(new Font(font, 30), 72));
 
             Assert.Equal(60, size.Width, 1);
-            Assert.Equal(31.7, size.Height, 1);
+            Assert.Equal(31.6, size.Height, 1);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -39,32 +39,32 @@ namespace SixLabors.Fonts.Tests
         [InlineData(
             VerticalAlignment.Bottom,
             HorizontalAlignment.Left,
-            -50,
+            -60,
             10)]
         [InlineData(
             VerticalAlignment.Bottom,
             HorizontalAlignment.Right,
-            -50,
+            -60,
             -320)]
         [InlineData(
             VerticalAlignment.Bottom,
             HorizontalAlignment.Center,
-            -50,
+            -60,
             -155)]
         [InlineData(
             VerticalAlignment.Center,
             HorizontalAlignment.Left,
-            -25,
+            -30,
             10)]
         [InlineData(
             VerticalAlignment.Center,
             HorizontalAlignment.Right,
-            -25,
+            -30,
             -320)]
         [InlineData(
             VerticalAlignment.Center,
             HorizontalAlignment.Center,
-            -25,
+            -30,
             -155)]
         public void VerticalAlignmentTests(
             VerticalAlignment vertical,
@@ -210,7 +210,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Theory]
-        [InlineData("a", 100, 100, 125, 640)]
+        [InlineData("a", 100, 100, 125, 452)]
         public void LayoutWithLocation(string text, float x, float y, float expectedX, float expectedY)
         {
             var c = new FontCollection();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- Updates `FontInstance` to check the `OS2Table.FontStyleSelection.USE_TYPO_METRICS` flag and fallback to `HorizontalHeadTable` when required.
- Reworks `TextLayout` vertical alignment to more closely match System.Drawing. 

Fixes #161 

### Comparison images. 
Left Six Labors, Right System.Drawing. 

Notes: 
- Our horizontal alignment matches SkiaSharp
- Vertical difference is minimal and likely due to rounding difference as they are smaller then any font metric. 

**VerticalAlign.Top**
![top-multi](https://user-images.githubusercontent.com/385879/109083160-47e62280-76fd-11eb-96df-f838e9fbe76d.jpg)

**VerticalAlign.Center**
![center-multi](https://user-images.githubusercontent.com/385879/109083147-43ba0500-76fd-11eb-9b89-bb25ebfd5af3.jpg)

**VerticalAlign.Bottom**
![bottom-multi](https://user-images.githubusercontent.com/385879/109083150-44eb3200-76fd-11eb-8723-eedd0e36f5a0.jpg)

**VerticalAlign.Top**
![top-single](https://user-images.githubusercontent.com/385879/109083152-4583c880-76fd-11eb-81c3-c5b952495389.jpg)

**VerticalAlign.Center**
![center-single](https://user-images.githubusercontent.com/385879/109083156-461c5f00-76fd-11eb-8755-e2a4e91d5deb.jpg)

**VerticalAlign.Bottom**
![bottom-single](https://user-images.githubusercontent.com/385879/109083157-474d8c00-76fd-11eb-882d-269919e2d74d.jpg)

I did notice that we seem to measure the rectangle differently to System.Drawing for some fonts only. Note the difference in the white rectangle in the following image. This appears to have no bearing on the actual layout though.

![measure-diff](https://user-images.githubusercontent.com/385879/109083754-6698e900-76fe-11eb-8c75-77b8d3e224e8.jpg)


<!-- Thanks for contributing to SixLabors.Fonts! -->
