### PR TITLE
Better font family not found exception

### DIFF
--- a/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
@@ -1,6 +1,10 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace SixLabors.Fonts
 {
     /// <summary>
@@ -14,12 +18,51 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="family">The name of the missing font family.</param>
         public FontFamilyNotFoundException(string family)
-            : base($"{family} could not be found")
-            => this.FontFamily = family;
+            : this(family, Array.Empty<string>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FontFamilyNotFoundException"/> class.
+        /// </summary>
+        /// <param name="family">The name of the missing font family.</param>
+        /// <param name="searchDirectories">
+        /// The collection of directories that were searched for the font family.
+        /// Pass an empty collection if font families were not searched in directories.
+        /// </param>
+        public FontFamilyNotFoundException(string family, IReadOnlyCollection<string> searchDirectories)
+            : base(GetMessage(family, searchDirectories))
+        {
+            this.FontFamily = family;
+            this.SearchDirectories = searchDirectories;
+        }
 
         /// <summary>
         /// Gets the name of the font family we failed to find.
         /// </summary>
         public string FontFamily { get; }
+
+        /// <summary>
+        /// Gets the collection of directories that were unsuccessfully searched for the font family.
+        /// </summary>
+        /// <remarks>
+        /// If the searched collection does not involve the system font collection then the search directories are empty.
+        /// </remarks>
+        public IReadOnlyCollection<string> SearchDirectories { get; }
+
+        private static string GetMessage(string family, IReadOnlyCollection<string> searchDirectories)
+        {
+            if (searchDirectories.Count == 0)
+            {
+                return $"The \"{family}\" font family could not be found";
+            }
+
+            if (searchDirectories.Count == 1)
+            {
+                return $"The \"{family}\" font family could not be found in the following directory: {searchDirectories.First()}";
+            }
+
+            return $"The \"{family}\" font family could not be found in the following directories:{Environment.NewLine}{string.Join(Environment.NewLine, searchDirectories.Select(e => $"  * {e}"))}";
+        }
     }
 }

--- a/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
+++ b/src/SixLabors.Fonts/Exceptions/FontFamilyNotFoundException.cs
@@ -38,7 +38,7 @@ namespace SixLabors.Fonts
         }
 
         /// <summary>
-        /// Gets the name of the font family we failed to find.
+        /// Gets the name of the font family that was not found.
         /// </summary>
         public string FontFamily { get; }
 
@@ -46,7 +46,7 @@ namespace SixLabors.Fonts
         /// Gets the collection of directories that were unsuccessfully searched for the font family.
         /// </summary>
         /// <remarks>
-        /// If the searched collection does not involve the system font collection then the search directories are empty.
+        /// If the exception did not originate from the <see cref="SystemFonts.Collection"/> then this property will be empty.
         /// </remarks>
         public IReadOnlyCollection<string> SearchDirectories { get; }
 
@@ -62,7 +62,7 @@ namespace SixLabors.Fonts
                 return $"The \"{family}\" font family could not be found in the following directory: {searchDirectories.First()}";
             }
 
-            return $"The \"{family}\" font family could not be found in the following directories:{Environment.NewLine}{string.Join(Environment.NewLine, searchDirectories.Select(e => $"  * {e}"))}";
+            return $"The \"{family}\" font family could not be found in the following directories:{Environment.NewLine}{string.Join(Environment.NewLine, searchDirectories.Select(e => $" * {e}"))}";
         }
     }
 }

--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -16,7 +16,25 @@ namespace SixLabors.Fonts
     /// </summary>
     public sealed class FontCollection : IFontCollection, IFontMetricsCollection
     {
+        private readonly HashSet<string> searchDirectories;
         private readonly HashSet<FontMetrics> metricsCollection = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FontCollection"/> class.
+        /// </summary>
+        public FontCollection()
+            : this(Array.Empty<string>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FontCollection"/> class.
+        /// </summary>
+        /// <param name="searchDirectories">The collection of directories used to search for font families.</param>
+        internal FontCollection(IReadOnlyCollection<string> searchDirectories)
+        {
+            this.searchDirectories = new HashSet<string>(searchDirectories ?? throw new ArgumentNullException(nameof(searchDirectories)));
+        }
 
         /// <inheritdoc/>
         public IEnumerable<FontFamily> Families => this.FamiliesByCultureImpl(CultureInfo.InvariantCulture);
@@ -253,7 +271,7 @@ namespace SixLabors.Fonts
                 return family;
             }
 
-            throw new FontFamilyNotFoundException(name);
+            throw new FontFamilyNotFoundException(name, this.searchDirectories);
         }
     }
 }

