### PR TITLE
Add netcore 3.1 target

### DIFF
--- a/src/SixLabors.Fonts/FontReader.cs
+++ b/src/SixLabors.Fonts/FontReader.cs
@@ -152,7 +152,7 @@ namespace SixLabors.Fonts
         public TTableType? TryGetTable<TTableType>()
             where TTableType : Table
         {
-            if (this.loadedTables.TryGetValue(typeof(TTableType), out Table table))
+            if (this.loadedTables.TryGetValue(typeof(TTableType), out Table? table))
             {
                 return (TTableType)table;
             }
@@ -179,14 +179,14 @@ namespace SixLabors.Fonts
             if (tbl is null)
             {
                 string tag = this.loader.GetTag<TTableType>();
-                throw new MissingFontTableException($"Table '{tag}' is missing", tag);
+                throw new MissingFontTableException($"Table '{tag}' is missing", tag!);
             }
 
             return tbl;
         }
 
         public TableHeader? GetHeader(string tag)
-            => this.Headers.TryGetValue(tag, out TableHeader header)
+            => this.Headers.TryGetValue(tag, out TableHeader? header)
                 ? header
                 : null;
 

--- a/src/SixLabors.Fonts/FontRectangle.cs
+++ b/src/SixLabors.Fonts/FontRectangle.cs
@@ -347,7 +347,7 @@ namespace SixLabors.Fonts
             => $"FontRectangle [ X={this.X}, Y={this.Y}, Width={this.Width}, Height={this.Height} ]";
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is FontRectangle other
             && this.Equals(other);
 

--- a/src/SixLabors.Fonts/GlyphRendererParameters.cs
+++ b/src/SixLabors.Fonts/GlyphRendererParameters.cs
@@ -107,7 +107,7 @@ namespace SixLabors.Fonts
             || (other.Font?.Equals(this.Font, StringComparison.OrdinalIgnoreCase) == true));
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is GlyphRendererParameters p && this.Equals(p);
+        public override bool Equals(object? obj) => obj is GlyphRendererParameters p && this.Equals(p);
 
         /// <inheritdoc/>
         public override int GetHashCode()

--- a/src/SixLabors.Fonts/IColorGlyphRenderer.cs
+++ b/src/SixLabors.Fonts/IColorGlyphRenderer.cs
@@ -81,7 +81,7 @@ namespace SixLabors.Fonts
             => !left.Equals(right);
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is GlyphColor p && this.Equals(p);
+        public override bool Equals(object? obj) => obj is GlyphColor p && this.Equals(p);
 
         /// <summary>
         /// Compares the <see cref="GlyphColor"/> for equality to this color.

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -11,7 +11,7 @@
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageTags>font;truetype;opentype;woff</PackageTags>
     <Description>A cross-platform library for loading and laying out fonts for processing and measuring; written in C#</Description>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <!--Prevent version conflicts in DrawWithImageSharp-->
@@ -36,7 +36,7 @@
     <None Include="..\..\shared-infrastructure\branding\icons\fonts\sixlabors.fonts.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
@@ -45,7 +45,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>

--- a/src/SixLabors.Fonts/Tables/TableLoader.cs
+++ b/src/SixLabors.Fonts/Tables/TableLoader.cs
@@ -36,18 +36,17 @@ namespace SixLabors.Fonts.Tables
 
         public static TableLoader Default { get; } = new TableLoader();
 
-        public string GetTag(Type type)
+        public string? GetTag(Type type)
         {
-            this.types.TryGetValue(type, out string value);
+            this.types.TryGetValue(type, out string? value);
 
             return value;
         }
 
         public string GetTag<TType>()
         {
-            this.types.TryGetValue(typeof(TType), out string value);
-
-            return value;
+            this.types.TryGetValue(typeof(TType), out string? value);
+            return value!;
         }
 
         internal IEnumerable<Type> RegisteredTypes() => this.types.Keys;
@@ -71,19 +70,19 @@ namespace SixLabors.Fonts.Tables
         private void Register<T>(Func<FontReader, T?> createFunc)
             where T : Table
         {
-            string name =
+            string? name =
                 typeof(T).GetTypeInfo()
                     .CustomAttributes
                     .First(x => x.AttributeType == typeof(TableNameAttribute))
-                    .ConstructorArguments[0].Value.ToString();
+                    .ConstructorArguments[0].Value!.ToString();
 
-            this.Register(name, createFunc);
+            this.Register(name!, createFunc);
         }
 
         internal Table? Load(string tag, FontReader reader)
 
              // loader missing? register an unknown type loader and carry on
-             => this.loaders.TryGetValue(tag, out Func<FontReader, Table?> func)
+             => this.loaders.TryGetValue(tag, out Func<FontReader, Table?>? func)
                 ? func.Invoke(reader)
                 : new UnknownTable(tag);
 
@@ -91,7 +90,7 @@ namespace SixLabors.Fonts.Tables
             where TTable : Table
         {
             // loader missing register an unknown type loader and carry on
-            if (this.typesLoaders.TryGetValue(typeof(TTable), out Func<FontReader, Table?> func))
+            if (this.typesLoaders.TryGetValue(typeof(TTable), out Func<FontReader, Table?>? func))
             {
                 return (TTable?)func.Invoke(reader);
             }

--- a/src/SixLabors.Fonts/Unicode/TODO/ArrayBuilder{T}.cs
+++ b/src/SixLabors.Fonts/Unicode/TODO/ArrayBuilder{T}.cs
@@ -159,7 +159,7 @@ namespace SixLabors.Fonts.Unicode
 
                 if (this.size > 0)
                 {
-                    Array.Copy(this.data, array, this.size);
+                    Array.Copy(this.data!, array, this.size);
                 }
 
                 this.data = array;

--- a/src/SixLabors.Fonts/Unicode/TODO/BidiDictionary{T1,T2}.cs
+++ b/src/SixLabors.Fonts/Unicode/TODO/BidiDictionary{T1,T2}.cs
@@ -11,6 +11,8 @@ namespace SixLabors.Fonts.Unicode
     /// <typeparam name="T1">Key type</typeparam>
     /// <typeparam name="T2">Value type</typeparam>
     internal sealed class BidiDictionary<T1, T2>
+        where T1 : struct
+        where T2 : struct
     {
         public Dictionary<T1, T2> Forward { get; } = new Dictionary<T1, T2>();
 

--- a/src/SixLabors.Fonts/Unicode/UnicodeData.cs
+++ b/src/SixLabors.Fonts/Unicode/UnicodeData.cs
@@ -30,12 +30,12 @@ namespace SixLabors.Fonts.Unicode
 
         private static UnicodeTrie GetTrie(string name)
         {
-            Stream stream = typeof(UnicodeData)
+            Stream? stream = typeof(UnicodeData)
                 .GetTypeInfo()
                 .Assembly
                 .GetManifestResourceStream("SixLabors.Fonts.Unicode.Resources." + name);
 
-            return new UnicodeTrie(stream);
+            return new UnicodeTrie(stream!);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds a .NET Core 3.1 Target. See #201 for discussion.

Wasn't sure about some of the new nullability fixes I had to implement to could do with a review. 

<!-- Thanks for contributing to SixLabors.Fonts! -->
