### PR TITLE
Add an overload of `AddSystemFonts`

### DIFF
--- a/src/SixLabors.Fonts/FontCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/FontCollectionExtensions.cs
@@ -37,12 +37,20 @@ namespace SixLabors.Fonts
         /// <returns>The <see cref="FontCollection"/> containing the system fonts.</returns>
         public static FontCollection AddSystemFonts(this FontCollection collection, Predicate<FontMetrics> match)
         {
+            bool isMatch = false;
             foreach (FontMetrics metric in (IReadOnlyFontMetricsCollection)SystemFonts.Collection)
             {
-                if (match(metric))
+                bool currentMatch = match(metric);
+                isMatch |= currentMatch;
+                if (currentMatch)
                 {
                     ((IFontMetricsCollection)collection).AddMetrics(metric);
                 }
+            }
+
+            if (isMatch)
+            {
+                collection.AddSearchDirectories(SystemFonts.Collection.SearchDirectories);
             }
 
             return collection;

--- a/src/SixLabors.Fonts/FontCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/FontCollectionExtensions.cs
@@ -31,7 +31,7 @@ namespace SixLabors.Fonts
         /// Adds the fonts from the <see cref="SystemFonts"/> collection to this <see cref="FontCollection"/>.
         /// </summary>
         /// <param name="collection">The font collection.</param>
-        /// <param name="match">The System.Predicate delegate that defines the conditions of <see cref="FontMetrics"/> to add into the font collection.</param>
+        /// <param name="match">The <see cref="System.Predicate"/> delegate that defines the conditions of <see cref="FontMetrics"/> to add into the font collection.</param>
         /// <returns>The <see cref="FontCollection"/> containing the system fonts.</returns>
         public static FontCollection AddSystemFonts(this FontCollection collection, Predicate<FontMetrics> match)
         {

--- a/src/SixLabors.Fonts/FontCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/FontCollectionExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
+
 namespace SixLabors.Fonts
 {
     /// <summary>
@@ -17,9 +19,28 @@ namespace SixLabors.Fonts
         {
             // This cast is safe because our underlying SystemFontCollection implements
             // both interfaces separately.
-            foreach (FontMetrics? metric in (IReadOnlyFontMetricsCollection)SystemFonts.Collection)
+            foreach (FontMetrics metric in (IReadOnlyFontMetricsCollection)SystemFonts.Collection)
             {
                 ((IFontMetricsCollection)collection).AddMetrics(metric);
+            }
+
+            return collection;
+        }
+
+        /// <summary>
+        /// Adds the fonts from the <see cref="SystemFonts"/> collection to this <see cref="FontCollection"/>.
+        /// </summary>
+        /// <param name="collection">The font collection.</param>
+        /// <param name="match">The System.Predicate delegate that defines the conditions of <see cref="FontMetrics"/> to add into the font collection.</param>
+        /// <returns>The <see cref="FontCollection"/> containing the system fonts.</returns>
+        public static FontCollection AddSystemFonts(this FontCollection collection, Predicate<FontMetrics> match)
+        {
+            foreach (FontMetrics metric in (IReadOnlyFontMetricsCollection)SystemFonts.Collection)
+            {
+                if (match(metric))
+                {
+                    ((IFontMetricsCollection)collection).AddMetrics(metric);
+                }
             }
 
             return collection;

--- a/src/SixLabors.Fonts/FontCollectionExtensions.cs
+++ b/src/SixLabors.Fonts/FontCollectionExtensions.cs
@@ -31,7 +31,7 @@ namespace SixLabors.Fonts
         /// Adds the fonts from the <see cref="SystemFonts"/> collection to this <see cref="FontCollection"/>.
         /// </summary>
         /// <param name="collection">The font collection.</param>
-        /// <param name="match">The <see cref="System.Predicate"/> delegate that defines the conditions of <see cref="FontMetrics"/> to add into the font collection.</param>
+        /// <param name="match">The <see cref="Predicate{T}"/> delegate that defines the conditions of <see cref="FontMetrics"/> to add into the font collection.</param>
         /// <returns>The <see cref="FontCollection"/> containing the system fonts.</returns>
         public static FontCollection AddSystemFonts(this FontCollection collection, Predicate<FontMetrics> match)
         {

--- a/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
@@ -77,9 +77,14 @@ namespace SixLabors.Fonts.Tests
         public void CanAddSystemFontsWithFilter()
         {
             var collection = new FontCollection();
-            collection.AddSystemFonts(p => false);
+            collection.AddSystemFonts(_ => false);
 
             Assert.False(collection.Families.Any());
+
+            collection.AddSystemFonts(_ => true);
+
+            Assert.True(collection.Families.Any());
+            Assert.Equal(SystemFonts.Collection.Families.Count(), collection.Families.Count());
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontCollectionTests.cs
@@ -71,5 +71,14 @@ namespace SixLabors.Fonts.Tests
             Assert.True(collection.Families.Any());
             Assert.Equal(collection.Families.Count(), SystemFonts.Families.Count());
         }
+
+        [Fact]
+        public void CanAddSystemFontsWithFilter()
+        {
+            var collection = new FontCollection();
+            collection.AddSystemFonts(p => false);
+
+            Assert.False(collection.Families.Any());
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Add `public static FontCollection AddSystemFonts(this FontCollection collection, Predicate<FontMetrics> match)` for filtering unwanted system fonts.

See #239 for details.
<!-- Thanks for contributing to SixLabors.Fonts! -->