--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -16,7 +16,7 @@ namespace SixLabors.Fonts
     /// </summary>
     public sealed class FontCollection : IFontCollection, IFontMetricsCollection
     {
-        private readonly HashSet<string> searchDirectories;
+        private readonly HashSet<string> searchDirectories = new();
         private readonly HashSet<FontMetrics> metricsCollection = new();
 
         /// <summary>
@@ -36,16 +36,17 @@ namespace SixLabors.Fonts
         /// are actually added after searching inside physical file system directories. The message of the
         /// <see cref="FontFamilyNotFoundException"/> will include the searched directories.
         /// </remarks>
-        public FontCollection(IReadOnlyCollection<string> searchDirectories)
+        internal FontCollection(IReadOnlyCollection<string> searchDirectories)
         {
-            this.searchDirectories = new HashSet<string>(searchDirectories ?? throw new ArgumentNullException(nameof(searchDirectories)));
+            Guard.NotNull(searchDirectories, nameof(searchDirectories));
+            foreach (string? dir in searchDirectories)
+            {
+                this.searchDirectories.Add(dir);
+            }
         }
 
         /// <inheritdoc/>
         public IEnumerable<FontFamily> Families => this.FamiliesByCultureImpl(CultureInfo.InvariantCulture);
-
-        /// <inheritdoc/>
-        public IEnumerable<string> SearchDirectories => this.searchDirectories;
 
         /// <inheritdoc/>
         public FontFamily Add(string path)
@@ -190,7 +191,7 @@ namespace SixLabors.Fonts
 
         internal void AddSearchDirectories(IEnumerable<string> directories)
         {
-            foreach (var directory in directories)
+            foreach (string? directory in directories)
             {
                 this.searchDirectories.Add(directory);
             }

--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -31,7 +31,12 @@ namespace SixLabors.Fonts
         /// Initializes a new instance of the <see cref="FontCollection"/> class.
         /// </summary>
         /// <param name="searchDirectories">The collection of directories used to search for font families.</param>
-        internal FontCollection(IReadOnlyCollection<string> searchDirectories)
+        /// <remarks>
+        /// Use this constructor instead of the parameterless constructor if the fonts added to that collection
+        /// are actually added after searching inside physical file system directories. The message of the
+        /// <see cref="FontFamilyNotFoundException"/> will include the searched directories.
+        /// </remarks>
+        public FontCollection(IReadOnlyCollection<string> searchDirectories)
         {
             this.searchDirectories = new HashSet<string>(searchDirectories ?? throw new ArgumentNullException(nameof(searchDirectories)));
         }

--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -40,6 +40,9 @@ namespace SixLabors.Fonts
         public IEnumerable<FontFamily> Families => this.FamiliesByCultureImpl(CultureInfo.InvariantCulture);
 
         /// <inheritdoc/>
+        public IEnumerable<string> SearchDirectories => this.searchDirectories;
+
+        /// <inheritdoc/>
         public FontFamily Add(string path)
             => this.Add(path, out _);
 
@@ -179,6 +182,14 @@ namespace SixLabors.Fonts
         /// <inheritdoc/>
         IEnumerator<FontMetrics> IReadOnlyFontMetricsCollection.GetEnumerator()
             => this.metricsCollection.GetEnumerator();
+
+        internal void AddSearchDirectories(IEnumerable<string> directories)
+        {
+            foreach (var directory in directories)
+            {
+                this.searchDirectories.Add(directory);
+            }
+        }
 
         private FontFamily AddImpl(string path, CultureInfo culture, out FontDescription description)
         {

--- a/src/SixLabors.Fonts/FontCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/FontCollectionExtensions.cs
@@ -22,6 +22,8 @@ namespace SixLabors.Fonts
                 ((IFontMetricsCollection)collection).AddMetrics(metric);
             }
 
+            collection.AddSearchDirectories(SystemFonts.Collection.SearchDirectories);
+
             return collection;
         }
     }

--- a/src/SixLabors.Fonts/IReadOnlySystemFontCollection.cs
+++ b/src/SixLabors.Fonts/IReadOnlySystemFontCollection.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+
+namespace SixLabors.Fonts
+{
+    /// <summary>
+    /// Represents a readonly collection of Operating System fonts.
+    /// </summary>
+    public interface IReadOnlySystemFontCollection : IReadOnlyFontCollection
+    {
+        /// <summary>
+        /// <para>
+        /// Gets the collection of Operating System directories that were searched for font families.
+        /// </para>
+        /// </summary>
+        public IEnumerable<string> SearchDirectories { get; }
+    }
+}

