### PR TITLE
Drop NetStandard 1.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,36 +20,20 @@
 
   <!--
     https://apisof.net/
-    +===================+=======+==========+=====================+
-    | SUPPORTS          | CULTUREINFO_LCID | NULLABLE_ATTRIBUTES |
-    +===================+==================+=====================+
-    | netcoreapp3.1     |         Y        |         Y           |
-    | netcoreapp2.1     |         Y        |         N           |
-    | netcoreapp2.0     |         Y        |         N           |
-    | netstandard2.1    |         Y        |         Y           |
-    | netstandard2.0    |         Y        |         N           |
-    | netstandard1.3    |         N        |         N           |
-    | net472            |         Y        |         N           |
-    +===================+==================+=====================+
+    +===================+=====================+
+    | SUPPORTS          | NULLABLE_ATTRIBUTES |
+    +===================+=====================+
+    | netcoreapp3.1     |         Y           |
+    | netstandard2.1    |         Y           |
+    | netstandard2.0    |         N           |
+    +===================+=====================+
   -->
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_CULTUREINFO_LCID;NULLABLE_ATTRIBUTES</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants)SUPPORTS_CULTUREINFO_LCID</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants)SUPPORTS_CULTUREINFO_LCID</DefineConstants>
+    <DefineConstants>$(DefineConstants);NULLABLE_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_CULTUREINFO_LCID;NULLABLE_ATTRIBUTES</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_CULTUREINFO_LCID</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_CULTUREINFO_LCID</DefineConstants>
+    <DefineConstants>$(DefineConstants);NULLABLE_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/src/SixLabors.Fonts/Buffer{T}.cs
+++ b/src/SixLabors.Fonts/Buffer{T}.cs
@@ -39,7 +39,7 @@ namespace SixLabors.Fonts
             ref byte r0 = ref MemoryMarshal.GetReference<byte>(this.buffer);
             return MemoryMarshal.CreateSpan(ref Unsafe.As<byte, T>(ref r0), this.length);
 #else
-            return MemoryMarshal.Cast<byte, T>(this.buffer.AsSpan()).Slice(0, this.length);
+            return MemoryMarshal.Cast<byte, T>(this.buffer).Slice(0, this.length);
 #endif
         }
 

--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -61,7 +61,6 @@ namespace SixLabors.Fonts
         public bool TryGet(string name, out FontFamily family)
             => this.TryGetImpl(name, CultureInfo.InvariantCulture, out family);
 
-#if SUPPORTS_CULTUREINFO_LCID
         /// <inheritdoc/>
         public FontFamily Add(string path, CultureInfo culture)
             => this.AddImpl(path, culture, out _);
@@ -111,7 +110,6 @@ namespace SixLabors.Fonts
         /// <inheritdoc/>
         public bool TryGet(string name, CultureInfo culture, out FontFamily family)
             => this.TryGetImpl(name, culture, out family);
-#endif
 
         /// <inheritdoc/>
         FontFamily IFontMetricsCollection.AddMetrics(FontMetrics metrics, CultureInfo culture)

--- a/src/SixLabors.Fonts/FontReader.cs
+++ b/src/SixLabors.Fonts/FontReader.cs
@@ -70,7 +70,7 @@ namespace SixLabors.Fonts
                 // This is a woff2 file.
                 this.TableFormat = TableFormat.Woff2;
 
-#if NETSTANDARD2_0 || NETSTANDARD1_3
+#if NETSTANDARD2_0
                 throw new NotSupportedException("Brotli compression is not available and is required for decoding woff2");
 #else
 

--- a/src/SixLabors.Fonts/IFontCollection.cs
+++ b/src/SixLabors.Fonts/IFontCollection.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
-#if SUPPORTS_CULTUREINFO_LCID
 using System.Globalization;
-#endif
 using System.IO;
 
 namespace SixLabors.Fonts
@@ -75,7 +73,6 @@ namespace SixLabors.Fonts
         /// <returns>The new <see cref="IEnumerable{T}"/>.</returns>
         public IEnumerable<FontFamily> AddCollection(Stream stream, out IEnumerable<FontDescription> descriptions);
 
-#if SUPPORTS_CULTUREINFO_LCID
         /// <summary>
         /// Adds a font to the collection.
         /// </summary>
@@ -149,6 +146,5 @@ namespace SixLabors.Fonts
             Stream stream,
             CultureInfo culture,
             out IEnumerable<FontDescription> descriptions);
-#endif
     }
 }

--- a/src/SixLabors.Fonts/IReadonlyFontCollection.cs
+++ b/src/SixLabors.Fonts/IReadonlyFontCollection.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-#if SUPPORTS_CULTUREINFO_LCID
 using System.Globalization;
