### PR TITLE
Fix rendering of leading emoji.

### DIFF
--- a/samples/DrawWithImageSharp/TextAlignment.cs
+++ b/samples/DrawWithImageSharp/TextAlignment.cs
@@ -43,7 +43,7 @@ namespace DrawWithImageSharp
                     location.Y = 0;
                     break;
                 case VerticalAlignment.Center:
-                    location.Y = img.Height / 2;
+                    location.Y = img.Height / 2F;
                     break;
                 case VerticalAlignment.Bottom:
                     location.Y = img.Height;
@@ -55,14 +55,13 @@ namespace DrawWithImageSharp
             switch (horiz)
             {
                 case HorizontalAlignment.Left:
-
                     location.X = 0;
                     break;
                 case HorizontalAlignment.Right:
                     location.X = img.Width;
                     break;
                 case HorizontalAlignment.Center:
-                    location.X = img.Width / 2;
+                    location.X = img.Width / 2F;
                     break;
                 default:
                     break;

--- a/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
+++ b/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using SixLabors.Fonts;
 using SixLabors.ImageSharp;
@@ -60,10 +61,10 @@ namespace DrawWithImageSharp
                     location.X = 0;
                     break;
                 case HorizontalAlignment.Right:
-                    location.X = img.Width - wrappingWidth;
+                    location.X = img.Width;
                     break;
                 case HorizontalAlignment.Center:
-                    location.X = (img.Width - wrappingWidth) / 2F;
+                    location.X = img.Width / 2F;
                     break;
                 default:
                     break;
@@ -85,7 +86,7 @@ namespace DrawWithImageSharp
             string text = $"    {horiz}     {vert}         {horiz}     {vert}         {horiz}     {vert}     ";
             renderer.RenderText(text, style);
 
-            System.Collections.Generic.IEnumerable<IPath> shapesToDraw = glyphBuilder.Paths;
+            IEnumerable<IPath> shapesToDraw = glyphBuilder.Paths;
             img.Mutate(x => x.Fill(Color.Black, glyphBuilder.Paths));
 
             Rgba32 f = Color.Fuchsia;

--- a/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
+++ b/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
@@ -44,7 +44,7 @@ namespace DrawWithImageSharp
                     location.Y = 0;
                     break;
                 case VerticalAlignment.Center:
-                    location.Y = img.Height / 2;
+                    location.Y = img.Height / 2F;
                     break;
                 case VerticalAlignment.Bottom:
                     location.Y = img.Height;
@@ -63,7 +63,7 @@ namespace DrawWithImageSharp
                     location.X = img.Width - wrappingWidth;
                     break;
                 case HorizontalAlignment.Center:
-                    location.X = (img.Width - wrappingWidth) / 2;
+                    location.X = (img.Width - wrappingWidth) / 2F;
                     break;
                 default:
                     break;

--- a/src/SixLabors.Fonts/GlyphLayout.cs
+++ b/src/SixLabors.Fonts/GlyphLayout.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Numerics;
@@ -11,8 +11,9 @@ namespace SixLabors.Fonts
     /// </summary>
     internal readonly struct GlyphLayout
     {
-        internal GlyphLayout(int codePoint, Glyph glyph, Vector2 location, float width, float height, float lineHeight, bool startOfLine, bool isWhiteSpace, bool isControlCharacter)
+        internal GlyphLayout(int grapheme, int codePoint, Glyph glyph, Vector2 location, float width, float height, float lineHeight, bool startOfLine, bool isWhiteSpace, bool isControlCharacter)
         {
+            this.GraphemeIndex = grapheme;
             this.LineHeight = lineHeight;
             this.CodePoint = codePoint;
             this.Glyph = glyph;
@@ -23,6 +24,11 @@ namespace SixLabors.Fonts
             this.IsWhiteSpace = isWhiteSpace;
             this.IsControlCharacter = isControlCharacter;
         }
+
+        /// <summary>
+        /// Gets the index of the grapheme in the combined text that the glyph is a member of.
+        /// </summary>
+        public int GraphemeIndex { get; }
 
         /// <summary>
         /// Gets a value indicating whether gets the glyphe represents a whitespace character.
@@ -107,10 +113,18 @@ namespace SixLabors.Fonts
             sb.Append('\'');
             switch (this.CodePoint)
             {
-                case '\t': sb.Append("\\t"); break;
-                case '\n': sb.Append("\\n"); break;
-                case '\r': sb.Append("\\r"); break;
-                case ' ': sb.Append(" "); break;
+                case '\t':
+                    sb.Append("\\t");
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case ' ':
+                    sb.Append(" ");
+                    break;
                 default:
                     sb.Append(char.ConvertFromUtf32(this.CodePoint));
                     break;

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -47,7 +47,7 @@ namespace SixLabors.Fonts
                         originX = maxWidth;
                         break;
                     case HorizontalAlignment.Center:
-                        originX = 0.5f * maxWidth;
+                        originX = maxWidth / 2F;
                         break;
                     case HorizontalAlignment.Left:
                         originX = 0;
@@ -326,14 +326,9 @@ namespace SixLabors.Fonts
                 if (glyphLayout.StartOfLine)
                 {
                     // scan ahead measuring width
-                    float width = glyphLayout.Width;
-                    for (int j = i + 1; j < layout.Count; j++)
+                    float width = 0;
+                    for (int j = i; j < layout.Count; j++)
                     {
-                        if (layout[j].StartOfLine)
-                        {
-                            break;
-                        }
-
                         width = layout[j].Location.X + layout[j].Width; // rhs
                     }
 
@@ -343,7 +338,7 @@ namespace SixLabors.Fonts
                             lineOffset = new Vector2(originX - width, 0) + offset;
                             break;
                         case HorizontalAlignment.Center:
-                            lineOffset = new Vector2(originX - (width / 2f), 0) + offset;
+                            lineOffset = new Vector2(originX - (width / 2F), 0) + offset;
                             break;
                         case HorizontalAlignment.Left:
                             lineOffset = new Vector2(originX, 0) + offset;

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Numerics;
 using SixLabors.Fonts.Exceptions;
 using SixLabors.Fonts.Unicode;
@@ -43,6 +44,7 @@ namespace SixLabors.Fonts
 
                 switch (options.HorizontalAlignment)
                 {
+                    // TODO: Check this.
                     case HorizontalAlignment.Right:
                         originX = maxWidth;
                         break;
@@ -90,6 +92,7 @@ namespace SixLabors.Fonts
             bool nextWrappableRequired = false;
             bool startOfLine = true;
             float totalHeight = 0;
+            int graphemeIndex = 0;
 
             if (lineBreaker.TryGetNextBreak(out LineBreak b))
             {
@@ -203,7 +206,7 @@ namespace SixLabors.Fonts
                     {
                         float w = g.AdvanceWidth * spanStyle.PointSize / scale;
                         float h = g.Height * spanStyle.PointSize / scale;
-                        layout.Add(new GlyphLayout(codePoint, new Glyph(g, spanStyle.PointSize), glyphLocation, w, h, lineHeight, startOfLine, false, false));
+                        layout.Add(new GlyphLayout(graphemeIndex, codePoint, new Glyph(g, spanStyle.PointSize), glyphLocation, w, h, lineHeight, startOfLine, false, false));
 
                         if (w > glyphWidth)
                         {
@@ -211,6 +214,8 @@ namespace SixLabors.Fonts
                         }
                     }
 
+                    // Increment the index to signify we have moved on the a new cluster.
+                    graphemeIndex++;
                     startOfLine = false;
 
                     // move forward the actual width of the glyph, we are retaining the baseline
@@ -236,7 +241,7 @@ namespace SixLabors.Fonts
                                 }
 
                                 Vector2 current = layout[j].Location;
-                                layout[j] = new GlyphLayout(layout[j].CodePoint, layout[j].Glyph, new Vector2(current.X - wrappingOffset, current.Y + lineHeight), layout[j].Width, layout[j].Height, layout[j].LineHeight, startOfLine, layout[j].IsWhiteSpace, layout[j].IsControlCharacter);
+                                layout[j] = new GlyphLayout(layout[j].GraphemeIndex, layout[j].CodePoint, layout[j].Glyph, new Vector2(current.X - wrappingOffset, current.Y + lineHeight), layout[j].Width, layout[j].Height, layout[j].LineHeight, startOfLine, layout[j].IsWhiteSpace, layout[j].IsControlCharacter);
                                 startOfLine = false;
 
                                 location.X = layout[j].Location.X + layout[j].Width;
@@ -258,13 +263,13 @@ namespace SixLabors.Fonts
                     previousGlyph = null;
                     startOfLine = true;
 
-                    layout.Add(new GlyphLayout(codePoint, new Glyph(glyph, spanStyle.PointSize), location, 0, glyphHeight, lineHeight, startOfLine, true, true));
+                    layout.Add(new GlyphLayout(-1, codePoint, new Glyph(glyph, spanStyle.PointSize), location, 0, glyphHeight, lineHeight, startOfLine, true, true));
                     startOfLine = false;
                 }
                 else if (codepoints[i] == '\n')
                 {
                     // carriage return resets the XX coordinate to 0
-                    layout.Add(new GlyphLayout(codePoint, new Glyph(glyph, spanStyle.PointSize), location, 0, glyphHeight, lineHeight, startOfLine, true, true));
+                    layout.Add(new GlyphLayout(-1, codePoint, new Glyph(glyph, spanStyle.PointSize), location, 0, glyphHeight, lineHeight, startOfLine, true, true));
                     location.X = 0;
                     location.Y += lineHeight;
                     totalHeight += lineHeight;
@@ -292,7 +297,7 @@ namespace SixLabors.Fonts
                         finalWidth += tabStop;
                     }
 
-                    layout.Add(new GlyphLayout(codePoint, new Glyph(glyph, spanStyle.PointSize), location, finalWidth, glyphHeight, lineHeight, startOfLine, true, false));
+                    layout.Add(new GlyphLayout(-1, codePoint, new Glyph(glyph, spanStyle.PointSize), location, finalWidth, glyphHeight, lineHeight, startOfLine, true, false));
                     startOfLine = false;
 
                     // advance to a position > width away that
@@ -301,53 +306,73 @@ namespace SixLabors.Fonts
                 }
                 else if (codepoints[i] == ' ')
                 {
-                    layout.Add(new GlyphLayout(codePoint, new Glyph(glyph, spanStyle.PointSize), location, glyphWidth, glyphHeight, lineHeight, startOfLine, true, false));
+                    layout.Add(new GlyphLayout(-1, codePoint, new Glyph(glyph, spanStyle.PointSize), location, glyphWidth, glyphHeight, lineHeight, startOfLine, true, false));
                     startOfLine = false;
                     location.X += glyphWidth;
                     previousGlyph = null;
                 }
             }
 
-            var offset = new Vector2(0, top);
+            var offsetY = new Vector2(0, top);
             switch (options.VerticalAlignment)
             {
                 case VerticalAlignment.Center:
-                    offset += new Vector2(0, -(totalHeight / 2F));
+                    offsetY += new Vector2(0, -(totalHeight / 2F));
                     break;
                 case VerticalAlignment.Bottom:
-                    offset += new Vector2(0, -totalHeight);
+                    offsetY += new Vector2(0, -totalHeight);
                     break;
             }
 
-            Vector2 lineOffset = offset;
+            Vector2 offsetX = offsetY;
             for (int i = 0; i < layout.Count; i++)
             {
                 GlyphLayout glyphLayout = layout[i];
+                graphemeIndex = glyphLayout.GraphemeIndex;
+
+                // Scan ahead getting the total width of each line.
                 if (glyphLayout.StartOfLine)
                 {
-                    // scan ahead measuring width
                     float width = 0;
                     for (int j = i; j < layout.Count; j++)
                     {
-                        width = layout[j].Location.X + layout[j].Width; // rhs
+                        GlyphLayout nextLayout = layout[j];
+                        if (nextLayout.StartOfLine && (nextLayout.GraphemeIndex != graphemeIndex || nextLayout.GraphemeIndex == -1))
+                        {
+                            // Leading graphemes are made up of multiple glyphs all marked as 'StartOfLine so we only
+                            // break when we are sure we have entered a cluster or when we have hit a previously defined break.
+                            break;
+                        }
+
+                        width = nextLayout.Location.X + nextLayout.Width;
                     }
 
                     switch (options.HorizontalAlignment)
                     {
+                        case HorizontalAlignment.Left:
+                            offsetX = new Vector2(originX, 0) + offsetY;
+                            break;
                         case HorizontalAlignment.Right:
-                            lineOffset = new Vector2(originX - width, 0) + offset;
+                            offsetX = new Vector2(originX - width, 0) + offsetY;
                             break;
                         case HorizontalAlignment.Center:
-                            lineOffset = new Vector2(originX - (width / 2F), 0) + offset;
-                            break;
-                        case HorizontalAlignment.Left:
-                            lineOffset = new Vector2(originX, 0) + offset;
+                            offsetX = new Vector2(originX - (width / 2F), 0) + offsetY;
                             break;
                     }
                 }
 
                 // TODO calculate an offset from the 'origin' based on TextAlignment for each line
-                layout[i] = new GlyphLayout(glyphLayout.CodePoint, glyphLayout.Glyph, glyphLayout.Location + lineOffset + origin, glyphLayout.Width, glyphLayout.Height, glyphLayout.LineHeight, glyphLayout.StartOfLine, glyphLayout.IsWhiteSpace, glyphLayout.IsControlCharacter);
+                layout[i] = new GlyphLayout(
+                    glyphLayout.GraphemeIndex,
+                    glyphLayout.CodePoint,
+                    glyphLayout.Glyph,
+                    glyphLayout.Location + offsetX + origin,
+                    glyphLayout.Width,
+                    glyphLayout.Height,
+                    glyphLayout.LineHeight,
+                    glyphLayout.StartOfLine,
+                    glyphLayout.IsWhiteSpace,
+                    glyphLayout.IsControlCharacter);
             }
 
             return layout;

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -324,13 +324,13 @@ namespace SixLabors.Fonts
                     break;
             }
 
-            Vector2 offsetX = offsetY;
+            Vector2 offsetX = Vector2.Zero;
             for (int i = 0; i < layout.Count; i++)
             {
                 GlyphLayout glyphLayout = layout[i];
                 graphemeIndex = glyphLayout.GraphemeIndex;
 
-                // Scan ahead getting the total width of each line.
+                // Scan ahead getting the width.
                 if (glyphLayout.StartOfLine)
                 {
                     float width = 0;
@@ -340,7 +340,7 @@ namespace SixLabors.Fonts
                         if (nextLayout.StartOfLine && (nextLayout.GraphemeIndex != graphemeIndex || nextLayout.GraphemeIndex == -1))
                         {
                             // Leading graphemes are made up of multiple glyphs all marked as 'StartOfLine so we only
-                            // break when we are sure we have entered a cluster or when we have hit a previously defined break.
+                            // break when we are sure we have entered a new cluster or previously defined break.
                             break;
                         }
 

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -39,22 +39,7 @@ namespace SixLabors.Fonts
             {
                 // trim trailing white spaces from the text
                 text = text.TrimEnd(null);
-
                 maxWidth = options.WrappingWidth / options.DpiX;
-
-                switch (options.HorizontalAlignment)
-                {
-                    // TODO: Check this.
-                    case HorizontalAlignment.Right:
-                        originX = maxWidth;
-                        break;
-                    case HorizontalAlignment.Center:
-                        originX = maxWidth / 2F;
-                        break;
-                    case HorizontalAlignment.Left:
-                        originX = 0;
-                        break;
-                }
             }
 
             // lets convert the text into codepoints
@@ -336,15 +321,16 @@ namespace SixLabors.Fonts
                     float width = 0;
                     for (int j = i; j < layout.Count; j++)
                     {
-                        GlyphLayout nextLayout = layout[j];
-                        if (nextLayout.StartOfLine && (nextLayout.GraphemeIndex != graphemeIndex || nextLayout.GraphemeIndex == -1))
+                        GlyphLayout current = layout[j];
+                        int currentGraphemeIndex = current.GraphemeIndex;
+                        if (current.StartOfLine && (currentGraphemeIndex != graphemeIndex))
                         {
                             // Leading graphemes are made up of multiple glyphs all marked as 'StartOfLine so we only
                             // break when we are sure we have entered a new cluster or previously defined break.
                             break;
                         }
 
-                        width = nextLayout.Location.X + nextLayout.Width;
+                        width = current.Location.X + current.Width;
                     }
 
                     switch (options.HorizontalAlignment)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Track the grapheme cluster that glyphs belong to so that we do not incorrectly break when calculating the width + offset of leading combined glyphs. Fixes #137 

All existing tests pass and I haven't added new tests yet. I've just added some sample code so far. 

Everything appears to be ok.

![image](https://user-images.githubusercontent.com/385879/111239628-70bd5180-85f1-11eb-83b1-afc19a8e3a1a.png)

![image](https://user-images.githubusercontent.com/385879/111239651-803c9a80-85f1-11eb-8e7b-247a291512e8.png)

Wrapped text output also matches the sample output in master though I've simplified the code.

*Master*

![AlignmentWrapped Master](https://user-images.githubusercontent.com/385879/111239729-b37f2980-85f1-11eb-8fd2-22aa82409ddf.png)


*This Branch*

![AlignmentWrapped](https://user-images.githubusercontent.com/385879/111355660-7b262c80-867f-11eb-892c-0a9387ef6eb5.png)

<!-- Thanks for contributing to SixLabors.Fonts! -->
