### PR TITLE
Add FontCollection.AddSystemFontCollection

### DIFF
--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -15,7 +14,7 @@ namespace SixLabors.Fonts
     /// <summary>
     /// Represents a collection of font families.
     /// </summary>
-    public sealed class FontCollection : IFontCollection, IFontMetricsCollection, IReadOnlyFontMetricsCollection
+    public sealed class FontCollection : IFontCollection, IFontMetricsCollection
     {
         private readonly HashSet<IFontMetrics> metricsCollection = new HashSet<IFontMetrics>();
 

--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -161,6 +161,10 @@ namespace SixLabors.Fonts
         IEnumerable<FontStyle> IReadOnlyFontMetricsCollection.GetAllStyles(string name, CultureInfo culture)
             => ((IReadOnlyFontMetricsCollection)this).GetAllMetrics(name, culture).Select(x => x.Description.Style).ToArray();
 
+        /// <inheritdoc/>
+        IEnumerator<IFontMetrics> IReadOnlyFontMetricsCollection.GetEnumerator()
+            => this.metricsCollection.GetEnumerator();
+
         private FontFamily AddImpl(string path, CultureInfo culture, out FontDescription description)
         {
             var instance = new FileFontMetrics(path);
@@ -254,13 +258,5 @@ namespace SixLabors.Fonts
 
             throw new FontFamilyNotFoundException(name);
         }
-
-        /// <inheritdoc/>
-        IEnumerator<IFontMetrics> IEnumerable<IFontMetrics>.GetEnumerator()
-            => this.metricsCollection.GetEnumerator();
-
-        /// <inheritdoc/>
-        IEnumerator IEnumerable.GetEnumerator()
-            => this.metricsCollection.GetEnumerator();
     }
 }

--- a/src/SixLabors.Fonts/FontCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/FontCollectionExtensions.cs
@@ -13,7 +13,7 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="collection">The font collection.</param>
         /// <returns>The <see cref="FontCollection"/> containing the system fonts.</returns>
-        public static FontCollection AddSystemFontCollection(this FontCollection collection)
+        public static FontCollection AddSystemFonts(this FontCollection collection)
         {
             // This cast is safe because our underlying SystemFontCollection implements
             // both interfaces separately.

--- a/src/SixLabors.Fonts/FontCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/FontCollectionExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.Fonts
+{
+    /// <summary>
+    /// Extension methods for <see cref="IFontCollection"/>.
+    /// </summary>
+    public static class FontCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the fonts from the <see cref="SystemFonts"/> collection to this <see cref="FontCollection"/>.
+        /// </summary>
+        /// <param name="collection">The font collection.</param>
+        /// <returns>The <see cref="FontCollection"/> containing the system fonts.</returns>
+        public static FontCollection AddSystemFontCollection(this FontCollection collection)
+        {
+            // This cast is safe because our underlying SystemFontCollection implements
+            // both interfaces separately.
+            foreach (IFontMetrics? metric in (IReadOnlyFontMetricsCollection)SystemFonts.Collection)
+            {
+                ((IFontMetricsCollection)collection).AddMetrics(metric);
+            }
+
+            return collection;
+        }
+    }
+}

--- a/src/SixLabors.Fonts/IFontMetricsCollection.cs
+++ b/src/SixLabors.Fonts/IFontMetricsCollection.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Globalization;
+
+namespace SixLabors.Fonts
+{
+    /// <summary>
+    /// Represents a collection of <see cref="IFontMetrics"/>
+    /// </summary>
+    internal interface IFontMetricsCollection : IReadOnlyFontMetricsCollection
+    {
+        /// <summary>
+        /// Adds the font metrics and culture to the <see cref="IFontMetricsCollection"/>.
+        /// </summary>
+        /// <param name="metrics">The font metrics to add.</param>
+        /// <param name="culture">The culture of the font metrics to add.</param>
+        /// <returns>The new <see cref="FontFamily"/>.</returns>
+        FontFamily AddMetrics(IFontMetrics metrics, CultureInfo culture);
+
+        /// <summary>
+        /// Adds the font metrics to the <see cref="IFontMetricsCollection"/>.
+        /// </summary>
+        /// <param name="metrics">The font metrics to add.</param>
+        void AddMetrics(IFontMetrics metrics);
+    }
+}

