### PR TITLE
Support Word Breaking.

### DIFF
--- a/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
+++ b/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13.3" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13.7" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/SixLabors.Fonts/GlyphLayout.cs
+++ b/src/SixLabors.Fonts/GlyphLayout.cs
@@ -78,6 +78,24 @@ namespace SixLabors.Fonts
         /// <returns>The <see cref="bool"/>.</returns>
         public bool IsWhiteSpace() => CodePoint.IsWhiteSpace(this.CodePoint);
 
+        /// <summary>
+        /// Create a new <see cref="GlyphLayout"/> from the given layout offset by the specifid amount.
+        /// </summary>
+        /// <param name="glyphLayout">The glyph layout.</param>
+        /// <param name="offset">The vector to offset the layout by.</param>
+        /// <param name="startOfLine">Whether the glyph should be considered to fall at the start of a line.</param>
+        /// <returns>The <see cref="GlyphLayout"/>.</returns>
+        public static GlyphLayout Offset(GlyphLayout glyphLayout, Vector2 offset, bool startOfLine)
+            => new GlyphLayout(
+                glyphLayout.GraphemeIndex,
+                glyphLayout.CodePoint,
+                glyphLayout.Glyph,
+                glyphLayout.Location + offset,
+                glyphLayout.Width,
+                glyphLayout.Height,
+                glyphLayout.LineHeight,
+                startOfLine);
+
         internal FontRectangle BoundingBox(Vector2 dpi)
         {
             FontRectangle box = this.Glyph.BoundingBox(this.Location * dpi, dpi);

--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -31,7 +31,7 @@ namespace SixLabors.Fonts
             GlyphColor? glyphColor = null)
         {
             this.FontMetrics = font;
-            this.Codepoint = codePoint;
+            this.CodePoint = codePoint;
             this.UnitsPerEm = unitsPerEM;
             this.vector = vector;
 
@@ -56,7 +56,7 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Gets the Unicode codepoint of the glyph.
         /// </summary>
-        public CodePoint Codepoint { get; }
+        public CodePoint CodePoint { get; }
 
         /// <summary>
         /// Gets the advance width for horizontal layout, expressed in font units.

--- a/src/SixLabors.Fonts/RendererOptions.cs
+++ b/src/SixLabors.Fonts/RendererOptions.cs
@@ -121,10 +121,15 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Gets or sets the width relative to the current DPI at which text will automatically wrap onto a newline
         /// </summary>
-        /// <value>
-        ///     if value is -1 then wrapping is disabled.
-        /// </value>
+        /// <remarks>
+        /// If value is -1 then wrapping is disabled.
+        /// </remarks>
         public float WrappingWidth { get; set; } = -1;
+
+        /// <summary>
+        /// Gets or sets the word breaking mode to use when wrapping text.
+        /// </summary>
+        public WordBreaking WordBreaking { get; set; }
 
         /// <summary>
         /// Gets or sets the line spacing. Applied as a multiple of the line height.

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -72,9 +72,9 @@ namespace SixLabors.Fonts
             float left = glyphLayouts.Min(x => x.Location.X);
             float right = glyphLayouts.Max(x => x.Location.X + x.Width);
 
-            // location is bottom left of the line
+            // Location is bottom left of the line. We offset the bottom by the top to handle the ascender
             float top = glyphLayouts.Min(x => x.Location.Y - x.LineHeight);
-            float bottom = glyphLayouts.Max(x => x.Location.Y - x.LineHeight + x.Height);
+            float bottom = glyphLayouts.Max(x => x.Location.Y - x.LineHeight + x.Height) - top;
 
             Vector2 topLeft = new Vector2(left, top) * dpi;
             Vector2 bottomRight = new Vector2(right, bottom) * dpi;

--- a/src/SixLabors.Fonts/Unicode/UnicodeUtility.cs
+++ b/src/SixLabors.Fonts/Unicode/UnicodeUtility.cs
@@ -28,6 +28,101 @@ namespace SixLabors.Fonts.Unicode
         public static bool IsBmpCodePoint(uint value) => value <= 0xFFFFu;
 
         /// <summary>
+        /// Returns <see langword="true"/> if <paramref name="value"/> is a
+        /// Chinese/Japanese/Korean (CJK) character.
+        /// </summary>
+        /// <remarks>
+        /// <see href="https://blog.ceshine.net/post/cjk-unicode/"/>
+        /// <see href="https://en.wikipedia.org/wiki/Hiragana_%28Unicode_block%29"/>
+        /// <see href="https://en.wikipedia.org/wiki/Katakana_(Unicode_block)"/>
+        /// <see href="https://en.wikipedia.org/wiki/Hangul_Syllables"/>
+        /// <see href="https://en.wikipedia.org/wiki/CJK_Unified_Ideographs"/>
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsCJKCodePoint(uint value)
+        {
+            // Hiragana
+            if (IsInRangeInclusive(value, 0x3040u, 0x309Fu))
+            {
+                return true;
+            }
+
+            // Katakana
+            if (IsInRangeInclusive(value, 0x30A0u, 0x30FFu))
+            {
+                return true;
+            }
+
+            // Hangul Syllables
+            if (IsInRangeInclusive(value, 0xAC00u, 0xD7A3u))
+            {
+                return true;
+            }
+
+            // CJK Unified Ideographs
+            if (IsInRangeInclusive(value, 0x4E00u, 0x9FFFu))
+            {
+                return true;
+            }
+
+            // CJK Unified Ideographs Extension A
+            if (IsInRangeInclusive(value, 0x3400u, 0x4DBFu))
+            {
+                return true;
+            }
+
+            // CJK Unified Ideographs Extension B
+            if (IsInRangeInclusive(value, 0x20000u, 0x2A6DFu))
+            {
+                return true;
+            }
+
+            // CJK Unified Ideographs Extension C
+            if (IsInRangeInclusive(value, 0x2A700u, 0x2B73Fu))
+            {
+                return true;
+            }
+
+            // CJK Unified Ideographs Extension D
+            if (IsInRangeInclusive(value, 0x2B740u, 0x2B81Fu))
+            {
+                return true;
+            }
+
+            // CJK Unified Ideographs Extension E
+            if (IsInRangeInclusive(value, 0x2B820u, 0x2CEAFu))
+            {
+                return true;
+            }
+
+            // CJK Unified Ideographs Extension F
+            if (IsInRangeInclusive(value, 0x2CEB0u, 0x2EBEFu))
+            {
+                return true;
+            }
+
+            // CJK Unified Ideographs Extension G
+            if (IsInRangeInclusive(value, 0x30000u, 0x3134Fu))
+            {
+                return true;
+            }
+
+            // CJK Compatibility Ideographs
+            if (IsInRangeInclusive(value, 0xF900u, 0xFAFFu))
+            {
+                return true;
+            }
+
+            // CJK Compatibility Ideographs Supplement
+            if (IsInRangeInclusive(value, 0x2F800u, 0x2FA1Fu))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Returns the Unicode plane (0 through 16, inclusive) which contains this code point.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SixLabors.Fonts/WordBreaking.cs
+++ b/src/SixLabors.Fonts/WordBreaking.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.Fonts
+{
+    /// <summary>
+    /// Defines modes to determine when line breaks should appear when words overflow
+    /// their content box.
+    /// </summary>
+    public enum WordBreaking
+    {
+        /// <summary>
+        /// No word breaking.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The word is broken based upon grapheme boundaries.
+        /// </summary>
+        Auto
+    }
+}

--- a/src/SixLabors.Fonts/WordBreaking.cs
+++ b/src/SixLabors.Fonts/WordBreaking.cs
@@ -10,13 +10,20 @@ namespace SixLabors.Fonts
     public enum WordBreaking
     {
         /// <summary>
-        /// No word breaking.
+        /// Use the default line break rule.
         /// </summary>
-        None,
+        Normal,
 
         /// <summary>
-        /// The word is broken based upon grapheme boundaries.
+        /// To prevent overflow, word breaks should be inserted between any two
+        /// characters (excluding Chinese/Japanese/Korean text).
         /// </summary>
-        Auto
+        BreakAll,
+
+        /// <summary>
+        /// Word breaks should not be used for Chinese/Japanese/Korean (CJK) text.
+        /// Non-CJK text behavior is the same as for <see cref="Normal"/>
+        /// </summary>
+        KeepAll
     }
 }

--- a/tests/SixLabors.Fonts.Tests/FontMetricsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontMetricsTests.cs
@@ -63,7 +63,7 @@ namespace SixLabors.Fonts.Tests
 
             Assert.Equal(glyphMetrics, glyphMetrics1);
 
-            Assert.Equal(codePoint, glyphMetrics.Codepoint);
+            Assert.Equal(codePoint, glyphMetrics.CodePoint);
             Assert.Equal(font.FontMetrics.UnitsPerEm, glyphMetrics.UnitsPerEm);
             Assert.Equal(glyphMetrics.UnitsPerEm * 72F, glyphMetrics.ScaleFactor);
             Assert.Equal(1296, glyphMetrics.AdvanceWidth);
@@ -91,7 +91,7 @@ namespace SixLabors.Fonts.Tests
 
             Assert.Equal(glyphMetrics, glyphMetrics1);
 
-            Assert.Equal(codePoint, glyphMetrics.Codepoint);
+            Assert.Equal(codePoint, glyphMetrics.CodePoint);
             Assert.Equal(font.FontMetrics.UnitsPerEm, glyphMetrics.UnitsPerEm);
             Assert.Equal(glyphMetrics.UnitsPerEm * 72F, glyphMetrics.ScaleFactor);
             Assert.Equal(1296, glyphMetrics.AdvanceWidth);
@@ -120,7 +120,7 @@ namespace SixLabors.Fonts.Tests
             Assert.Equal(glyphMetrics, glyphMetrics1);
 
             // Position 0.
-            Assert.Equal(codePoint, glyphMetrics.Codepoint);
+            Assert.Equal(codePoint, glyphMetrics.CodePoint);
             Assert.Equal(font.FontMetrics.UnitsPerEm, glyphMetrics.UnitsPerEm);
             Assert.Equal(glyphMetrics.UnitsPerEm * 72F, glyphMetrics.ScaleFactor);
             Assert.Equal(364, glyphMetrics.AdvanceWidth);

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_180.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_180.cs
@@ -16,7 +16,7 @@ namespace SixLabors.Fonts.Tests.Issues
             FontRectangle size = TextMeasurer.Measure("H", new RendererOptions(font));
 
             Assert.Equal(17.6, size.Width, 1);
-            Assert.Equal(28.5, size.Height, 1);
+            Assert.Equal(35.6, size.Height, 1);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -185,6 +185,33 @@ namespace SixLabors.Fonts.Tests
             Assert.Equal(height, size.Height, 4);
         }
 
