### PR TITLE
Apply features in order

### DIFF
--- a/src/SixLabors.Fonts/GlyphPositioningCollection.cs
+++ b/src/SixLabors.Fonts/GlyphPositioningCollection.cs
@@ -52,8 +52,22 @@ namespace SixLabors.Fonts
         public GlyphShapingData GetGlyphShapingData(int index) => this.glyphs[index];
 
         /// <inheritdoc />
-        public void AddShapingFeature(int index, Tag feature)
+        public void AddShapingFeature(int index, TagEntry feature)
             => this.glyphs[index].Features.Add(feature);
+
+        /// <inheritdoc />
+        public void EnableShapingFeature(int index, Tag feature)
+        {
+            List<TagEntry> features = this.glyphs[index].Features;
+            foreach (TagEntry tagEntry in features)
+            {
+                if (tagEntry.Tag == feature)
+                {
+                    tagEntry.Enabled = true;
+                    break;
+                }
+            }
+        }
 
         /// <summary>
         /// Removes all elements from the collection.
@@ -137,7 +151,7 @@ namespace SixLabors.Fonts
 
                 if (m.Count > 0)
                 {
-                    this.glyphs[i] = new GlyphShapingData(codePoint, data.Direction, glyphIds, new HashSet<Tag>(), data.LigatureId, data.LigatureComponentCount);
+                    this.glyphs[i] = new GlyphShapingData(codePoint, data.Direction, glyphIds, new List<TagEntry>(), data.LigatureId, data.LigatureComponentCount);
                     this.offsets[i] = offset;
                     this.map[offset] = m.ToArray();
                 }
@@ -183,7 +197,7 @@ namespace SixLabors.Fonts
 
                 if (m.Count > 0)
                 {
-                    this.glyphs.Add(new GlyphShapingData(codePoint, data.Direction, glyphIds, new HashSet<Tag>(), data.LigatureId, data.LigatureComponentCount));
+                    this.glyphs.Add(new GlyphShapingData(codePoint, data.Direction, glyphIds, new List<TagEntry>(), data.LigatureId, data.LigatureComponentCount));
                     this.offsets.Add(offset);
                     this.map[offset] = m.ToArray();
                 }
@@ -232,7 +246,7 @@ namespace SixLabors.Fonts
         }
 
         /// <summary>
-        /// Gets the rectangluar advanced bounds of the glyph at the given index and id.
+        /// Gets the rectangular advanced bounds of the glyph at the given index and id.
         /// </summary>
         /// <param name="fontMetrics">The font face with metrics.</param>
         /// <param name="index">The zero-based index of the elements to offset.</param>

--- a/src/SixLabors.Fonts/GlyphShapingData.cs
+++ b/src/SixLabors.Fonts/GlyphShapingData.cs
@@ -10,7 +10,7 @@ using SixLabors.Fonts.Unicode;
 namespace SixLabors.Fonts
 {
     /// <summary>
-    /// Contains supplemetary data that allows the shaping of glyphs.
+    /// Contains supplementary data that allows the shaping of glyphs.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal readonly struct GlyphShapingData
@@ -22,7 +22,7 @@ namespace SixLabors.Fonts
         /// <param name="direction">The text direction.</param>
         /// <param name="glyphIds">The collection of glyph ids.</param>
         public GlyphShapingData(CodePoint codePoint, TextDirection direction, ushort[] glyphIds)
-            : this(codePoint, direction, glyphIds, new HashSet<Tag>(), 0, 1)
+            : this(codePoint, direction, glyphIds, new List<TagEntry>(), 0, 1)
         {
         }
 
@@ -39,7 +39,7 @@ namespace SixLabors.Fonts
             CodePoint codePoint,
             TextDirection direction,
             ushort[] glyphIds,
-            HashSet<Tag> features,
+            List<TagEntry> features,
             int ligatureId,
             int ligatureComponents)
         {
@@ -79,7 +79,7 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Gets the collection of features.
         /// </summary>
-        public HashSet<Tag> Features { get; }
+        public List<TagEntry> Features { get; }
 
         private string DebuggerDisplay
             => FormattableString

--- a/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
+++ b/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
@@ -63,8 +63,22 @@ namespace SixLabors.Fonts
             => this.glyphs[this.offsets[index]] = data;
 
         /// <inheritdoc />
-        public void AddShapingFeature(int index, Tag feature)
+        public void AddShapingFeature(int index, TagEntry feature)
             => this.glyphs[this.offsets[index]].Features.Add(feature);
+
+        /// <inheritdoc />
+        public void EnableShapingFeature(int index, Tag feature)
+        {
+            List<TagEntry> features = this.glyphs[this.offsets[index]].Features;
+            foreach (TagEntry tagEntry in features)
+            {
+                if (tagEntry.Tag == feature)
+                {
+                    tagEntry.Enabled = true;
+                    break;
+                }
+            }
+        }
 
         /// <summary>
         /// Adds the glyph id and the codepoint it represents to the collection.

--- a/src/SixLabors.Fonts/IGlyphShapingCollection.cs
+++ b/src/SixLabors.Fonts/IGlyphShapingCollection.cs
@@ -35,6 +35,13 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="index">The zero-based index of the element.</param>
         /// <param name="feature">The feature to apply.</param>
-        void AddShapingFeature(int index, Tag feature);
+        void AddShapingFeature(int index, TagEntry feature);
+
+        /// <summary>
+        /// Enables a previously added shaping feature.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element.</param>
+        /// <param name="feature">The feature to enable.</param>
+        void EnableShapingFeature(int index, Tag feature);
     }
 }

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/AdvancedTypographicUtils.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/AdvancedTypographicUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using SixLabors.Fonts.Tables.AdvancedTypographic.GPos;
 using SixLabors.Fonts.Unicode;
