### PR TITLE
Add line recognition

### DIFF
--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -58,8 +58,7 @@ namespace SixLabors.Fonts
         /// <returns>Whether any of the characters had non-empty bounds.</returns>
         public static bool TryMeasureCharacterBounds(ReadOnlySpan<char> text, TextOptions options, out GlyphBounds[] characterBounds)
             => TextMeasurerInt.Default.TryMeasureCharacterBounds(text, options, out characterBounds);
-        
-```suggestion
+
         /// <summary>
         /// Gets the number of lines contained within the text.
         /// </summary>
@@ -214,13 +213,13 @@ namespace SixLabors.Fonts
 
                 return GetSize(glyphsToRender, options.Dpi);
             }
-            
+
             /// <summary>
-            /// Counts the lines from the generated layout.
+            /// Gets the number of lines contained within the text.
             /// </summary>
             /// <param name="text">The text.</param>
             /// <param name="options">The style.</param>
-            /// <returns>The count of lines used.</returns>
+            /// <returns>The line count.</returns>
             internal int CountLines(ReadOnlySpan<char> text, TextOptions options)
             {
                 IReadOnlyList<GlyphLayout> glyphsToRender = this.layoutEngine.GenerateLayout(text, options);

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -59,12 +59,13 @@ namespace SixLabors.Fonts
         public static bool TryMeasureCharacterBounds(ReadOnlySpan<char> text, TextOptions options, out GlyphBounds[] characterBounds)
             => TextMeasurerInt.Default.TryMeasureCharacterBounds(text, options, out characterBounds);
         
+```suggestion
         /// <summary>
-        /// Counts the lines from the generated layout.
+        /// Gets the number of lines contained within the text.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The style.</param>
-        /// <returns>The count of lines used.</returns>
+        /// <returns>The line count.</returns>
         public static int CountLines(string text, TextOptions options)
             => TextMeasurerInt.Default.CountLines(text.AsSpan(), options);
 

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -58,6 +58,24 @@ namespace SixLabors.Fonts
         /// <returns>Whether any of the characters had non-empty bounds.</returns>
         public static bool TryMeasureCharacterBounds(ReadOnlySpan<char> text, TextOptions options, out GlyphBounds[] characterBounds)
             => TextMeasurerInt.Default.TryMeasureCharacterBounds(text, options, out characterBounds);
+        
+        /// <summary>
+        /// Counts the lines from the generated layout.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="options">The style.</param>
+        /// <returns>The count of lines used.</returns>
+        public static int CountLines(string text, TextOptions options)
+            => TextMeasurerInt.Default.CountLines(text.AsSpan(), options);
+
+        /// <summary>
+        /// Counts the lines from the generated layout.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="options">The style.</param>
+        /// <returns>The count of lines used.</returns>
+        public static int CountLines(ReadOnlySpan<char> text, TextOptions options)
+            => TextMeasurerInt.Default.CountLines(text, options);
 
         internal static FontRectangle GetSize(IReadOnlyList<GlyphLayout> glyphLayouts, float dpi)
         {
@@ -194,6 +212,20 @@ namespace SixLabors.Fonts
                 IReadOnlyList<GlyphLayout> glyphsToRender = this.layoutEngine.GenerateLayout(text, options);
 
                 return GetSize(glyphsToRender, options.Dpi);
+            }
+            
+            /// <summary>
+            /// Counts the lines from the generated layout.
+            /// </summary>
+            /// <param name="text">The text.</param>
+            /// <param name="options">The style.</param>
+            /// <returns>The count of lines used.</returns>
+            internal int CountLines(ReadOnlySpan<char> text, TextOptions options)
+            {
+                IReadOnlyList<GlyphLayout> glyphsToRender = this.layoutEngine.GenerateLayout(text, options);
+                int usedLines = glyphsToRender.Count(x => x.IsStartOfLine);
+
+                return usedLines;
             }
         }
     }

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -70,11 +70,11 @@ namespace SixLabors.Fonts
             => TextMeasurerInt.Default.CountLines(text.AsSpan(), options);
 
         /// <summary>
-        /// Counts the lines from the generated layout.
+        /// Gets the number of lines contained within the text.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The style.</param>
-        /// <returns>The count of lines used.</returns>
+        /// <returns>The line count.</returns>
         public static int CountLines(ReadOnlySpan<char> text, TextOptions options)
             => TextMeasurerInt.Default.CountLines(text, options);
 

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -334,6 +334,33 @@ namespace SixLabors.Fonts.Tests
             Assert.NotEqual(FontRectangle.Empty, measurement);
         }
 
+        [Theory]
+        [InlineData("hello world", 1)]
+        [InlineData("hello world\nhello world", 2)]
+        [InlineData("hello world\nhello world\nhello world", 3)]
+        public void CountLines(string text, int usedLines)
+        {
+            Font font = CreateFont(text);
+            int count = TextMeasurer.CountLines(text, new TextOptions(font) { Dpi = font.FontMetrics.ScaleFactor });
+
+            Assert.Equal(count, usedLines);
+        }
+
+        [Theory]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 25, 7)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 50, 7)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 100, 6)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 200, 6)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 300, 5)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 3000, 1)]
+        public void CountLinesWrappingLength(string text, int wrappingLength, int usedLines)
+        {
+            Font font = CreateFont(text);
+            int count = TextMeasurer.CountLines(text, new TextOptions(font) { Dpi = font.FontMetrics.ScaleFactor, WrappingLength = wrappingLength });
+
+            Assert.Equal(count, usedLines);
+        }
+
         public static Font CreateFont(string text)
         {
             var fc = (IFontMetricsCollection)new FontCollection();

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -346,6 +346,26 @@ namespace SixLabors.Fonts.Tests
             Assert.Equal(usedLines, count);
         }
 
+        [Fact]
+        public void CountLinesWithSpan()
+        {
+            Font font = CreateFont("hello\n!");
+
+            Span<char> text = stackalloc char[]
+            {
+                'h',
+                'e',
+                'l',
+                'l',
+                'o',
+                '\n',
+                '!'
+            };
+            int count = TextMeasurer.CountLines(text, new TextOptions(font) { Dpi = font.FontMetrics.ScaleFactor });
+
+            Assert.Equal(2, count);
+        }
+
         [Theory]
         [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 25, 7)]
         [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 50, 7)]

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -343,7 +343,7 @@ namespace SixLabors.Fonts.Tests
             Font font = CreateFont(text);
             int count = TextMeasurer.CountLines(text, new TextOptions(font) { Dpi = font.FontMetrics.ScaleFactor });
 
-            Assert.Equal(count, usedLines);
+            Assert.Equal(usedLines, count);
         }
 
         [Theory]
@@ -351,14 +351,12 @@ namespace SixLabors.Fonts.Tests
         [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 50, 7)]
         [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 100, 6)]
         [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 200, 6)]
-        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 300, 5)]
-        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 3000, 1)]
         public void CountLinesWrappingLength(string text, int wrappingLength, int usedLines)
         {
             Font font = CreateFont(text);
             int count = TextMeasurer.CountLines(text, new TextOptions(font) { Dpi = font.FontMetrics.ScaleFactor, WrappingLength = wrappingLength });
 
-            Assert.Equal(count, usedLines);
+            Assert.Equal(usedLines, count);
         }
 
         public static Font CreateFont(string text)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Add line recognition to determine the number of rows needed in the generated layout.
<!-- Thanks for contributing to SixLabors.Fonts! -->
