### PR TITLE
Fix many typos

### DIFF
--- a/src/SixLabors.Fonts/BigEndianBinaryReader.cs
+++ b/src/SixLabors.Fonts/BigEndianBinaryReader.cs
@@ -10,7 +10,7 @@ using System.Text;
 namespace SixLabors.Fonts
 {
     /// <summary>
-    /// BinaryReader using bigendian encoding.
+    /// BinaryReader using big-endian encoding.
     /// </summary>
     internal class BigEndianBinaryReader : IDisposable
     {
@@ -56,7 +56,7 @@ namespace SixLabors.Fonts
         /// <param name="origin">Origin of seek operation.</param>
         public void Seek(long offset, SeekOrigin origin)
         {
-            // if begin offsert the offset by the start of stream postion
+            // if begin offset the offset by the start of stream position
             if (origin == SeekOrigin.Begin)
             {
                 offset += this.StartOfStream;

--- a/src/SixLabors.Fonts/ColorFontSupport.cs
+++ b/src/SixLabors.Fonts/ColorFontSupport.cs
@@ -17,7 +17,7 @@ namespace SixLabors.Fonts
         None = 0,
 
         /// <summary>
-        /// Render using glyphs accessed via Micropsfts COLR/CPAL table extensions to OpenType
+        /// Render using glyphs accessed via Microsoft's COLR/CPAL table extensions to OpenType
         /// </summary>
         MicrosoftColrFormat = 1
     }

--- a/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
@@ -4,7 +4,7 @@
 namespace SixLabors.Fonts
 {
     /// <summary>
-    /// Execption for detailing missing font familys.
+    /// Exception for detailing missing font families.
     /// </summary>
     /// <seealso cref="FontException" />
     public class FontFamilyNotFoundException : FontException
@@ -18,7 +18,7 @@ namespace SixLabors.Fonts
             => this.FontFamily = family;
 
         /// <summary>
-        /// Gets the name of the font familiy we failed to find.
+        /// Gets the name of the font family we failed to find.
         /// </summary>
         public string FontFamily { get; }
     }

--- a/src/SixLabors.Fonts/Exceptions/GlyphMissingException.cs
+++ b/src/SixLabors.Fonts/Exceptions/GlyphMissingException.cs
@@ -6,7 +6,7 @@ using SixLabors.Fonts.Unicode;
 namespace SixLabors.Fonts
 {
     /// <summary>
-    /// Execption for detailing missing font families.
+    /// Exception for detailing missing font families.
     /// </summary>
     /// <seealso cref="FontException" />
     public class GlyphMissingException : FontException

--- a/src/SixLabors.Fonts/Exceptions/InvalidFontFileException.cs
+++ b/src/SixLabors.Fonts/Exceptions/InvalidFontFileException.cs
@@ -6,7 +6,7 @@ using System;
 namespace SixLabors.Fonts
 {
     /// <summary>
-    /// Exception font loading can throw if it encounteres invalid data during font loading.
+    /// Exception font loading can throw if it encounters invalid data during font loading.
     /// </summary>
     /// <seealso cref="Exception" />
     public class InvalidFontFileException : Exception

--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -163,8 +163,8 @@ namespace SixLabors.Fonts
 
             if (this.RequestedStyle.HasFlag(FontStyle.Italic))
             {
-                // Can't find style requested and they want one thats at least partial itallic.
-                // Try the regual italic.
+                // Can't find style requested and they want one that's at least partial italic.
+                // Try the regular italic.
                 if (this.Family.TryGetMetrics(FontStyle.Italic, out metrics))
                 {
                     return metrics;
@@ -173,7 +173,7 @@ namespace SixLabors.Fonts
 
             if (this.RequestedStyle.HasFlag(FontStyle.Bold))
             {
-                // Can't find style requested and they want one thats at least partial bold.
+                // Can't find style requested and they want one that's at least partial bold.
                 // Try the regular bold.
                 if (this.Family.TryGetMetrics(FontStyle.Bold, out metrics))
                 {

--- a/src/SixLabors.Fonts/FontMetrics.cs
+++ b/src/SixLabors.Fonts/FontMetrics.cs
@@ -225,7 +225,7 @@ namespace SixLabors.Fonts
         internal static FontMetrics LoadFont(FontReader reader)
         {
             // https://www.microsoft.com/typography/otspec/recom.htm#TableOrdering
-            // recomended order
+            // recommended order
             HeadTable head = reader.GetTable<HeadTable>(); // head - not saving but loading in suggested order
             HorizontalHeadTable hhea = reader.GetTable<HorizontalHeadTable>(); // hhea
             reader.GetTable<MaximumProfileTable>(); // maxp
@@ -339,7 +339,7 @@ namespace SixLabors.Fonts
                     {
                         LayerRecord? layer = indexes[i];
 
-                        vectors[i] = this.CreateGlyphMetrics(codePoint, layer.GlyphId, GlyphType.ColrLayer, layer.PalletteIndex);
+                        vectors[i] = this.CreateGlyphMetrics(codePoint, layer.GlyphId, GlyphType.ColrLayer, layer.PaletteIndex);
                     }
                 }
 

--- a/src/SixLabors.Fonts/FontRectangle.cs
+++ b/src/SixLabors.Fonts/FontRectangle.cs
@@ -253,7 +253,7 @@ namespace SixLabors.Fonts
         /// Creates a FontRectangle that represents the intersection between this FontRectangle and the <paramref name="rectangle"/>.
         /// </summary>
         /// <param name="rectangle">The rectangle.</param>
-        /// <returns>New <see cref="FontRectangle"/> representing the intersections between the two rectrangles.</returns>
+        /// <returns>New <see cref="FontRectangle"/> representing the intersections between the two rectangles.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FontRectangle Intersect(FontRectangle rectangle)
             => Intersect(rectangle, this);
@@ -263,7 +263,7 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        /// <returns>New <see cref="FontRectangle"/> representing the inflated rectrangle</returns>
+        /// <returns>New <see cref="FontRectangle"/> representing the inflated rectangle</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FontRectangle Inflate(float width, float height)
             => new FontRectangle(
@@ -276,12 +276,12 @@ namespace SixLabors.Fonts
         /// Creates a new <see cref="FontRectangle"/> inflated by the specified amount.
         /// </summary>
         /// <param name="size">The size.</param>
-        /// <returns>New <see cref="FontRectangle"/> representing the inflated rectrangle</returns>
+        /// <returns>New <see cref="FontRectangle"/> representing the inflated rectangle</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FontRectangle Inflate(Vector2 size) => this.Inflate(size.X, size.Y);
 
         /// <summary>
-        /// Determines if the specfied point is contained within the rectangular region defined by
+        /// Determines if the specified point is contained within the rectangular region defined by
         /// this <see cref="FontRectangle"/>.
         /// </summary>
         /// <param name="x">The x-coordinate of the given point.</param>
@@ -310,10 +310,10 @@ namespace SixLabors.Fonts
             (this.Y <= rectangle.Y) && (rectangle.Bottom <= this.Bottom);
 
         /// <summary>
-        /// Determines if the specfied <see cref="FontRectangle"/> intersects the rectangular region defined by
+        /// Determines if the specified <see cref="FontRectangle"/> intersects the rectangular region defined by
         /// this <see cref="FontRectangle"/>.
         /// </summary>
-        /// <param name="rectangle">The other Rectange. </param>
+        /// <param name="rectangle">The other rectangle.</param>
         /// <returns>The <see cref="bool"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IntersectsWith(FontRectangle rectangle) =>
@@ -324,7 +324,7 @@ namespace SixLabors.Fonts
         /// Adjusts the location of this rectangle by the specified amount.
         /// </summary>
         /// <param name="point">The point.</param>
-        /// <returns>New <see cref="FontRectangle"/> representing the offset rectrangle.</returns>
+        /// <returns>New <see cref="FontRectangle"/> representing the offset rectangle.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FontRectangle Offset(Vector2 point) => this.Offset(point.X, point.Y);
 
@@ -333,7 +333,7 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="dx">The amount to offset the x-coordinate.</param>
         /// <param name="dy">The amount to offset the y-coordinate.</param>
-        /// <returns>New <see cref="FontRectangle"/> representing the inflated rectrangle.</returns>
+        /// <returns>New <see cref="FontRectangle"/> representing the inflated rectangle.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FontRectangle Offset(float dx, float dy)
             => new FontRectangle(this.X + dx, this.Y + dy, this.Width, this.Height);

--- a/src/SixLabors.Fonts/IColorGlyphRenderer.cs
+++ b/src/SixLabors.Fonts/IColorGlyphRenderer.cs
@@ -84,10 +84,10 @@ namespace SixLabors.Fonts
         public override bool Equals(object obj) => obj is GlyphColor p && this.Equals(p);
 
         /// <summary>
-        /// Compares the  <see cref="GlyphColor"/> for equality to this color.
+        /// Compares the <see cref="GlyphColor"/> for equality to this color.
         /// </summary>
         /// <param name="other">
-        /// The other <see cref="GlyphColor"/> to compair to.
+        /// The other <see cref="GlyphColor"/> to compare to.
         /// </param>
         /// <returns>
         /// True if the current color is equal to the <paramref name="other"/> parameter; otherwise, false.

--- a/src/SixLabors.Fonts/IFontCollection.cs
+++ b/src/SixLabors.Fonts/IFontCollection.cs
@@ -56,7 +56,7 @@ namespace SixLabors.Fonts
         /// Adds a true type font collection (.ttc).
         /// </summary>
         /// <param name="path">The font collection path.</param>
-        /// <param name="descriptions">The descriptions of the added fonst.</param>
+        /// <param name="descriptions">The descriptions of the added fonts.</param>
         /// <returns>The new <see cref="IEnumerable{T}"/>.</returns>
         public IEnumerable<FontFamily> AddCollection(string path, out IEnumerable<FontDescription> descriptions);
 
@@ -123,7 +123,7 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="path">The font collection path.</param>
         /// <param name="culture">The culture of the fonts to add.</param>
-        /// <param name="descriptions">The descriptions of the added fonst.</param>
+        /// <param name="descriptions">The descriptions of the added fonts.</param>
         /// <returns>The new <see cref="IEnumerable{FontFamily}"/>.</returns>
         public IEnumerable<FontFamily> AddCollection(
             string path,

--- a/src/SixLabors.Fonts/IFontMetrics.cs
+++ b/src/SixLabors.Fonts/IFontMetrics.cs
@@ -12,7 +12,7 @@ namespace SixLabors.Fonts
     public interface IFontMetrics
     {
         /// <summary>
-        /// Gets the basic descripton of the face.
+        /// Gets the basic description of the face.
         /// </summary>
         FontDescription Description { get; }
 

--- a/src/SixLabors.Fonts/IGlyphRenderer.cs
+++ b/src/SixLabors.Fonts/IGlyphRenderer.cs
@@ -29,7 +29,7 @@ namespace SixLabors.Fonts
         void QuadraticBezierTo(Vector2 secondControlPoint, Vector2 point);
 
         /// <summary>
-        /// Draw a Cubics bezier curve connecting the previous point to <paramref name="point"/>.
+        /// Draw a cubic bezier curve connecting the previous point to <paramref name="point"/>.
         /// </summary>
         /// <param name="secondControlPoint">The second control point.</param>
         /// <param name="thirdControlPoint">The third control point.</param>

--- a/src/SixLabors.Fonts/IGlyphRendererExtensions.cs
+++ b/src/SixLabors.Fonts/IGlyphRendererExtensions.cs
@@ -6,7 +6,7 @@ using System;
 namespace SixLabors.Fonts
 {
     /// <summary>
-    /// A surface that can have a glyph renered to it as a series of actions.
+    /// A surface that can have a glyph rendered to it as a series of actions.
     /// </summary>
     public static class IGlyphRendererExtensions
     {
@@ -16,7 +16,7 @@ namespace SixLabors.Fonts
         /// <param name="renderer">The target renderer surface.</param>
         /// <param name="text">The text.</param>
         /// <param name="options">The options.</param>
-        /// <returns>Returns the orginonal <paramref name="renderer"/></returns>
+        /// <returns>Returns the original <paramref name="renderer"/></returns>
         public static IGlyphRenderer Render(this IGlyphRenderer renderer, ReadOnlySpan<char> text, RendererOptions options)
         {
             new TextRenderer(renderer).RenderText(text, options);

--- a/src/SixLabors.Fonts/IO/ZlibInflateStream.cs
+++ b/src/SixLabors.Fonts/IO/ZlibInflateStream.cs
@@ -32,7 +32,7 @@ namespace SixLabors.Fonts.IO
         /// <summary>
         /// The read crc data.
         /// </summary>
-        private byte[]? crcread;
+        private byte[]? crcRead;
 
         /// <summary>
         /// The stream responsible for decompressing the input stream.
@@ -132,16 +132,16 @@ namespace SixLabors.Fonts.IO
                 throw new ObjectDisposedException("inner stream");
             }
 
-            // We dont't check CRC on reading
+            // We don't check CRC on reading
             int read = this.deflateStream.Read(buffer, offset, count);
-            if (read < 1 && this.crcread is null)
+            if (read < 1 && this.crcRead is null)
             {
                 // The deflater has ended. We try to read the next 4 bytes from raw stream (crc)
-                this.crcread = new byte[4];
+                this.crcRead = new byte[4];
                 for (int i = 0; i < 4; i++)
                 {
                     // we dont really check/use this
-                    this.crcread[i] = (byte)this.rawStream.ReadByte();
+                    this.crcRead[i] = (byte)this.rawStream.ReadByte();
                 }
             }
 
@@ -196,13 +196,13 @@ namespace SixLabors.Fonts.IO
                     this.deflateStream.Dispose();
                     this.deflateStream = null;
 
-                    if (this.crcread is null)
+                    if (this.crcRead is null)
                     {
                         // Consume the trailing 4 bytes
-                        this.crcread = new byte[4];
+                        this.crcRead = new byte[4];
                         for (int i = 0; i < 4; i++)
                         {
-                            this.crcread[i] = (byte)this.rawStream.ReadByte();
+                            this.crcRead[i] = (byte)this.rawStream.ReadByte();
                         }
                     }
                 }

--- a/src/SixLabors.Fonts/RendererOptions.cs
+++ b/src/SixLabors.Fonts/RendererOptions.cs
@@ -114,7 +114,7 @@ namespace SixLabors.Fonts
         public float DpiY { get; set; }
 
         /// <summary>
-        /// Gets or sets the collection of Fallback fontfamiles to try and use when a specific glyph is missing.
+        /// Gets or sets the collection of fallback font families to try and use when a specific glyph is missing.
         /// </summary>
         public IEnumerable<FontFamily> FallbackFontFamilies { get; set; } = Array.Empty<FontFamily>();
 

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -73,7 +73,7 @@ namespace SixLabors.Fonts
                 }
                 catch
                 {
-                    // We swallow exceptions installing system fonts as we hold no garantees about permissions etc.
+                    // We swallow exceptions installing system fonts as we hold no guarantees about permissions etc.
                 }
             }
         }

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -17,7 +17,7 @@ namespace SixLabors.Fonts
         private static readonly Lazy<SystemFontCollection> LazySystemFonts = new Lazy<SystemFontCollection>(() => new SystemFontCollection());
 
         /// <summary>
-        /// Gets the collection containing the globaly installed system fonts.
+        /// Gets the collection containing the globally installed system fonts.
         /// </summary>
         public static IReadOnlyFontCollection Collection => LazySystemFonts.Value;
 

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format12SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format12SubTable.cs
@@ -52,7 +52,7 @@ namespace SixLabors.Fonts.Tables.General.CMap
             // SequentialMapGroup | groups[numGroups] | Array of SequentialMapGroup records.
 
             // format has already been read by this point skip it
-            ushort reserver = reader.ReadUInt16();
+            ushort reserved = reader.ReadUInt16();
             uint length = reader.ReadUInt32();
             uint language = reader.ReadUInt32();
             uint numGroups = reader.ReadUInt32();

--- a/src/SixLabors.Fonts/Tables/General/Colr/BaseGlyphRecord.cs
+++ b/src/SixLabors.Fonts/Tables/General/Colr/BaseGlyphRecord.cs
@@ -25,14 +25,14 @@ namespace SixLabors.Fonts.Tables.General.Colr
 
     internal sealed class LayerRecord
     {
-        public LayerRecord(ushort glyphId, ushort palletteIndex)
+        public LayerRecord(ushort glyphId, ushort paletteIndex)
         {
             this.GlyphId = glyphId;
-            this.PalletteIndex = palletteIndex;
+            this.PaletteIndex = paletteIndex;
         }
 
         public ushort GlyphId { get; }
 
-        public ushort PalletteIndex { get; }
+        public ushort PaletteIndex { get; }
     }
 }

--- a/src/SixLabors.Fonts/Tables/General/CpalTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CpalTable.cs
@@ -7,17 +7,17 @@ namespace SixLabors.Fonts.Tables.General
     internal class CpalTable : Table
     {
         internal const string TableName = "CPAL";
-        private readonly ushort[] palletteOffsets;
-        private readonly GlyphColor[] palletteEntries;
+        private readonly ushort[] paletteOffsets;
+        private readonly GlyphColor[] paletteEntries;
 
-        public CpalTable(ushort[] palletteOffsets, GlyphColor[] palletteEntries)
+        public CpalTable(ushort[] paletteOffsets, GlyphColor[] paletteEntries)
         {
-            this.palletteEntries = palletteEntries;
-            this.palletteOffsets = palletteOffsets;
+            this.paletteEntries = paletteEntries;
+            this.paletteOffsets = paletteOffsets;
         }
 
-        public GlyphColor GetGlyphColor(int palletteIndex, int palletteEntryIndex)
-            => this.palletteEntries[this.palletteOffsets[palletteIndex] + palletteEntryIndex];
+        public GlyphColor GetGlyphColor(int paletteIndex, int paletteEntryIndex)
+            => this.paletteEntries[this.paletteOffsets[paletteIndex] + paletteEntryIndex];
 
         public static CpalTable? Load(FontReader fontReader)
         {
@@ -68,17 +68,17 @@ namespace SixLabors.Fonts.Tables.General
             }
 
             reader.Seek(offsetFirstColorRecord, System.IO.SeekOrigin.Begin);
-            var pallettes = new GlyphColor[numColorRecords];
+            var palettes = new GlyphColor[numColorRecords];
             for (int n = 0; n < numColorRecords; n++)
             {
                 var blue = reader.ReadByte();
                 var green = reader.ReadByte();
                 var red = reader.ReadByte();
                 var alpha = reader.ReadByte();
-                pallettes[n] = new GlyphColor(blue, green, red, alpha);
+                palettes[n] = new GlyphColor(blue, green, red, alpha);
             }
 
-            return new CpalTable(colorRecordIndices, pallettes);
+            return new CpalTable(colorRecordIndices, palettes);
         }
     }
 }

--- a/src/SixLabors.Fonts/Tables/General/HeadTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/HeadTable.cs
@@ -52,7 +52,7 @@ namespace SixLabors.Fonts.Tables.General
             // Bit 14: Last Resort font.If set, indicates that the glyphs encoded in the cmap subtables are simply generic symbolic representations of code point ranges and don’t truly represent support for those code points.If unset, indicates that the glyphs encoded in the cmap subtables represent proper support for those code points.
             // Bit 15: Reserved, set to 0
             None = 0,
-            BaslineY0 = 1 << 0,
+            BaselineY0 = 1 << 0,
             LeftSidebearingPointAtX0 = 1 << 1,
             InstructionDependOnPointSize = 1 << 2,
             ForcePPEMToInt = 1 << 3,
@@ -82,7 +82,7 @@ namespace SixLabors.Fonts.Tables.General
             Italic = 1 << 1,
             Underline = 1 << 2,
             Outline = 1 << 3,
-            Shaddow = 1 << 4,
+            Shadow = 1 << 4,
             Condensed = 1 << 5,
             Extended = 1 << 6,
         }

--- a/src/SixLabors.Fonts/Tables/General/IndexLocationTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/IndexLocationTable.cs
@@ -33,16 +33,16 @@ namespace SixLabors.Fonts.Tables.General
 
         public static IndexLocationTable Load(BigEndianBinaryReader reader, int glyphCount, HeadTable.IndexLocationFormats format)
         {
-            int entrycount = glyphCount + 1;
+            int entryCount = glyphCount + 1;
 
             if (format == HeadTable.IndexLocationFormats.Offset16)
             {
                 // Type     | Name        | Description
                 // ---------|-------------|---------------------------------------
                 // Offset16 | offsets[n]  | The actual local offset divided by 2 is stored. The value of n is numGlyphs + 1. The value for numGlyphs is found in the 'maxp' table.
-                ushort[] data = reader.ReadUInt16Array(entrycount);
-                uint[] convertedData = new uint[entrycount];
-                for (int i = 0; i < entrycount; i++)
+                ushort[] data = reader.ReadUInt16Array(entryCount);
+                uint[] convertedData = new uint[entryCount];
+                for (int i = 0; i < entryCount; i++)
                 {
                     convertedData[i] = (uint)(data[i] * 2);
                 }
@@ -54,7 +54,7 @@ namespace SixLabors.Fonts.Tables.General
                 // Type     | Name        | Description
                 // ---------|-------------|---------------------------------------
                 // Offset32 | offsets[n]  | The actual local offset is stored. The value of n is numGlyphs + 1. The value for numGlyphs is found in the 'maxp' table.
-                uint[] data = reader.ReadUInt32Array(entrycount);
+                uint[] data = reader.ReadUInt32Array(entryCount);
 
                 return new IndexLocationTable(data);
             }

--- a/src/SixLabors.Fonts/Tables/General/Kern/Format0SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/Kern/Format0SubTable.cs
@@ -7,9 +7,9 @@ namespace SixLabors.Fonts.Tables.General.Kern
 {
     internal sealed class Format0SubTable : KerningSubTable
     {
-        private readonly KearningPair[] pairs;
+        private readonly KerningPair[] pairs;
 
-        public Format0SubTable(KearningPair[] pairs, KerningCoverage coverage)
+        public Format0SubTable(KerningPair[] pairs, KerningCoverage coverage)
             : base(coverage)
             => this.pairs = pairs;
 
@@ -26,10 +26,10 @@ namespace SixLabors.Fonts.Tables.General.Kern
             ushort entrySelector = reader.ReadUInt16();
             ushort rangeShift = reader.ReadUInt16();
 
-            var pairs = new KearningPair[pairCount];
+            var pairs = new KerningPair[pairCount];
             for (int i = 0; i < pairCount; i++)
             {
-                pairs[i] = KearningPair.Read(reader);
+                pairs[i] = KerningPair.Read(reader);
             }
 
             return new Format0SubTable(pairs, coverage);
@@ -37,11 +37,11 @@ namespace SixLabors.Fonts.Tables.General.Kern
 
         protected override bool TryGetOffset(ushort index1, ushort index2, out short offset)
         {
-            int index = this.pairs.AsSpan().BinarySearch(new KearningPair(index1, index2, 0));
+            int index = this.pairs.AsSpan().BinarySearch(new KerningPair(index1, index2, 0));
 
             if (index >= 0)
             {
-                ref KearningPair pair = ref this.pairs[index];
+                ref KerningPair pair = ref this.pairs[index];
                 offset = pair.Offset;
                 return true;
             }

--- a/src/SixLabors.Fonts/Tables/General/Kern/KerningPair.cs
+++ b/src/SixLabors.Fonts/Tables/General/Kern/KerningPair.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace SixLabors.Fonts.Tables.General.Kern
 {
-    internal readonly struct KearningPair : IComparable<KearningPair>
+    internal readonly struct KerningPair : IComparable<KerningPair>
     {
-        internal KearningPair(ushort left, ushort right, short offset)
+        internal KerningPair(ushort left, ushort right, short offset)
         {
             this.Left = left;
             this.Right = right;
@@ -29,16 +29,16 @@ namespace SixLabors.Fonts.Tables.General.Kern
             return value + right;
         }
 
-        public static KearningPair Read(BigEndianBinaryReader reader)
+        public static KerningPair Read(BigEndianBinaryReader reader)
 
              // Type   | Field | Description
              // -------|-------|-------------------------------
              // uint16 | left  | The glyph index for the left-hand glyph in the kerning pair.
              // uint16 | right | The glyph index for the right-hand glyph in the kerning pair.
              // FWORD  | value | The kerning value for the above pair, in FUnits.If this value is greater than zero, the characters will be moved apart.If this value is less than zero, the character will be moved closer together.
-             => new KearningPair(reader.ReadUInt16(), reader.ReadUInt16(), reader.ReadFWORD());
+             => new KerningPair(reader.ReadUInt16(), reader.ReadUInt16(), reader.ReadFWORD());
 
-        public int CompareTo(KearningPair other)
+        public int CompareTo(KerningPair other)
             => this.Key.CompareTo(other.Key);
     }
 }

--- a/src/SixLabors.Fonts/Tables/General/NameTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/NameTable.cs
@@ -70,7 +70,7 @@ namespace SixLabors.Fonts.Tables.General
             {
                 if (name.NameID == nameId)
                 {
-                    // get just the first one, just incase.
+                    // get just the first one, just in case.
                     first ??= name;
                     if (name.Platform == PlatformIDs.Windows)
                     {

--- a/src/SixLabors.Fonts/Tables/General/OS2Table.cs
+++ b/src/SixLabors.Fonts/Tables/General/OS2Table.cs
@@ -115,16 +115,16 @@ namespace SixLabors.Fonts.Tables.General
             this.maxContext = maxContext;
         }
 
-        public OS2Table(OS2Table versionLessthan5Table, ushort lowerOpticalPointSize, ushort upperOpticalPointSize)
+        public OS2Table(OS2Table versionLessThan5Table, ushort lowerOpticalPointSize, ushort upperOpticalPointSize)
             : this(
-                versionLessthan5Table,
-                versionLessthan5Table.codePageRange1,
-                versionLessthan5Table.codePageRange2,
-                versionLessthan5Table.heightX,
-                versionLessthan5Table.capHeight,
-                versionLessthan5Table.defaultChar,
-                versionLessthan5Table.breakChar,
-                versionLessthan5Table.maxContext)
+                versionLessThan5Table,
+                versionLessThan5Table.codePageRange1,
+                versionLessThan5Table.codePageRange2,
+                versionLessThan5Table.heightX,
+                versionLessThan5Table.capHeight,
+                versionLessThan5Table.defaultChar,
+                versionLessThan5Table.breakChar,
+                versionLessThan5Table.maxContext)
         {
             this.lowerOpticalPointSize = lowerOpticalPointSize;
             this.upperOpticalPointSize = upperOpticalPointSize;
@@ -321,7 +321,7 @@ namespace SixLabors.Fonts.Tables.General
             breakChar = reader.ReadUInt16();
             maxContext = reader.ReadUInt16();
 
-            var versionLessthan5Table = new OS2Table(
+            var versionLessThan5Table = new OS2Table(
                     version0Table,
                     codePageRange1,
                     codePageRange2,
@@ -333,14 +333,14 @@ namespace SixLabors.Fonts.Tables.General
 
             if (version < 5)
             {
-                return versionLessthan5Table;
+                return versionLessThan5Table;
             }
 
             ushort lowerOpticalPointSize = reader.ReadUInt16();
             ushort upperOpticalPointSize = reader.ReadUInt16();
 
             return new OS2Table(
-                versionLessthan5Table,
+                versionLessThan5Table,
                 lowerOpticalPointSize,
                 upperOpticalPointSize);
         }

--- a/src/SixLabors.Fonts/Tables/TableLoader.cs
+++ b/src/SixLabors.Fonts/Tables/TableLoader.cs
@@ -50,9 +50,9 @@ namespace SixLabors.Fonts.Tables
             return value;
         }
 
-        internal IEnumerable<Type> RegisterdTypes() => this.types.Keys;
+        internal IEnumerable<Type> RegisteredTypes() => this.types.Keys;
 
-        internal IEnumerable<string> RegisterdTags() => this.types.Values;
+        internal IEnumerable<string> RegisteredTags() => this.types.Values;
 
         private void Register<T>(string tag, Func<FontReader, T?> createFunc)
             where T : Table

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -20,7 +20,7 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The style.</param>
-        /// <returns>A collection of layout that describe all thats needed to measure or render a series of glyphs.</returns>
+        /// <returns>A collection of layout that describe all that's needed to measure or render a series of glyphs.</returns>
         public IReadOnlyList<GlyphLayout> GenerateLayout(ReadOnlySpan<char> text, RendererOptions options)
         {
             if (text.IsEmpty)
@@ -82,7 +82,7 @@ namespace SixLabors.Fonts
             bool startOfLine = true;
             float totalHeight = 0;
 
-            // Calculate the intitial position of potential line breaks.
+            // Calculate the initial position of potential line breaks.
             var lineBreakEnumerator = new LineBreakEnumerator(text);
             if (lineBreakEnumerator.MoveNext())
             {
@@ -127,7 +127,7 @@ namespace SixLabors.Fonts
                     float fontHeight = glyph.FontMetrics.LineHeight * options.LineSpacing;
                     if (fontHeight > unscaledLineHeight)
                     {
-                        // Get the largest lineheight thus far
+                        // Get the largest line height thus far
                         unscaledLineHeight = fontHeight;
                         scale = glyph.ScaleFactor;
                         lineHeight = unscaledLineHeight * spanStyle.PointSize / scale;

--- a/src/SixLabors.Fonts/Unicode/GraphemeClusterClass.cs
+++ b/src/SixLabors.Fonts/Unicode/GraphemeClusterClass.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-// Redordering these enum properties will require the regeneration of the Grapheme.trie.
+// Reordering these enum properties will require the regeneration of the Grapheme.trie.
 namespace SixLabors.Fonts.Unicode
 {
     /// <summary>

--- a/src/SixLabors.Fonts/Unicode/LineBreakClass.cs
+++ b/src/SixLabors.Fonts/Unicode/LineBreakClass.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-// Redordering these enum properties will require the regeneration of the LineBreak.trie.
+// Reordering these enum properties will require the regeneration of the LineBreak.trie.
 namespace SixLabors.Fonts.Unicode
 {
     /// <summary>

--- a/src/SixLabors.Fonts/Unicode/LineBreakEnumerator.cs
+++ b/src/SixLabors.Fonts/Unicode/LineBreakEnumerator.cs
@@ -292,7 +292,7 @@ namespace SixLabors.Fonts.Unicode
             // - U+0028 (Left Opening Parenthesis)
             // - U+005B (Opening Square Bracket)
             // - U+007B (Left Curly Bracket)
-            // See custom colums|rules in the text pair table.
+            // See custom columns|rules in the text pair table.
             // https://www.unicode.org/Public/13.0.0/ucd/auxiliary/LineBreakTest.html
             this.lb30 = this.alphaNumericCount > 0
                 && cls == LineBreakClass.OP

--- a/src/SixLabors.Fonts/Unicode/SpanGraphemeEnumerator.cs
+++ b/src/SixLabors.Fonts/Unicode/SpanGraphemeEnumerator.cs
@@ -179,7 +179,7 @@ namespace SixLabors.Fonts.Unicode
                         processor.MoveNext();
                     }
 
-                    // Standlone RI scalars (or a single pair of RI scalars) can only be followed by trailers.
+                    // Standalone RI scalars (or a single pair of RI scalars) can only be followed by trailers.
                     break; // nothing but trailers after the final RI
 
                 default:

--- a/src/SixLabors.Fonts/Unicode/TODO/BidiAlgorithm.cs
+++ b/src/SixLabors.Fonts/Unicode/TODO/BidiAlgorithm.cs
@@ -169,7 +169,7 @@ namespace SixLabors.Fonts.Unicode
         private const int MaxPairedBracketDepth = 63;
 
         /// <summary>
-        /// Re-useable list of pending opening brackets used by the
+        /// Reusable list of pending opening brackets used by the
         /// LocatePairedBrackets method
         /// </summary>
         private readonly List<int> pendingOpeningBrackets = new List<int>();
@@ -320,7 +320,7 @@ namespace SixLabors.Fonts.Unicode
                     case BidiCharacterType.LeftToRightIsolate:
                     case BidiCharacterType.RightToLeftIsolate:
                         // Skip isolate pairs
-                        // (Because we're working with a slice, we need to adjust the indicies
+                        // (Because we're working with a slice, we need to adjust the indices
                         //  we're using for the isolatePairs map)
                         if (this.isolatePairs.TryGetValue(data.Start + i, out i))
                         {
@@ -668,7 +668,7 @@ namespace SixLabors.Fonts.Unicode
         /// <param name="level">The level of the run</param>
         private void AddLevelRun(int start, int length, int level)
         {
-            // Get original indicies to first and last character in this run
+            // Get original indices to first and last character in this run
             int firstCharIndex = this.MapX9(start);
             int lastCharIndex = this.MapX9(start + length - 1);
 
@@ -793,7 +793,7 @@ namespace SixLabors.Fonts.Unicode
                     // Remove this run as we've now processed it
                     this.levelRuns.RemoveAt(runIndex);
 
-                    // Add the x9 map indicies for the run range to the mapping
+                    // Add the x9 map indices for the run range to the mapping
                     // for this isolated run
                     this.isolatedRunMapping.Add(this.x9Map.AsSlice(r.Start, r.Length));
 
@@ -988,7 +988,7 @@ namespace SixLabors.Fonts.Unicode
                             seqEnd++;
                         }
 
-                        // Preceeded by, or followed by EN?
+                        // Preceded by, or followed by EN?
                         if ((seqStart == 0 ? sos : this.runResolvedTypes[seqStart - 1]) == BidiCharacterType.EuropeanNumber
                             || (seqEnd == this.runLength ? eos : this.runResolvedTypes[seqEnd]) == BidiCharacterType.EuropeanNumber)
                         {
@@ -1262,7 +1262,7 @@ namespace SixLabors.Fonts.Unicode
         /// <summary>
         /// Inspect a paired bracket set and determine its strong direction
         /// </summary>
-        /// <param name="pb">The paired bracket to be inpected</param>
+        /// <param name="pb">The paired bracket to be inspected</param>
         /// <returns>The direction of the bracket set content</returns>
         private BidiCharacterType InspectPairedBracket(in BracketPair pb)
         {
@@ -1432,7 +1432,7 @@ namespace SixLabors.Fonts.Unicode
         }
 
         /// <summary>
-        /// Check if a directionality type represents whitepsace
+        /// Check if a directionality type represents whitespace
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsWhitespace(BidiCharacterType biditype)

--- a/src/SixLabors.Fonts/Unicode/TODO/MappedArraySlice{T}.cs
+++ b/src/SixLabors.Fonts/Unicode/TODO/MappedArraySlice{T}.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 namespace SixLabors.Fonts.Unicode
 {
     /// <summary>
-    /// Provides a mapped view of an underlying slice, selecting arbitrary indicies
+    /// Provides a mapped view of an underlying slice, selecting arbitrary indices
     /// from the source array.
     /// </summary>
     /// <typeparam name="T">The type of item contained in the underlying array.</typeparam>

--- a/src/SixLabors.Fonts/VerticalAlignment.cs
+++ b/src/SixLabors.Fonts/VerticalAlignment.cs
@@ -4,7 +4,7 @@
 namespace SixLabors.Fonts
 {
     /// <summary>
-    /// Vertial alignment modes.
+    /// Vertical alignment modes.
     /// </summary>
     public enum VerticalAlignment
     {

--- a/tests/SixLabors.Fonts.Tests/FontDescriptionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontDescriptionTests.cs
@@ -85,7 +85,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void LoadFontDescription_CultureNamePriority_Exactmatch()
+        public void LoadFontDescription_CultureNamePriority_ExactMatch()
         {
             var usCulture = new CultureInfo(0x0409);
             var c1 = new CultureInfo(1034); // spanish - international

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -36,14 +36,14 @@ namespace SixLabors.Fonts.Tests
                 0),
                 10);
 
-            Vector2 locationInFontSpace = new Vector2(99, 99) / 72; // glyph ends up 10px over due to offiset in fake glyph
+            Vector2 locationInFontSpace = new Vector2(99, 99) / 72; // glyph ends up 10px over due to offset in fake glyph
             glyph.RenderTo(this.renderer, locationInFontSpace, 72, 0);
 
             Assert.Equal(new FontRectangle(99, 89, 0, 0), this.renderer.GlyphRects.Single());
         }
 
         [Fact]
-        public void IdenticalGlyphsInDifferentPalcesCreateIdenticalKeys()
+        public void IdenticalGlyphsInDifferentPlacesCreateIdenticalKeys()
         {
             Font fakeFont = CreateFont("AB");
             var textRenderer = new TextRenderer(this.renderer);
@@ -55,7 +55,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void BeginGlyph_returnsfalse_skiprenderingfigures()
+        public void BeginGlyph_ReturnsFalse_SkipRenderingFigures()
         {
             var renderer = new Mock<IGlyphRenderer>();
             renderer.Setup(x => x.BeginGlyph(It.IsAny<FontRectangle>(), It.IsAny<GlyphRendererParameters>())).Returns(false);
@@ -67,7 +67,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void BeginGlyph_returnstrue_rendersfigures()
+        public void BeginGlyph_ReturnsTrue_RendersFigures()
         {
             var renderer = new Mock<IGlyphRenderer>();
             renderer.Setup(x => x.BeginGlyph(It.IsAny<FontRectangle>(), It.IsAny<GlyphRendererParameters>())).Returns(true);

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
@@ -8,7 +8,7 @@ namespace SixLabors.Fonts.Tests.Issues
     public class Issues_27
     {
         [Fact]
-        public void ThrowsMeasureingWhitespace()
+        public void ThrowsMeasuringWhitespace()
         {
             // wendy one returns wrong points for 'o'
             Font font = new FontCollection().Add(TestFonts.WendyOneFile).CreateFont(12);

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
@@ -10,7 +10,7 @@ namespace SixLabors.Fonts.Tests.Issues
     public class Issues_33
     {
         [Theory]
-        [InlineData("\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs", 760, 70)] // newlines arn't directly measured but it is used for offseting
+        [InlineData("\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs", 760, 70)] // newlines aren't directly measured but it is used for offsetting
         [InlineData("\n\tHelloworld", 400, 10)]
         [InlineData("\tHelloworld", 400, 10)]
         [InlineData("  Helloworld", 340, 10)]

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
@@ -15,7 +15,6 @@ namespace SixLabors.Fonts.Tests.Issues
             Font font = CreateFont("\t x");
             FontRectangle xWidth = TextMeasurer.MeasureBounds("x", new RendererOptions(font, font.FontMetrics.ScaleFactor));
             FontRectangle tabWidth = TextMeasurer.MeasureBounds("\t", new RendererOptions(font, font.FontMetrics.ScaleFactor));
-            FontRectangle doublTabWidth = TextMeasurer.MeasureBounds("\t\t", new RendererOptions(font, font.FontMetrics.ScaleFactor));
             FontRectangle tabWithXWidth = TextMeasurer.MeasureBounds("\tx", new RendererOptions(font, font.FontMetrics.ScaleFactor));
 
             Assert.Equal(tabWidth.Width + xWidth.Width, tabWithXWidth.Width, 2);

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
@@ -15,7 +15,7 @@ namespace SixLabors.Fonts.Tests.Issues
         [InlineData(3)]
         [InlineData(4)]
         [InlineData(5)]
-        public void TextWidthFroTabOnlyTextSouldBeSingleTabWidthMultipliedByTabCount(int tabCount)
+        public void TextWidthForTabOnlyTextShouldBeSingleTabWidthMultipliedByTabCount(int tabCount)
         {
             Font font = CreateFont("\t x");
 
@@ -32,7 +32,7 @@ namespace SixLabors.Fonts.Tests.Issues
         [InlineData(3)]
         [InlineData(4)]
         [InlineData(5)]
-        public void TextWidthFroTabOnlyTextSouldBeSingleTabWidthMultipliedByTabCountMinusX(int tabCount)
+        public void TextWidthForTabOnlyTextShouldBeSingleTabWidthMultipliedByTabCountMinusX(int tabCount)
         {
             Font font = CreateFont("\t x");
 

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -41,7 +41,7 @@ namespace SixLabors.Fonts.Tests.Issues
         [InlineData("hello world hello world hello world hello world", HorizontalAlignment.Right)]
         [InlineData("hello world hello world hello world hello world", HorizontalAlignment.Center)]
         [InlineData("hello   world   hello   world   hello   hello   world", HorizontalAlignment.Left)]
-        public void NewWrappedLinesShouldNotStartOrEndWithWhiteSpace(string text, HorizontalAlignment horiAlignment)
+        public void NewWrappedLinesShouldNotStartOrEndWithWhiteSpace(string text, HorizontalAlignment horizontalAlignment)
         {
             Font font = CreateFont("\t x");
 
@@ -50,7 +50,7 @@ namespace SixLabors.Fonts.Tests.Issues
             IReadOnlyList<GlyphLayout> layout = new TextLayout().GenerateLayout(text.AsSpan(), new RendererOptions(new Font(font, 30), 72)
             {
                 WrappingWidth = 350,
-                HorizontalAlignment = horiAlignment
+                HorizontalAlignment = horizontalAlignment
             });
 
             float lineYPos = layout[0].Location.Y;

--- a/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/RendererOptionsTests.cs
@@ -22,7 +22,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void ContructorTest_FontOnly()
+        public void ConstructorTest_FontOnly()
         {
             Font font = FakeFont.CreateFont("ABC");
             var options = new RendererOptions(font);
@@ -36,7 +36,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void ContructorTest_FontWithSingleDpi()
+        public void ConstructorTest_FontWithSingleDpi()
         {
             Font font = FakeFont.CreateFont("ABC");
             float dpi = 123;
@@ -51,7 +51,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void ContructorTest_FontWithXandYDpis()
+        public void ConstructorTest_FontWithXandYDpis()
         {
             Font font = FakeFont.CreateFont("ABC");
             float dpix = 123;
@@ -67,7 +67,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void ContructorTest_FontWithOrigin()
+        public void ConstructorTest_FontWithOrigin()
         {
             Font font = FakeFont.CreateFont("ABC");
             var origin = new Vector2(123, 345);
@@ -82,7 +82,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void ContructorTest_FontWithSingleDpiWithOrigin()
+        public void ConstructorTest_FontWithSingleDpiWithOrigin()
         {
             Font font = FakeFont.CreateFont("ABC");
             var origin = new Vector2(123, 345);
@@ -98,7 +98,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void ContructorTest_FontWithXandYDpisWithOrigin()
+        public void ConstructorTest_FontWithXandYDpisWithOrigin()
         {
             Font font = FakeFont.CreateFont("ABC");
             var origin = new Vector2(123, 345);
@@ -115,10 +115,10 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void ContructorTest_FontOnly_WithFallbackFonts()
+        public void ConstructorTest_FontOnly_WithFallbackFonts()
         {
             Font font = FakeFont.CreateFont("ABC");
-            FontFamily[] fontFamilys = new[]
+            FontFamily[] fontFamilies = new[]
             {
                 FakeFont.CreateFont("DEF").Family,
                 FakeFont.CreateFont("GHI").Family
@@ -126,22 +126,22 @@ namespace SixLabors.Fonts.Tests
 
             var options = new RendererOptions(font)
             {
-                FallbackFontFamilies = fontFamilys
+                FallbackFontFamilies = fontFamilies
             };
 
             Assert.Equal(72, options.DpiX);
             Assert.Equal(72, options.DpiY);
-            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(fontFamilies, options.FallbackFontFamilies);
             Assert.Equal(font, options.Font);
             Assert.Equal(Vector2.Zero, options.Origin);
             VerifyPropertyDefault(options);
         }
 
         [Fact]
-        public void ContructorTest_FontWithSingleDpi_WithFallbackFonts()
+        public void ConstructorTest_FontWithSingleDpi_WithFallbackFonts()
         {
             Font font = FakeFont.CreateFont("ABC");
-            FontFamily[] fontFamilys = new[]
+            FontFamily[] fontFamilies = new[]
             {
                 FakeFont.CreateFont("DEF").Family,
                 FakeFont.CreateFont("GHI").Family
@@ -150,22 +150,22 @@ namespace SixLabors.Fonts.Tests
             float dpi = 123;
             var options = new RendererOptions(font, dpi)
             {
-                FallbackFontFamilies = fontFamilys
+                FallbackFontFamilies = fontFamilies
             };
 
             Assert.Equal(dpi, options.DpiX);
             Assert.Equal(dpi, options.DpiY);
-            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(fontFamilies, options.FallbackFontFamilies);
             Assert.Equal(font, options.Font);
             Assert.Equal(Vector2.Zero, options.Origin);
             VerifyPropertyDefault(options);
         }
 
         [Fact]
-        public void ContructorTest_FontWithXandYDpis_WithFallbackFonts()
+        public void ConstructorTest_FontWithXandYDpis_WithFallbackFonts()
         {
             Font font = FakeFont.CreateFont("ABC");
-            FontFamily[] fontFamilys = new[]
+            FontFamily[] fontFamilies = new[]
             {
                 FakeFont.CreateFont("DEF").Family,
                 FakeFont.CreateFont("GHI").Family
@@ -175,22 +175,22 @@ namespace SixLabors.Fonts.Tests
             float dpiy = 456;
             var options = new RendererOptions(font, dpix, dpiy)
             {
-                FallbackFontFamilies = fontFamilys
+                FallbackFontFamilies = fontFamilies
             };
 
             Assert.Equal(dpix, options.DpiX);
             Assert.Equal(dpiy, options.DpiY);
-            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(fontFamilies, options.FallbackFontFamilies);
             Assert.Equal(font, options.Font);
             Assert.Equal(Vector2.Zero, options.Origin);
             VerifyPropertyDefault(options);
         }
 
         [Fact]
-        public void ContructorTest_FontWithOrigin_WithFallbackFonts()
+        public void ConstructorTest_FontWithOrigin_WithFallbackFonts()
         {
             Font font = FakeFont.CreateFont("ABC");
-            FontFamily[] fontFamilys = new[]
+            FontFamily[] fontFamilies = new[]
             {
                 FakeFont.CreateFont("DEF").Family,
                 FakeFont.CreateFont("GHI").Family
@@ -199,22 +199,22 @@ namespace SixLabors.Fonts.Tests
             var origin = new Vector2(123, 345);
             var options = new RendererOptions(font, origin)
             {
-                FallbackFontFamilies = fontFamilys
+                FallbackFontFamilies = fontFamilies
             };
 
             Assert.Equal(72, options.DpiX);
             Assert.Equal(72, options.DpiY);
-            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(fontFamilies, options.FallbackFontFamilies);
             Assert.Equal(font, options.Font);
             Assert.Equal(origin, options.Origin);
             VerifyPropertyDefault(options);
         }
 
         [Fact]
-        public void ContructorTest_FontWithSingleDpiWithOrigin_WithFallbackFonts()
+        public void ConstructorTest_FontWithSingleDpiWithOrigin_WithFallbackFonts()
         {
             Font font = FakeFont.CreateFont("ABC");
-            FontFamily[] fontFamilys = new[]
+            FontFamily[] fontFamilies = new[]
             {
                 FakeFont.CreateFont("DEF").Family,
                 FakeFont.CreateFont("GHI").Family
@@ -224,22 +224,22 @@ namespace SixLabors.Fonts.Tests
             float dpi = 123;
             var options = new RendererOptions(font, dpi, origin)
             {
-                FallbackFontFamilies = fontFamilys
+                FallbackFontFamilies = fontFamilies
             };
 
             Assert.Equal(dpi, options.DpiX);
             Assert.Equal(dpi, options.DpiY);
-            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(fontFamilies, options.FallbackFontFamilies);
             Assert.Equal(font, options.Font);
             Assert.Equal(origin, options.Origin);
             VerifyPropertyDefault(options);
         }
 
         [Fact]
-        public void ContructorTest_FontWithXandYDpisWithOrigin_WithFallbackFonts()
+        public void ConstructorTest_FontWithXandYDpisWithOrigin_WithFallbackFonts()
         {
             Font font = FakeFont.CreateFont("ABC");
-            FontFamily[] fontFamilys = new[]
+            FontFamily[] fontFamilies = new[]
             {
                 FakeFont.CreateFont("DEF").Family,
                 FakeFont.CreateFont("GHI").Family
@@ -250,12 +250,12 @@ namespace SixLabors.Fonts.Tests
             float dpiy = 456;
             var options = new RendererOptions(font, dpix, dpiy, origin)
             {
-                FallbackFontFamilies = fontFamilys
+                FallbackFontFamilies = fontFamilies
             };
 
             Assert.Equal(dpix, options.DpiX);
             Assert.Equal(dpiy, options.DpiY);
-            Assert.Equal(fontFamilys, options.FallbackFontFamilies);
+            Assert.Equal(fontFamilies, options.FallbackFontFamilies);
             Assert.Equal(font, options.Font);
             Assert.Equal(origin, options.Origin);
             VerifyPropertyDefault(options);
@@ -265,7 +265,7 @@ namespace SixLabors.Fonts.Tests
         public void GetStylePassesCorrectValues()
         {
             Font font = FakeFont.CreateFontWithInstance("ABC", out Fakes.FakeFontInstance abcFontInstance);
-            FontFamily[] fontFamilys = new[]
+            FontFamily[] fontFamilies = new[]
             {
                 FakeFont.CreateFontWithInstance("DEF", out Fakes.FakeFontInstance defFontInstance).Family,
                 FakeFont.CreateFontWithInstance("GHI", out Fakes.FakeFontInstance ghiFontInstance).Family
@@ -273,7 +273,7 @@ namespace SixLabors.Fonts.Tests
 
             var options = new RendererOptions(font)
             {
-                FallbackFontFamilies = fontFamilys
+                FallbackFontFamilies = fontFamilies
             };
 
             AppliedFontStyle style = options.GetStyle(4, 10);
@@ -294,7 +294,7 @@ namespace SixLabors.Fonts.Tests
         public void GetMissingGlyphFromMainFont()
         {
             Font font = FakeFont.CreateFontWithInstance("ABC", out Fakes.FakeFontInstance abcFontInstance);
-            FontFamily[] fontFamilys = new[]
+            FontFamily[] fontFamilies = new[]
             {
                 FakeFont.CreateFontWithInstance("DEF", out Fakes.FakeFontInstance defFontInstance).Family,
                 FakeFont.CreateFontWithInstance("GHI", out Fakes.FakeFontInstance ghiFontInstance).Family
@@ -302,7 +302,7 @@ namespace SixLabors.Fonts.Tests
 
             var options = new RendererOptions(font)
             {
-                FallbackFontFamilies = fontFamilys
+                FallbackFontFamilies = fontFamilies
             };
 
             AppliedFontStyle style = options.GetStyle(4, 10);
@@ -319,7 +319,7 @@ namespace SixLabors.Fonts.Tests
         public void GetGlyphFromFirstAvailableInstance(char character, string instance)
         {
             Font font = FakeFont.CreateFontWithInstance("ABC", out Fakes.FakeFontInstance abcFontInstance);
-            FontFamily[] fontFamilys = new[]
+            FontFamily[] fontFamilies = new[]
             {
                 FakeFont.CreateFontWithInstance("DEF", out Fakes.FakeFontInstance defFontInstance).Family,
                 FakeFont.CreateFontWithInstance("EFGHI", out Fakes.FakeFontInstance efghiFontInstance).Family
@@ -327,7 +327,7 @@ namespace SixLabors.Fonts.Tests
 
             var options = new RendererOptions(font)
             {
-                FallbackFontFamilies = fontFamilys
+                FallbackFontFamilies = fontFamilies
             };
 
             AppliedFontStyle style = options.GetStyle(4, 10);

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format0SubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format0SubTableTests.cs
@@ -25,7 +25,7 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
                     new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }));
 
             BigEndianBinaryReader reader = writer.GetReader();
-            ushort format = reader.ReadUInt16(); // read format before we pass along as thats whet the cmap table does
+            ushort format = reader.ReadUInt16(); // read format before we pass along as that's what the cmap table does
             Assert.Equal(0, format);
 
             Format0SubTable table = Format0SubTable.Load(

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format4SubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CMap/Format4SubTableTests.cs
@@ -27,7 +27,7 @@ namespace SixLabors.Fonts.Tests.Tables.General.CMap
                     new ushort[] { 1, 2, 3, 4, 5, 6, 7, 8 }));
 
             BigEndianBinaryReader reader = writer.GetReader();
-            ushort format = reader.ReadUInt16(); // read format before we pass along as thats whet the cmap table does
+            ushort format = reader.ReadUInt16(); // read format before we pass along as that's what the cmap table does
             Assert.Equal(4, format);
 
             Format4SubTable table = Format4SubTable.Load(

--- a/tests/SixLabors.Fonts.Tests/Tables/General/ColrTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/ColrTableTests.cs
@@ -33,8 +33,8 @@ namespace SixLabors.Fonts.Tests.Tables.General
                     Glyph = 1,
                     Layers =
                     {
-                        new ColrLayerRecord { Glyph = 10, Pallete = 1 },
-                        new ColrLayerRecord { Glyph = 11, Pallete = 2 }
+                        new ColrLayerRecord { Glyph = 10, Palette = 1 },
+                        new ColrLayerRecord { Glyph = 11, Palette = 2 }
                     }
                 },
                 new ColrGlyphRecord
@@ -42,8 +42,8 @@ namespace SixLabors.Fonts.Tests.Tables.General
                     Glyph = 2,
                     Layers =
                     {
-                        new ColrLayerRecord { Glyph = 12, Pallete = 1 },
-                        new ColrLayerRecord { Glyph = 13, Pallete = 2 }
+                        new ColrLayerRecord { Glyph = 12, Palette = 1 },
+                        new ColrLayerRecord { Glyph = 13, Palette = 2 }
                     }
                 }
             });

--- a/tests/SixLabors.Fonts.Tests/Tables/General/Glyphs/CompositeGlyphLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/Glyphs/CompositeGlyphLoaderTests.cs
@@ -11,7 +11,7 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
     public class CompositeGlyphLoaderTests
     {
         [Fact]
-        public void LoadSingleGlyphWithUInt16Offset_unsignd_short()
+        public void LoadSingleGlyphWithUInt16Offset_unsigned_short()
         {
             var writer = new BigEndianBinaryWriter();
             writer.WriteUInt16((ushort)CompositeGlyphFlags.ArgsAreWords); // 16bit unsigned
@@ -63,7 +63,7 @@ namespace SixLabors.Fonts.Tests.Tables.General.Glyphs
         }
 
         [Fact]
-        public void LoadSingleGlyphWithUInt8Offset_unsignd_byte()
+        public void LoadSingleGlyphWithUInt8Offset_unsigned_byte()
         {
             var writer = new BigEndianBinaryWriter();
             writer.WriteUInt16(0); // 8bit unsigned

--- a/tests/SixLabors.Fonts.Tests/Tables/TableLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/TableLoaderTests.cs
@@ -34,12 +34,12 @@ namespace SixLabors.Fonts.Tests.Tables
         public void AllNamedTablesAreRegistered(Type type, string name)
         {
             var tl = new TableLoader();
-            Assert.Contains(type, tl.RegisterdTypes());
+            Assert.Contains(type, tl.RegisteredTypes());
             Assert.Equal(name, tl.GetTag(type));
         }
 
         [Fact]
-        public void DefaultIsnotNull() => Assert.NotNull(TableLoader.Default);
+        public void DefaultIsNotNull() => Assert.NotNull(TableLoader.Default);
 
         [Fact]
         public void TryingToLoadUnregisteredTagReturnsUnknownTable()

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -69,7 +69,7 @@ namespace SixLabors.Fonts.Tests
             -155)]
         public void VerticalAlignmentTests(
             VerticalAlignment vertical,
-            HorizontalAlignment horizental,
+            HorizontalAlignment horizontal,
             float top,
             float left)
         {
@@ -78,7 +78,7 @@ namespace SixLabors.Fonts.Tests
 
             var span = new RendererOptions(font, font.FontMetrics.ScaleFactor)
             {
-                HorizontalAlignment = horizental,
+                HorizontalAlignment = horizontal,
                 VerticalAlignment = vertical
             };
 

--- a/tests/SixLabors.Fonts.Tests/TrueTypeCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TrueTypeCollectionTests.cs
@@ -11,7 +11,7 @@ namespace SixLabors.Fonts.Tests
     public class TrueTypeCollectionTests
     {
         [Fact]
-        public void AddViaPathReturnsDecription()
+        public void AddViaPathReturnsDescription()
         {
             var suit = new FontCollection();
             IEnumerable<FontFamily> collectionFromPath = suit.AddCollection(TestFonts.SimpleTrueTypeCollection, out IEnumerable<FontDescription> descriptions);
@@ -40,7 +40,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Fact]
-        public void AddViaStreamhReturnsDecription()
+        public void AddViaStreamReturnsDescription()
         {
             var suit = new FontCollection();
             IEnumerable<FontFamily> collectionFromPath = suit.AddCollection(TestFonts.SSimpleTrueTypeCollectionData(), out IEnumerable<FontDescription> descriptions);

--- a/tests/SixLabors.Fonts.Tests/WriterExtensions.cs
+++ b/tests/SixLabors.Fonts.Tests/WriterExtensions.cs
@@ -556,7 +556,7 @@ namespace SixLabors.Fonts.Tests
                 foreach (ColrLayerRecord l in g.Layers)
                 {
                     writer.WriteUInt16(l.Glyph);
-                    writer.WriteUInt16(l.Pallete);
+                    writer.WriteUInt16(l.Palette);
                 }
             }
         }
@@ -576,7 +576,7 @@ namespace SixLabors.Fonts.Tests
         {
             public ushort Glyph { get; set; }
 
-            public ushort Pallete { get; set; }
+            public ushort Palette { get; set; }
 
             public int LayerSize => 4;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Many typos are fixed. No public classes/methods/members have any typos, only internal or private classes/methods/members are fixed meaning that no breaking change is introduced by this pull request.