### PR TITLE
Properly Fix #171

### DIFF
--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -72,7 +72,7 @@ namespace SixLabors.Fonts
             // Remember where the top of the layouted text is for accurate vertical alignment.
             // This is important because there is considerable space between the lineHeight at the glyph's ascender.
             float top = 0;
-
+            float scale = 0;
             bool firstLine = true;
             GlyphInstance? previousGlyph = null;
             int lastWrappableLocation = -1;
@@ -108,24 +108,31 @@ namespace SixLabors.Fonts
                 }
 
                 GlyphInstance? glyph = glyphs[0];
-                float scale = glyph.Font.EmSize * 72;
+                if (previousGlyph != null && glyph.Font != previousGlyph.Font)
+                {
+                    scale = glyph.Font.EmSize * 72;
+                }
+
                 float fontHeight = glyph.Font.LineHeight * options.LineSpacing;
                 if (fontHeight > unscaledLineHeight)
                 {
                     // get the larget lineheight thus far
                     unscaledLineHeight = fontHeight;
+                    scale = glyph.Font.EmSize * 72;
                     lineHeight = unscaledLineHeight * spanStyle.PointSize / scale;
                 }
 
                 if (glyph.Font.Ascender > unscaledLineMaxAscender)
                 {
                     unscaledLineMaxAscender = glyph.Font.Ascender;
+                    scale = glyph.Font.EmSize * 72;
                     lineMaxAscender = unscaledLineMaxAscender * spanStyle.PointSize / scale;
                 }
 
                 if (Math.Abs(glyph.Font.Descender) > unscaledLineMaxDescender)
                 {
                     unscaledLineMaxDescender = Math.Abs(glyph.Font.Descender);
+                    scale = glyph.Font.EmSize * 72;
                     lineMaxDescender = unscaledLineMaxDescender * spanStyle.PointSize / scale;
                 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
A proper fix for #171 (taking the fix from the OP)

I've tested this with a local build of ImageSharp.Drawing along with the existing tests to ensure nothing is broken.

![FallbackFontRendering_Rgba32_Solid400x200_(255,255,255,255)](https://user-images.githubusercontent.com/385879/119036273-7ac04f80-b9a8-11eb-8321-5e6988a31cd9.png)

<!-- Thanks for contributing to SixLabors.Fonts! -->
