### PR TITLE
Fix bad indexing when shaping fractions

### DIFF
--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/DefaultShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/DefaultShaper.cs
@@ -126,7 +126,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
             }
 
             // Enable contextual fractions.
-            for (int i = index; i < count; i++)
+            for (int i = index; i < index + count; i++)
             {
                 GlyphShapingData shapingData = collection.GetGlyphShapingData(i);
                 if (shapingData.CodePoint == FractionSlash || shapingData.CodePoint == Slash)
@@ -135,21 +135,27 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                     int end = i + 1;
 
                     // Apply numerator.
-                    shapingData = collection.GetGlyphShapingData(start - 1);
-                    while (start > 0 && CodePoint.IsDigit(shapingData.CodePoint))
+                    if (start > 0)
                     {
-                        this.AddFeature(collection, start - 1, 1, NumrTag);
-                        this.AddFeature(collection, start - 1, 1, FracTag);
-                        start--;
+                        shapingData = collection.GetGlyphShapingData(start - 1);
+                        while (start > 0 && CodePoint.IsDigit(shapingData.CodePoint))
+                        {
+                            this.AddFeature(collection, start - 1, 1, NumrTag);
+                            this.AddFeature(collection, start - 1, 1, FracTag);
+                            start--;
+                        }
                     }
 
                     // Apply denominator.
-                    shapingData = collection.GetGlyphShapingData(end);
-                    while (end < collection.Count && CodePoint.IsDigit(shapingData.CodePoint))
+                    if (end < collection.Count)
                     {
-                        this.AddFeature(collection, end, 1, DnomTag);
-                        this.AddFeature(collection, end, 1, FracTag);
-                        end++;
+                        shapingData = collection.GetGlyphShapingData(end);
+                        while (end < collection.Count && CodePoint.IsDigit(shapingData.CodePoint))
+                        {
+                            this.AddFeature(collection, end, 1, DnomTag);
+                            this.AddFeature(collection, end, 1, FracTag);
+                            end++;
+                        }
                     }
 
                     // Apply fraction slash.

--- a/tests/SixLabors.Fonts.Tests/TestFonts.cs
+++ b/tests/SixLabors.Fonts.Tests/TestFonts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,7 +13,7 @@ namespace SixLabors.Fonts.Tests
 {
     public static class TestFonts
     {
-        private static readonly Dictionary<string, Stream> Cache = new();
+        private static readonly ConcurrentDictionary<string, Stream> Cache = new();
 
         public static string TwemojiMozillaFile => GetFullPath("Twemoji Mozilla.ttf");
 
@@ -227,27 +228,14 @@ namespace SixLabors.Fonts.Tests
             public static string Issue97File => GetFullPath("Issues/Issue97.fuzz");
         }
 
-        private static Stream OpenStream(string path)
-        {
-            if (Cache.ContainsKey(path))
-            {
-                return Cache[path].Clone();
-            }
-
-            lock (Cache)
-            {
-                if (Cache.ContainsKey(path))
+        private static Stream OpenStream(string path) =>
+            Cache.GetOrAdd(
+                path,
+                p =>
                 {
-                    return Cache[path].Clone();
-                }
-
-                using (FileStream fs = File.OpenRead(path))
-                {
-                    Cache.Add(path, fs.Clone());
-                    return Cache[path].Clone();
-                }
-            }
-        }
+                    using FileStream fs = File.OpenRead(p);
+                    return fs.Clone();
+                }).Clone();
 
         private static Stream Clone(this Stream src)
         {
@@ -271,9 +259,7 @@ namespace SixLabors.Fonts.Tests
             };
 
             IEnumerable<string> fullPaths = paths.Select(x => Path.GetFullPath(Path.Combine(root, x)));
-            string rootPath = fullPaths
-                                .Where(x => Directory.Exists(x))
-                                .FirstOrDefault();
+            string rootPath = fullPaths.FirstOrDefault(x => Directory.Exists(x));
 
             Assert.True(rootPath != null, $"could not find the font folder in any of these location, \n{string.Join("\n", fullPaths)}");
 

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -322,6 +322,18 @@ namespace SixLabors.Fonts.Tests
             Assert.Equal(expectedY, glyphRenderer.GlyphRects[0].Location.Y, 2);
         }
 
+        // https://github.com/SixLabors/Fonts/issues/244
+        [Fact]
+        public void MeasureTextLeadingFraction()
+        {
+            FontCollection c = new();
+            Font font = c.Add(TestFonts.SimpleFontFileData()).CreateFont(12);
+            TextOptions textOptions = new(font);
+            FontRectangle measurement = TextMeasurer.Measure("/ This will fail", textOptions);
+
+            Assert.NotEqual(FontRectangle.Empty, measurement);
+        }
+
         public static Font CreateFont(string text)
         {
             var fc = (IFontMetricsCollection)new FontCollection();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Applies sanitation code to fractional shaping indexers. Fixes #244 

<!-- Thanks for contributing to SixLabors.Fonts! -->