--- a/src/SixLabors.Fonts/IReadonlyFontCollection.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontCollection.cs
@@ -19,6 +19,18 @@ namespace SixLabors.Fonts
         IEnumerable<FontFamily> Families { get; }
 
         /// <summary>
+        /// <para>
+        /// Gets the collection of directories that were searched for font families.
+        /// </para>
+        /// <para>
+        /// The search directories are only applicable for the <see cref="SystemFontCollection"/> or if
+        /// <see cref="FontCollectionExtensions.AddSystemFonts"/> was called on a font collection.
+        /// For font collections that do not involve system fonts, the search directories is always empty.
+        /// </para>
+        /// </summary>
+        public IEnumerable<string> SearchDirectories { get; }
+
+        /// <summary>
         /// Gets the specified font family matching the invariant culture and font family name.
         /// </summary>
         /// <param name="name">The font family name.</param>

--- a/src/SixLabors.Fonts/IReadonlyFontCollection.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontCollection.cs
@@ -19,18 +19,6 @@ namespace SixLabors.Fonts
         IEnumerable<FontFamily> Families { get; }
 
         /// <summary>
-        /// <para>
-        /// Gets the collection of directories that were searched for font families.
-        /// </para>
-        /// <para>
-        /// The search directories are only applicable for the <see cref="SystemFontCollection"/> or if
-        /// <see cref="FontCollectionExtensions.AddSystemFonts"/> was called on a font collection.
-        /// For font collections that do not involve system fonts, the search directories is always empty.
-        /// </para>
-        /// </summary>
-        public IEnumerable<string> SearchDirectories { get; }
-
-        /// <summary>
         /// Gets the specified font family matching the invariant culture and font family name.
         /// </summary>
         /// <param name="name">The font family name.</param>

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -29,16 +29,16 @@ namespace SixLabors.Fonts
             {
                 StandardFontLocations = new[]
                 {
-                    "%SYSTEMROOT%\\Fonts",
-                    "%APPDATA%\\Microsoft\\Windows\\Fonts",
-                    "%LOCALAPPDATA%\\Microsoft\\Windows\\Fonts",
+                    @"%SYSTEMROOT%\Fonts",
+                    @"%APPDATA%\Microsoft\Windows\Fonts",
+                    @"%LOCALAPPDATA%\Microsoft\Windows\Fonts",
                 };
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 StandardFontLocations = new[]
                 {
-                    "~/.fonts/",
+                    "%HOME%/.fonts/",
                     "/usr/local/share/fonts/",
                     "/usr/share/fonts/",
                 };
@@ -47,11 +47,12 @@ namespace SixLabors.Fonts
             {
                 StandardFontLocations = new[]
                 {
-                    "~/Library/Fonts/",
+                    // As documented on "Mac OS X: Font locations and their purposes"
+                    // https://web.archive.org/web/20191015122508/https://support.apple.com/en-us/HT201722
+                    "%HOME%/Library/Fonts/",
                     "/Library/Fonts/",
-                    "/Network/Library/Fonts/",
                     "/System/Library/Fonts/",
-                    "/System Folder/Fonts/",
+                    "/Network/Library/Fonts/",
                 };
             }
             else

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -103,6 +103,9 @@ namespace SixLabors.Fonts
         public IEnumerable<FontFamily> Families => this.collection.Families;
 
         /// <inheritdoc/>
+        public IEnumerable<string> SearchDirectories => this.collection.SearchDirectories;
+
+        /// <inheritdoc/>
         public FontFamily Get(string name) => this.collection.Get(name);
 
         /// <inheritdoc/>

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -14,9 +14,10 @@ namespace SixLabors.Fonts
     /// <summary>
     /// Provides a collection of fonts.
     /// </summary>
-    internal sealed class SystemFontCollection : IReadOnlyFontCollection, IReadOnlyFontMetricsCollection
+    internal sealed class SystemFontCollection : IReadOnlySystemFontCollection, IReadOnlyFontMetricsCollection
     {
         private readonly FontCollection collection;
+        private readonly IReadOnlyCollection<string> searchDirectories;
 
         /// <summary>
         /// Gets the default set of locations we probe for System Fonts.
@@ -69,12 +70,12 @@ namespace SixLabors.Fonts
         public SystemFontCollection(IEnumerable<string> paths)
         {
             string[] expanded = paths.Select(x => Environment.ExpandEnvironmentVariables(x)).ToArray();
-            string[] foundDirectories = expanded.Where(x => Directory.Exists(x)).ToArray();
+            this.searchDirectories = expanded.Where(x => Directory.Exists(x)).ToArray();
 
-            this.collection = new FontCollection(foundDirectories);
+            this.collection = new FontCollection(this.searchDirectories);
 
             // We do this to provide a consistent experience with case sensitive file systems.
-            IEnumerable<string> files = foundDirectories
+            IEnumerable<string> files = this.searchDirectories
                                 .SelectMany(x => Directory.EnumerateFiles(x, "*.*", SearchOption.AllDirectories))
                                 .Where(x => Path.GetExtension(x).Equals(".ttf", StringComparison.OrdinalIgnoreCase)
                                 || Path.GetExtension(x).Equals(".ttc", StringComparison.OrdinalIgnoreCase));
@@ -103,7 +104,7 @@ namespace SixLabors.Fonts
         public IEnumerable<FontFamily> Families => this.collection.Families;
 
         /// <inheritdoc/>
-        public IEnumerable<string> SearchDirectories => this.collection.SearchDirectories;
+        public IEnumerable<string> SearchDirectories => this.searchDirectories;
 
         /// <inheritdoc/>
         public FontFamily Get(string name) => this.collection.Get(name);

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -12,12 +12,12 @@ namespace SixLabors.Fonts
     /// </summary>
     public static class SystemFonts
     {
-        private static readonly Lazy<SystemFontCollection> LazySystemFonts = new Lazy<SystemFontCollection>(() => new SystemFontCollection());
+        private static readonly Lazy<SystemFontCollection> LazySystemFonts = new(() => new SystemFontCollection());
 
         /// <summary>
         /// Gets the collection containing the globally installed system fonts.
         /// </summary>
-        public static IReadOnlyFontCollection Collection => LazySystemFonts.Value;
+        public static IReadOnlySystemFontCollection Collection => LazySystemFonts.Value;
 
         /// <summary>
         /// Gets the collection of <see cref="FontFamily"/>s installed on current system.

--- a/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
@@ -57,6 +57,7 @@ namespace SixLabors.Fonts.Tests
                 () => new FontCollection().Get(invalid));
 
             Assert.Equal(invalid, ex.FontFamily);
+            Assert.Empty(ex.SearchDirectories);
         }
 
         [Fact]

--- a/tests/SixLabors.Fonts.Tests/SystemFontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/SystemFontCollectionTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests
@@ -128,6 +129,31 @@ namespace SixLabors.Fonts.Tests
 
             Assert.True(styles.Any());
             Assert.Equal(family.GetAvailableStyles(), styles);
+        }
+
+        [Fact]
+        public void SystemFonts_FontFamilyNotFound_Throws()
+        {
+            void Action() => SystemFonts.Get("AFontThatDoesNotExist");
+
+            FontFamilyNotFoundException exception = Assert.Throws<FontFamilyNotFoundException>(Action);
+            Assert.Equal("AFontThatDoesNotExist", exception.FontFamily);
+            Assert.Contains("AFontThatDoesNotExist", exception.Message);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Contains(@"Windows\Fonts", exception.Message);
+                Assert.Contains(exception.SearchDirectories, e => e.Contains(@"Windows\Fonts"));
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Assert.Contains(@"/share/fonts/", exception.Message);
+                Assert.Contains(exception.SearchDirectories, e => e.Contains(@"share/fonts"));
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Assert.Contains(@"/Library/Fonts/", exception.Message);
+                Assert.Contains(exception.SearchDirectories, e => e.Contains(@"Library/Fonts"));
+            }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
The message now includes all the directory paths where font families were searched and a new `SearchDirectories` property with those same paths.

Before this pull request the exception message was:
> ```
> Caviar Dreams could not be found

After this pull request, the exception message is (specific paths depend on the operating system):
> ```
> The "Caviar Dreams" font family could not be found in the following directories:
>   * /Users/0xced/Library/Fonts/
>   * /Library/Fonts/
>   * /System/Library/Fonts/

Also, the system fonts search paths were improved
* Verbatim string literals are used on Windows
* `%HOME%` is used instead of `~` for Linux and macOS user paths because unlike environment variables, the tilde is not expanded by `Environment.ExpandEnvironmentVariables`
* `/System Folder/Fonts/` was removed on macOS, this was a relic of the Mac OS  9 to OS X transition