### PR TITLE
#167 - Code documentation spelling error

### DIFF
--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -29,7 +29,7 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Calculates the bounding box
         /// </summary>
-        /// <param name="location">location to calualte from.</param>
+        /// <param name="location">location to calculate from.</param>
         /// <param name="dpi">dpi to calualtes in relation to</param>
         /// <returns>The bounding box</returns>
         public FontRectangle BoundingBox(Vector2 location, Vector2 dpi)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR fixes a spelling issue for the code documentation for the `Glyph.BoundingBox()` method.

[Issue 167](https://github.com/SixLabors/Fonts/issues/167)

<!-- Thanks for contributing to SixLabors.Fonts! -->
