### PR TITLE
Fix Horizontal Alignment

### DIFF
--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -36,9 +36,19 @@ namespace SixLabors.Fonts
             float originX = 0;
             if (options.WrappingWidth > 0)
             {
-                // trim trailing white spaces from the text
+                // Trim trailing white spaces from the text
                 text = text.TrimEnd(null);
                 maxWidth = options.WrappingWidth / options.DpiX;
+
+                switch (options.HorizontalAlignment)
+                {
+                    case HorizontalAlignment.Right:
+                        originX = maxWidth;
+                        break;
+                    case HorizontalAlignment.Center:
+                        originX = maxWidth * .5F;
+                        break;
+                }
             }
 
             int codePointCount = CodePoint.GetCodePointCount(text);
@@ -134,7 +144,7 @@ namespace SixLabors.Fonts
                             top = lineMaxAscender;
                             break;
                         case VerticalAlignment.Center:
-                            top = (lineMaxAscender / 2F) - (lineMaxDescender / 2F);
+                            top = (lineMaxAscender * .5F) - (lineMaxDescender * .5F);
                             break;
                         case VerticalAlignment.Bottom:
                             top = -lineMaxDescender;
@@ -338,7 +348,7 @@ namespace SixLabors.Fonts
             switch (options.VerticalAlignment)
             {
                 case VerticalAlignment.Center:
-                    offsetY += new Vector2(0, -(totalHeight / 2F));
+                    offsetY += new Vector2(0, -(totalHeight * .5F));
                     break;
                 case VerticalAlignment.Bottom:
                     offsetY += new Vector2(0, -totalHeight);
@@ -378,7 +388,7 @@ namespace SixLabors.Fonts
                             offsetX = new Vector2(originX - width, 0) + offsetY;
                             break;
                         case HorizontalAlignment.Center:
-                            offsetX = new Vector2(originX - (width / 2F), 0) + offsetY;
+                            offsetX = new Vector2(originX - (width * .5F), 0) + offsetY;
                             break;
                     }
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Reimplements horizontal alignment. It must have been deleted during a merge.

![test-image-lc](https://user-images.githubusercontent.com/385879/118098960-828e5b80-b3cc-11eb-97c0-ce0890dd42e8.png)
![test-image-cc](https://user-images.githubusercontent.com/385879/118098955-81f5c500-b3cc-11eb-80b3-21e4a62aa326.png)
![test-image-rc](https://user-images.githubusercontent.com/385879/118098962-8326f200-b3cc-11eb-9dd3-bf01803ce9b9.png)


<!-- Thanks for contributing to SixLabors.Fonts! -->