-#endif
 
 namespace SixLabors.Fonts
 {
@@ -45,7 +43,6 @@ namespace SixLabors.Fonts
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/></exception>
         bool TryGet(string name, out FontFamily family);
 
-#if SUPPORTS_CULTUREINFO_LCID
         /// <summary>
         /// Gets the collection of <see cref="FontFamily"/> in this <see cref="FontCollection"/>
         /// using the given culture.
@@ -80,6 +77,5 @@ namespace SixLabors.Fonts
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/></exception>
         bool TryGet(string name, CultureInfo culture, out FontFamily family);
-#endif
     }
 }

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -9,9 +9,9 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl Condition="'$(RepositoryUrl)' == ''">https://github.com/SixLabors/Fonts/</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
-    <PackageTags>font;truetype;opentype;woff</PackageTags>
+    <PackageTags>font;truetype;opentype;woff;woff2</PackageTags>
     <Description>A cross-platform library for loading and laying out fonts for processing and measuring; written in C#</Description>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.1;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <!--Prevent version conflicts in DrawWithImageSharp-->
@@ -39,7 +39,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>

--- a/src/SixLabors.Fonts/StringComparerHelpers.cs
+++ b/src/SixLabors.Fonts/StringComparerHelpers.cs
@@ -10,12 +10,11 @@ namespace SixLabors.Fonts
     {
         public static StringComparer GetCaseInsensitiveStringComparer(CultureInfo culture)
         {
-#if SUPPORTS_CULTUREINFO_LCID
             if (culture != null)
             {
                 return StringComparer.Create(culture, true);
             }
-#endif
+
             return StringComparer.OrdinalIgnoreCase;
         }
     }

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -87,7 +87,6 @@ namespace SixLabors.Fonts
         public bool TryGet(string name, out FontFamily family)
             => this.collection.TryGet(name, out family);
 
-#if SUPPORTS_CULTUREINFO_LCID
         /// <inheritdoc/>
         public IEnumerable<FontFamily> GetByCulture(CultureInfo culture)
             => this.collection.GetByCulture(culture);
@@ -99,7 +98,6 @@ namespace SixLabors.Fonts
         /// <inheritdoc/>
         public bool TryGet(string name, CultureInfo culture, out FontFamily family)
             => this.collection.TryGet(name, culture, out family);
-#endif
 
         /// <inheritdoc/>
         bool IReadOnlyFontMetricsCollection.TryGetMetrics(string name, CultureInfo culture, FontStyle style, [NotNullWhen(true)] out FontMetrics? metrics)

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-#if SUPPORTS_CULTUREINFO_LCID
 using System.Globalization;
-#endif
 
 namespace SixLabors.Fonts
 {
@@ -52,7 +50,6 @@ namespace SixLabors.Fonts
         public static Font CreateFont(string name, float size, FontStyle style)
             => Collection.Get(name).CreateFont(size, style);
 
-#if SUPPORTS_CULTUREINFO_LCID
         /// <inheritdoc cref="IReadOnlyFontCollection.GetByCulture(CultureInfo)"/>
         public static IEnumerable<FontFamily> GetByCulture(CultureInfo culture)
             => Collection.GetByCulture(culture);
@@ -85,6 +82,5 @@ namespace SixLabors.Fonts
         /// <returns>The new <see cref="Font"/>.</returns>
         public static Font CreateFont(string name, CultureInfo culture, float size, FontStyle style)
             => Collection.Get(name, culture).CreateFont(size, style);
-#endif
     }
 }

--- a/src/SixLabors.Fonts/Tables/General/NameTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/NameTable.cs
@@ -59,11 +59,7 @@ namespace SixLabors.Fonts.Tables.General
 
         public string GetNameById(CultureInfo culture, KnownNameIds nameId)
         {
-#if SUPPORTS_CULTUREINFO_LCID
             int languageId = culture.LCID;
-#else
-            int languageId = 0x0409;
-#endif
             NameRecord? usaVersion = null;
             NameRecord? firstWindows = null;
             NameRecord? first = null;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
From the [Microsoft Documentation](https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#which-net-standard-version-to-target)

>We recommend you target .NET Standard 2.0, unless you need to support an earlier version. Most general-purpose libraries should not need APIs outside of .NET Standard 2.0. .NET Standard 2.0 is supported by all modern platforms and is the recommended way to support multiple platforms with one target.

There's no need for us to support this.  .NET Standard 2.0 is supported by pretty much everything.


<!-- Thanks for contributing to SixLabors.Fonts! -->
