### PR TITLE
Add user locations to system font collection. 

### DIFF
--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -25,6 +25,8 @@ namespace SixLabors.Fonts
             {
                 // windows directories
                 "%SYSTEMROOT%\\Fonts",
+                "%APPDATA%\\Microsoft\\Windows\\Fonts",
+                "%LOCALAPPDATA%\\Microsoft\\Windows\\Fonts",
 
                 // linux directories
                 "~/.fonts/",


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds local/roaming user folders to `SystemFontCollection` to allow loading of non-admin user installed fonts.
Fixes #162


<!-- Thanks for contributing to SixLabors.Fonts! -->
