### PR TITLE
Fix example reading a font description

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ We currently only support otf and woff fonts with True Type outlines.
 
 ```c#
 FontDescription description = null;
-using(var fs = File.OpenReader("Font.ttf")){
+using(var fs = File.OpenRead("Font.ttf")){
     description = FontDescription.Load(fs); // once it has loaded the data the stream is no longer required and can be disposed of
 }
 
-string name = description.FontName;
+string name = description.FontName(CultureInfo.InvariantCulture);
 
 ```
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Update example how to read a font description.