+#if OS_WINDOWS
+        [Theory]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", WordBreaking.Normal, 120.4883, 870.6344)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", WordBreaking.BreakAll, 143.4863, 399.9999)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", WordBreaking.KeepAll, 70.8887, 699.9998)]
+        public void MeasureTextWordBreak(string text, WordBreaking wordBreaking, float height, float width)
+        {
+            // Testing using Windows only to ensure that actual glyphs are rendered
+            // against known physically tested values.
+            FontFamily arial = SystemFonts.Get("Arial");
+            FontFamily jhengHei = SystemFonts.Get("Microsoft JhengHei");
+
+            Font font = arial.CreateFont(20);
+            FontRectangle size = TextMeasurer.Measure(
+                text,
+                new RendererOptions(font, 72)
+                {
+                    WrappingWidth = 400,
+                    WordBreaking = wordBreaking,
+                    FallbackFontFamilies = new[] { jhengHei }
+                });
+
+            Assert.Equal(width, size.Width, 4);
+            Assert.Equal(height, size.Height, 4);
+        }
+#endif
+
         [Theory]
         [InlineData("ab", 477, 1081, false)] // no kerning rules defined for lowercase ab so widths should stay the same
         [InlineData("ab", 477, 1081, true)]

--- a/tests/SixLabors.Fonts.Tests/Unicode/UnicodeUtilityTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Unicode/UnicodeUtilityTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.Fonts.Unicode;
+using Xunit;
+
+namespace SixLabors.Fonts.Tests.Unicode
+{
+    public class UnicodeUtilityTests
+    {
+        [Theory]
+        [InlineData(0x3040u, 0x309Fu)] // Hiragana
+        [InlineData(0x30A0u, 0x30FFu)] // Katakana
+        [InlineData(0xAC00u, 0xD7A3u)] // Hangul Syllables
+        [InlineData(0x4E00u, 0x9FFFu)] // CJK Unified Ideographs
+        [InlineData(0x3400u, 0x4DBFu)] // CJK Unified Ideographs Extension A
+        [InlineData(0x20000u, 0x2A6DFu)] // CJK Unified Ideographs Extension B
+        [InlineData(0x2A700u, 0x2B73Fu)] // CJK Unified Ideographs Extension C
+        [InlineData(0x2B740u, 0x2B81Fu)] // CJK Unified Ideographs Extension D
+        [InlineData(0x2B820u, 0x2CEAFu)] // CJK Unified Ideographs Extension E
+        [InlineData(0x2CEB0u, 0x2EBEFu)] // CJK Unified Ideographs Extension F
+        [InlineData(0x30000u, 0x3134Fu)] // CJK Unified Ideographs Extension G
+        [InlineData(0xF900u, 0xFAFFu)] // CJK Compatibility Ideographs
+        [InlineData(0x2F800u, 0x2FA1Fu)] // CJK Compatibility Ideographs Supplement
+        public void CanDetectCJKCodePoints(uint min, uint max)
+        {
+            for (uint i = min; i <= max; i++)
+            {
+                Assert.True(UnicodeUtility.IsCJKCodePoint(i));
+            }
+        }
+
+        [Theory]
+        [InlineData(0x0u, 0x7Fu)] // ASCII
+        public void NoFalsePositiveCJKCodePoints(uint min, uint max)
+        {
+            for (uint i = min; i <= max; i++)
+            {
+                Assert.False(UnicodeUtility.IsCJKCodePoint(i));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds support for word breaking. Implementation follows the CSS specification. Fixes #60 
https://developer.mozilla.org/en-US/docs/Web/CSS/word-break

A new `WordBreaking` enum has been added to `RendererOptions` with the following values.

- `Normal` (_Use the default line break rule_)
- `BreakAll`  (_To prevent overflow, word breaks should be inserted between any two characters (excluding Chinese/Japanese/Korean text)_)
- `KeepAll` (_Word breaks should not be used for Chinese/Japanese/Korean (CJK) text. Non-CJK text behavior is the same as for normal_)

Depreciated Break-Word is not supported.

`Normal`
![normal](https://user-images.githubusercontent.com/385879/130816533-7033d396-035f-47df-9ec4-3ac519f5fcc7.png)

`BreakAll`
![break-all](https://user-images.githubusercontent.com/385879/130816520-f7ace465-3d2e-47d0-a647-2f25f77c4cc8.png)

`KeepAll`
![keep-all](https://user-images.githubusercontent.com/385879/130816529-edc6527c-eb2f-43e7-8a02-884d1630c59d.png)

I haven't implemented hyphen support. I had a crack but found I could not get the information I required until following the break which is too late. 


<!-- Thanks for contributing to SixLabors.Fonts! -->