@@ -33,7 +34,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                 }
 
                 GlyphShapingData data = collection.GetGlyphShapingData(collectionIdx);
-                if (!data.Features.Contains(feature))
+                if (!ContainsFeatureTag(data.Features, feature))
                 {
                     return false;
                 }
@@ -48,6 +49,19 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
             }
 
             return i == inputSequence.Length;
+        }
+
+        internal static bool ContainsFeatureTag(List<TagEntry> featureList, Tag feature)
+        {
+            foreach (TagEntry tagEntry in featureList)
+            {
+                if (tagEntry.Tag == feature)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal static bool MatchSequence(IGlyphShapingCollection collection, int glyphSequenceIndex, ushort[] sequenceToMatch)

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
@@ -120,18 +120,28 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                     count++;
                 }
 
-                foreach ((Tag Feature, ushort Index, LookupTable LookupTable) featureLookup in lookups)
+                for (ushort j = 0; j < count; j++)
                 {
-                    for (ushort j = 0; j < count; j++)
+                    ushort offset = (ushort)(j + index);
+
+                    // Apply features in order.
+                    List<TagEntry> featuresToApply = collection.GetGlyphShapingData(offset).Features;
+                    foreach (TagEntry featureToApply in featuresToApply)
                     {
-                        ushort offset = (ushort)(j + index);
-                        HashSet<Tag> features = collection.GetGlyphShapingData(offset).Features;
-                        if (!features.Contains(featureLookup.Feature))
+                        if (!featureToApply.Enabled)
                         {
                             continue;
                         }
 
-                        updated |= featureLookup.LookupTable.TryUpdatePosition(fontMetrics, this, collection, featureLookup.Feature, offset, count - j);
+                        foreach ((Tag Feature, ushort Index, LookupTable LookupTable) featureLookup in lookups)
+                        {
+                            if (featureLookup.Feature != featureToApply.Tag)
+                            {
+                                continue;
+                            }
+
+                            updated |= featureLookup.LookupTable.TryUpdatePosition(fontMetrics, this, collection, featureLookup.Feature, offset, count - j);
+                        }
                     }
                 }
             }

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ArabicShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ArabicShaper.cs
@@ -77,9 +77,15 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
         /// <inheritdoc/>
         public override void AssignFeatures(IGlyphShapingCollection collection, int index, int count)
         {
-            // Add plan features
             AddFeature(collection, index, count, CcmpTag);
             AddFeature(collection, index, count, LoclTag);
+            AddFeature(collection, index, count, IsolTag, false);
+            AddFeature(collection, index, count, FinaTag, false);
+            AddFeature(collection, index, count, Fin2Tag, false);
+            AddFeature(collection, index, count, Fin3Tag, false);
+            AddFeature(collection, index, count, MediTag, false);
+            AddFeature(collection, index, count, Med2Tag, false);
+            AddFeature(collection, index, count, InitTag, false);
             AddFeature(collection, index, count, MsetTag);
 
             base.AssignFeatures(collection, index, count);
@@ -121,25 +127,25 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                 switch (actions[i])
                 {
                     case Fina:
-                        collection.AddShapingFeature(i + index, FinaTag);
+                        collection.EnableShapingFeature(i + index, FinaTag);
                         break;
                     case Fin2:
-                        collection.AddShapingFeature(i + index, Fin2Tag);
+                        collection.EnableShapingFeature(i + index, Fin2Tag);
                         break;
                     case Fin3:
-                        collection.AddShapingFeature(i + index, Fin3Tag);
+                        collection.EnableShapingFeature(i + index, Fin3Tag);
                         break;
                     case Isol:
-                        collection.AddShapingFeature(i + index, IsolTag);
+                        collection.EnableShapingFeature(i + index, IsolTag);
                         break;
                     case Init:
-                        collection.AddShapingFeature(i + index, InitTag);
+                        collection.EnableShapingFeature(i + index, InitTag);
                         break;
                     case Medi:
-                        collection.AddShapingFeature(i + index, MediTag);
+                        collection.EnableShapingFeature(i + index, MediTag);
                         break;
                     case Med2:
-                        collection.AddShapingFeature(i + index, Med2Tag);
+                        collection.EnableShapingFeature(i + index, Med2Tag);
                         break;
                 }
             }

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/DefaultShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/DefaultShaper.cs
@@ -114,12 +114,12 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
             }
         }
 
-        protected static void AddFeature(IGlyphShapingCollection collection, int index, int count, Tag variationFeatures)
+        protected static void AddFeature(IGlyphShapingCollection collection, int index, int count, Tag variationFeatures, bool enabled = true)
         {
             int end = index + count;
             for (int i = index; i < end; i++)
             {
-                collection.AddShapingFeature(i, variationFeatures);
+                collection.AddShapingFeature(i, new TagEntry(variationFeatures, enabled));
             }
         }
     }

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/TagEntry.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/TagEntry.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics;
+
+namespace SixLabors.Fonts.Tables.AdvancedTypographic
+{
+    [DebuggerDisplay("Tag: {Tag}, Enabled: {Enabled}")]
+    internal class TagEntry
+    {
+        public TagEntry(Tag tag, bool enabled)
+        {
+            this.Tag = tag;
+            this.Enabled = enabled;
+        }
+
+        public bool Enabled { get; set; }
+
+        public Tag Tag { get; }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This change will apply the glyph shaping features in order. 

I did not commit it directly to the ligatures branch, because i thought its worth a review first.