### PR TITLE
Fix shaping when positions are not updated

### DIFF
--- a/samples/DrawWithImageSharp/BoundingBoxes.cs
+++ b/samples/DrawWithImageSharp/BoundingBoxes.cs
@@ -18,8 +18,9 @@ namespace DrawWithImageSharp
             using var img = new Image<Rgba32>(1000, 1000);
             img.Mutate(x => x.Fill(Color.White));
 
-            FontRectangle box = TextMeasurer.MeasureBounds(text, new SixLabors.Fonts.TextOptions(font));
-            (IPathCollection paths, IPathCollection boxes) = GenerateGlyphsWithBox(text, new SixLabors.Fonts.TextOptions(font));
+            TextOptions options = new(font);
+            FontRectangle box = TextMeasurer.MeasureBounds(text, options);
+            (IPathCollection paths, IPathCollection boxes) = GenerateGlyphsWithBox(text, options);
 
             Rgba32 f = Color.Fuchsia;
             f.A = 128;
@@ -35,15 +36,15 @@ namespace DrawWithImageSharp
         /// Generates the shapes corresponding the glyphs described by the font and with the setting ing withing the FontSpan
         /// </summary>
         /// <param name="text">The text to generate glyphs for</param>
-        /// <param name="style">The style and settings to use while rendering the glyphs</param>
+        /// <param name="options">The style and settings to use while rendering the glyphs</param>
         /// <returns>The paths, boxes, and text box.</returns>
-        private static (IPathCollection Paths, IPathCollection Boxes) GenerateGlyphsWithBox(string text, SixLabors.Fonts.TextOptions style)
+        private static (IPathCollection Paths, IPathCollection Boxes) GenerateGlyphsWithBox(string text, TextOptions options)
         {
             var glyphBuilder = new CustomGlyphBuilder(Vector2.Zero);
 
             var renderer = new TextRenderer(glyphBuilder);
 
-            renderer.RenderText(text, style);
+            renderer.RenderText(text, options);
 
             return (glyphBuilder.Paths, glyphBuilder.Boxes);
         }

--- a/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
+++ b/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13.9" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13.15" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/samples/DrawWithImageSharp/TextAlignmentSample.cs
+++ b/samples/DrawWithImageSharp/TextAlignmentSample.cs
@@ -69,7 +69,7 @@ namespace DrawWithImageSharp
 
             var renderer = new TextRenderer(glyphBuilder);
 
-            var style = new SixLabors.Fonts.TextOptions(font)
+            TextOptions textOptions = new(font)
             {
                 TabWidth = 4,
                 WrappingLength = 0,
@@ -79,7 +79,7 @@ namespace DrawWithImageSharp
             };
 
             string text = $"{horiz} x y z\n{vert} x y z";
-            renderer.RenderText(text, style);
+            renderer.RenderText(text, textOptions);
 
             IEnumerable<IPath> shapesToDraw = glyphBuilder.Paths;
             img.Mutate(x => x.Fill(Color.Black, glyphBuilder.Paths));

--- a/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
+++ b/samples/DrawWithImageSharp/TextAlignmentWrapped.cs
@@ -72,7 +72,7 @@ namespace DrawWithImageSharp
 
             var renderer = new TextRenderer(glyphBuilder);
 
-            var style = new SixLabors.Fonts.TextOptions(font)
+            TextOptions textOptions = new(font)
             {
                 TabWidth = 4,
                 WrappingLength = wrappingWidth,
@@ -82,7 +82,7 @@ namespace DrawWithImageSharp
             };
 
             string text = $"    {horiz}     {vert}         {horiz}     {vert}         {horiz}     {vert}     ";
-            renderer.RenderText(text, style);
+            renderer.RenderText(text, textOptions);
 
             IEnumerable<IPath> shapesToDraw = glyphBuilder.Paths;
             img.Mutate(x => x.Fill(Color.Black, glyphBuilder.Paths));

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
@@ -179,7 +179,10 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
 
                 FixCursiveAttachment(collection, index, count);
                 FixMarkAttachment(collection, index, count);
-                UpdatePositions(fontMetrics, collection, index, count);
+                if (updated)
+                {
+                    UpdatePositions(fontMetrics, collection, index, count);
+                }
             }
 
             return updated;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- Fixes misapplication of positional updates when no positions have been applied.
- Fixes line spacing for vertical text.
- Updates Drawing ref for samples and fixes fallback font aggregation.
<!-- Thanks for contributing to SixLabors.Fonts! -->