--- a/src/SixLabors.Fonts/IReadonlyFontMetricsCollection.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontMetricsCollection.cs
@@ -10,8 +10,9 @@ namespace SixLabors.Fonts
 {
     /// <summary>
     /// Represents a readonly collection of font metrics.
+    /// The interface uses compiler pattern matching to provide enumeration capabilities.
     /// </summary>
-    internal interface IReadOnlyFontMetricsCollection : IEnumerable<IFontMetrics>
+    internal interface IReadOnlyFontMetricsCollection
     {
         /// <summary>
         /// Gets the specified font metrics matching the given culture and font family name.
@@ -48,5 +49,8 @@ namespace SixLabors.Fonts
         /// <returns>The <see cref="IEnumerable{FontStyle}"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/></exception>
         IEnumerable<FontStyle> GetAllStyles(string name, CultureInfo culture);
+
+        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+        IEnumerator<IFontMetrics> GetEnumerator();
     }
 }

--- a/src/SixLabors.Fonts/IReadonlyFontMetricsCollection.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontMetricsCollection.cs
@@ -11,7 +11,7 @@ namespace SixLabors.Fonts
     /// <summary>
     /// Represents a readonly collection of font metrics.
     /// </summary>
-    internal interface IReadOnlyFontMetricsCollection
+    internal interface IReadOnlyFontMetricsCollection : IEnumerable<IFontMetrics>
     {
         /// <summary>
         /// Gets the specified font metrics matching the given culture and font family name.

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
-#if SUPPORTS_CULTUREINFO_LCID
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-#endif
 using System.IO;
 using System.Linq;
 
@@ -14,7 +14,7 @@ namespace SixLabors.Fonts
     /// <summary>
     /// Provides a collection of fonts.
     /// </summary>
-    internal sealed class SystemFontCollection : IReadOnlyFontCollection
+    internal sealed class SystemFontCollection : IReadOnlyFontCollection, IReadOnlyFontMetricsCollection
     {
         private readonly FontCollection collection = new FontCollection();
 
@@ -101,5 +101,25 @@ namespace SixLabors.Fonts
         public bool TryGet(string name, CultureInfo culture, out FontFamily family)
             => this.collection.TryGet(name, culture, out family);
 #endif
+
+        /// <inheritdoc/>
+        bool IReadOnlyFontMetricsCollection.TryGetMetrics(string name, CultureInfo culture, FontStyle style, [NotNullWhen(true)] out IFontMetrics? metrics)
+            => ((IReadOnlyFontMetricsCollection)this.collection).TryGetMetrics(name, culture, style, out metrics);
+
+        /// <inheritdoc/>
+        IEnumerable<IFontMetrics> IReadOnlyFontMetricsCollection.GetAllMetrics(string name, CultureInfo culture)
+            => ((IReadOnlyFontMetricsCollection)this.collection).GetAllMetrics(name, culture);
+
+        /// <inheritdoc/>
+        IEnumerable<FontStyle> IReadOnlyFontMetricsCollection.GetAllStyles(string name, CultureInfo culture)
+            => ((IReadOnlyFontMetricsCollection)this.collection).GetAllStyles(name, culture);
+
+        /// <inheritdoc/>
+        IEnumerator<IFontMetrics> IEnumerable<IFontMetrics>.GetEnumerator()
+            => ((IReadOnlyFontMetricsCollection)this.collection).GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+            => ((IReadOnlyFontMetricsCollection)this.collection).GetEnumerator();
     }
 }

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -115,11 +114,7 @@ namespace SixLabors.Fonts
             => ((IReadOnlyFontMetricsCollection)this.collection).GetAllStyles(name, culture);
 
         /// <inheritdoc/>
-        IEnumerator<IFontMetrics> IEnumerable<IFontMetrics>.GetEnumerator()
-            => ((IReadOnlyFontMetricsCollection)this.collection).GetEnumerator();
-
-        /// <inheritdoc/>
-        IEnumerator IEnumerable.GetEnumerator()
+        IEnumerator<IFontMetrics> IReadOnlyFontMetricsCollection.GetEnumerator()
             => ((IReadOnlyFontMetricsCollection)this.collection).GetEnumerator();
     }
 }

--- a/tests/SixLabors.Fonts.Tests/FakeFont.cs
+++ b/tests/SixLabors.Fonts.Tests/FakeFont.cs
@@ -26,9 +26,9 @@ namespace SixLabors.Fonts.Tests
 
         internal static Font CreateFontWithInstance(string text, out FakeFontInstance instance)
         {
-            var fc = new FontCollection();
+            var fc = (IFontMetricsCollection)new FontCollection();
             instance = FakeFontInstance.CreateFontWithVaryingVerticalFontMetrics(text);
-            Font d = fc.Add(instance, CultureInfo.InvariantCulture).CreateFont(12);
+            Font d = fc.AddMetrics(instance, CultureInfo.InvariantCulture).CreateFont(12);
             return new Font(d, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests
@@ -56,6 +57,19 @@ namespace SixLabors.Fonts.Tests
                 () => new FontCollection().Get(invalid));
 
             Assert.Equal(invalid, ex.FontFamily);
+        }
+
+        [Fact]
+        public void CanAddSystemFonts()
+        {
+            var collection = new FontCollection();
+
+            Assert.False(collection.Families.Any());
+
+            collection.AddSystemFontCollection();
+
+            Assert.True(collection.Families.Any());
+            Assert.Equal(collection.Families.Count(), SystemFonts.Families.Count());
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
@@ -66,7 +66,7 @@ namespace SixLabors.Fonts.Tests
 
             Assert.False(collection.Families.Any());
 
-            collection.AddSystemFontCollection();
+            collection.AddSystemFonts();
 
             Assert.True(collection.Families.Any());
             Assert.Equal(collection.Families.Count(), SystemFonts.Families.Count());

--- a/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
@@ -15,8 +15,8 @@ namespace SixLabors.Fonts.Tests
         public void AddViaPathReturnsDescription()
         {
             var sut = new FontCollection();
+            sut.Add(TestFonts.CarterOneFile, out FontDescription description);
 
-            FontFamily family = sut.Add(TestFonts.CarterOneFile, out FontDescription description);
             Assert.NotNull(description);
             Assert.Equal("Carter One", description.FontFamilyInvariantCulture);
             Assert.Equal("Regular", description.FontSubFamilyNameInvariantCulture);

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -80,8 +80,8 @@ namespace SixLabors.Fonts.Tests
 
         public static Font CreateFont(string text)
         {
-            var fc = new FontCollection();
-            Font d = fc.Add(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
+            var fc = (IFontMetricsCollection)new FontCollection();
+            Font d = fc.AddMetrics(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
             return new Font(d, 1);
         }
 

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
@@ -26,8 +26,8 @@ namespace SixLabors.Fonts.Tests.Issues
 
         public static Font CreateFont(string text)
         {
-            var fc = new FontCollection();
-            Font d = fc.Add(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
+            var fc = (IFontMetricsCollection)new FontCollection();
+            Font d = fc.AddMetrics(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
             return new Font(d, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
@@ -27,8 +27,8 @@ namespace SixLabors.Fonts.Tests.Issues
 
         public static Font CreateFont(string text)
         {
-            var fc = new FontCollection();
-            Font d = fc.Add(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
+            var fc = (IFontMetricsCollection)new FontCollection();
+            Font d = fc.AddMetrics(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
             return new Font(d, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_35.cs
@@ -55,8 +55,8 @@ namespace SixLabors.Fonts.Tests.Issues
 
         public static Font CreateFont(string text)
         {
-            var fc = new FontCollection();
-            Font d = fc.Add(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
+            var fc = (IFontMetricsCollection)new FontCollection();
+            Font d = fc.AddMetrics(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
             return new Font(d, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_36.cs
@@ -48,8 +48,8 @@ namespace SixLabors.Fonts.Tests.Issues
 
         public static Font CreateFont(string text)
         {
-            var fc = new FontCollection();
-            Font d = fc.Add(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
+            var fc = (IFontMetricsCollection)new FontCollection();
+            Font d = fc.AddMetrics(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
             return new Font(d, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_39.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_39.cs
@@ -21,8 +21,8 @@ namespace SixLabors.Fonts.Tests.Issues
 
         public static Font CreateFont(string text)
         {
-            var fc = new FontCollection();
-            Font d = fc.Add(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
+            var fc = (IFontMetricsCollection)new FontCollection();
+            Font d = fc.AddMetrics(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
             return new Font(d, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -104,8 +104,8 @@ namespace SixLabors.Fonts.Tests.Issues
 
         public static Font CreateFont(string text)
         {
-            var fc = new FontCollection();
-            Font d = fc.Add(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
+            var fc = (IFontMetricsCollection)new FontCollection();
+            Font d = fc.AddMetrics(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
             return new Font(d, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/SystemFontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/SystemFontCollectionTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -8,6 +9,8 @@ namespace SixLabors.Fonts.Tests
 {
     public class SystemFontCollectionTests
     {
+        private static readonly SystemFontCollection SysFontCollection = new SystemFontCollection();
+
         [Fact]
         public void SystemFonts_IsPopulated()
         {
@@ -63,6 +66,36 @@ namespace SixLabors.Fonts.Tests
 
             font = SystemFonts.CreateFont(family.Name, family.Culture, 12F, FontStyle.Regular);
             Assert.NotNull(font);
+        }
+
+        [Fact]
+        public void CanEnumerateSystemFontMetrics()
+        {
+            IEnumerator<IFontMetrics> enumerator = ((IReadOnlyFontMetricsCollection)SysFontCollection).GetEnumerator();
+
+            int count = 0;
+            while (enumerator.MoveNext())
+            {
+                count++;
+                Assert.NotNull(enumerator.Current);
+            }
+
+            Assert.True(count > 0);
+        }
+
+        [Fact]
+        public void CanEnumerateNonGenericSystemFontMetrics()
+        {
+            System.Collections.IEnumerator enumerator = ((IReadOnlyFontMetricsCollection)SysFontCollection).GetEnumerator();
+
+            int count = 0;
+            while (enumerator.MoveNext())
+            {
+                count++;
+                Assert.NotNull(enumerator.Current);
+            }
+
+            Assert.True(count > 0);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/SystemFontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/SystemFontCollectionTests.cs
@@ -97,5 +97,37 @@ namespace SixLabors.Fonts.Tests
 
             Assert.True(count > 0);
         }
+
+        [Fact]
+        public void CanGetAllMetricsByCulture()
+        {
+            var collection = (IReadOnlyFontMetricsCollection)SysFontCollection;
+            FontFamily family = SysFontCollection.Families.First();
+            IEnumerable<IFontMetrics> metrics = collection.GetAllMetrics(family.Name, family.Culture);
+
+            Assert.True(metrics.Any());
+
+            foreach (IFontMetrics item in metrics)
+            {
+                Assert.True(family.TryGetMetrics(item.Description.Style, out IFontMetrics familyMetrics));
+                Assert.True(collection.TryGetMetrics(
+                    family.Name,
+                    family.Culture,
+                    item.Description.Style,
+                    out IFontMetrics fontMetrics));
+
+                Assert.Equal(familyMetrics, fontMetrics);
+            }
+        }
+
+        [Fact]
+        public void CanGetAllStylesByCulture()
+        {
+            FontFamily family = SysFontCollection.Families.First();
+            IEnumerable<FontStyle> styles = ((IReadOnlyFontMetricsCollection)SysFontCollection).GetAllStyles(family.Name, family.Culture);
+
+            Assert.True(styles.Any());
+            Assert.Equal(family.GetAvailableStyles(), styles);
+        }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -221,8 +221,8 @@ namespace SixLabors.Fonts.Tests
 
         public static Font CreateFont(string text)
         {
-            var fc = new FontCollection();
-            Font d = fc.Add(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
+            var fc = (IFontMetricsCollection)new FontCollection();
+            Font d = fc.AddMetrics(new FakeFontInstance(text), CultureInfo.InvariantCulture).CreateFont(12);
             return new Font(d, 1);
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Implements `FontCollection.AddSystemFontCollection()` extension and normalizes the process of adding metrics to the underlying collection.

<!-- Thanks for contributing to SixLabors.Fonts! -->
