### PR TITLE
Add ability to add custom feature tags

### DIFF
--- a/src/SixLabors.Fonts/FileFontMetrics.cs
+++ b/src/SixLabors.Fonts/FileFontMetrics.cs
@@ -99,12 +99,12 @@ namespace SixLabors.Fonts
             => this.metrics.Value.GetGlyphMetrics(codePoint, glyphId, support);
 
         /// <inheritdoc/>
-        internal override void ApplySubstitution(GlyphSubstitutionCollection collection, KerningMode kerningMode)
-            => this.metrics.Value.ApplySubstitution(collection, kerningMode);
+        internal override void ApplySubstitution(GlyphSubstitutionCollection collection)
+            => this.metrics.Value.ApplySubstitution(collection);
 
         /// <inheritdoc/>
-        internal override void UpdatePositions(GlyphPositioningCollection collection, KerningMode kerningMode)
-            => this.metrics.Value.UpdatePositions(collection, kerningMode);
+        internal override void UpdatePositions(GlyphPositioningCollection collection)
+            => this.metrics.Value.UpdatePositions(collection);
 
         /// <summary>
         /// Reads a <see cref="StreamFontMetrics"/> from the specified stream.

--- a/src/SixLabors.Fonts/FontMetrics.cs
+++ b/src/SixLabors.Fonts/FontMetrics.cs
@@ -141,14 +141,12 @@ namespace SixLabors.Fonts
         /// Applies any available substitutions to the collection of glyphs.
         /// </summary>
         /// <param name="collection">The glyph substitution collection.</param>
-        /// <param name="kerningMode">The kerning mode.</param>
-        internal abstract void ApplySubstitution(GlyphSubstitutionCollection collection, KerningMode kerningMode);
+        internal abstract void ApplySubstitution(GlyphSubstitutionCollection collection);
 
         /// <summary>
         /// Applies any available positioning updates to the collection of glyphs.
         /// </summary>
         /// <param name="collection">The glyph positioning collection.</param>
-        /// <param name="kerningMode">The kerning mode.</param>
-        internal abstract void UpdatePositions(GlyphPositioningCollection collection, KerningMode kerningMode);
+        internal abstract void UpdatePositions(GlyphPositioningCollection collection);
     }
 }

--- a/src/SixLabors.Fonts/GlyphPositioningCollection.cs
+++ b/src/SixLabors.Fonts/GlyphPositioningCollection.cs
@@ -33,12 +33,11 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Initializes a new instance of the <see cref="GlyphPositioningCollection"/> class.
         /// </summary>
-        /// <param name="options">The text options.</param>
-        public GlyphPositioningCollection(TextOptions options)
+        /// <param name="textOptions">The text options.</param>
+        public GlyphPositioningCollection(TextOptions textOptions)
         {
-            this.IsVerticalLayoutMode = options.LayoutMode.IsVertical();
-            this.ColorFontSupport = options.ColorFontSupport;
-            this.ApplyHinting = options.ApplyHinting;
+            this.TextOptions = textOptions;
+            this.IsVerticalLayoutMode = textOptions.LayoutMode.IsVertical();
         }
 
         /// <inheritdoc />
@@ -47,16 +46,8 @@ namespace SixLabors.Fonts
         /// <inheritdoc />
         public bool IsVerticalLayoutMode { get; }
 
-        /// <summary>
-        /// Gets a value indicating whether to enable various color font formats.
-        /// </summary>
-        public ColorFontSupport ColorFontSupport { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether to apply hinting - The use of mathematical instructions
-        /// to adjust the display of an outline font so that it lines up with a rasterized grid.
-        /// </summary>
-        public bool ApplyHinting { get; }
+        /// <inheritdoc />
+        public TextOptions TextOptions { get; }
 
         /// <inheritdoc />
         public ReadOnlySpan<ushort> this[int index] => this.glyphs[index].GlyphIds;
@@ -137,7 +128,7 @@ namespace SixLabors.Fonts
                 {
                     // Perform a semi-deep clone (FontMetrics is not cloned) so we can continue to
                     // cache the original in the font metrics and only update our collection.
-                    foreach (GlyphMetrics gm in fontMetrics.GetGlyphMetrics(codePoint, id, this.ColorFontSupport))
+                    foreach (GlyphMetrics gm in fontMetrics.GetGlyphMetrics(codePoint, id, this.TextOptions.ColorFontSupport))
                     {
                         if (gm.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
                         {
@@ -186,7 +177,7 @@ namespace SixLabors.Fonts
                 {
                     // Perform a semi-deep clone (FontMetrics is not cloned) so we can continue to
                     // cache the original in the font metrics and only update our collection.
-                    foreach (GlyphMetrics gm in fontMetrics.GetGlyphMetrics(codePoint, id, this.ColorFontSupport))
+                    foreach (GlyphMetrics gm in fontMetrics.GetGlyphMetrics(codePoint, id, this.TextOptions.ColorFontSupport))
                     {
                         if (gm.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
                         {

--- a/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
+++ b/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
@@ -27,8 +27,12 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Initializes a new instance of the <see cref="GlyphSubstitutionCollection"/> class.
         /// </summary>
-        /// <param name="mode">The text layout mode.</param>
-        public GlyphSubstitutionCollection(LayoutMode mode) => this.IsVerticalLayoutMode = mode.IsVertical();
+        /// <param name="textOptions">The text options.</param>
+        public GlyphSubstitutionCollection(TextOptions textOptions)
+        {
+            this.TextOptions = textOptions;
+            this.IsVerticalLayoutMode = textOptions.LayoutMode.IsVertical();
+        }
 
         /// <summary>
         /// Gets the number of glyphs ids contained in the collection.
@@ -38,6 +42,9 @@ namespace SixLabors.Fonts
 
         /// <inheritdoc />
         public bool IsVerticalLayoutMode { get; private set; }
+
+        /// <inheritdoc />
+        public TextOptions TextOptions { get; }
 
         /// <summary>
         /// Gets or sets the running id of any ligature glyphs contained withing this collection are a member of.

--- a/src/SixLabors.Fonts/IGlyphShapingCollection.cs
+++ b/src/SixLabors.Fonts/IGlyphShapingCollection.cs
@@ -22,6 +22,11 @@ namespace SixLabors.Fonts
         bool IsVerticalLayoutMode { get; }
 
         /// <summary>
+        /// Gets the text options used by this collection.
+        /// </summary>
+        TextOptions TextOptions { get; }
+
+        /// <summary>
         /// Gets the glyph ids at the specified index.
         /// </summary>
         /// <param name="index">The zero-based index of the elements to get.</param>

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -262,21 +262,22 @@ namespace SixLabors.Fonts
         }
 
         /// <inheritdoc/>
-        internal override void ApplySubstitution(GlyphSubstitutionCollection collection, KerningMode kerningMode)
+        internal override void ApplySubstitution(GlyphSubstitutionCollection collection)
         {
             if (this.gSubTable != null)
             {
-                this.gSubTable.ApplySubstitution(this, collection, kerningMode);
+                this.gSubTable.ApplySubstitution(this, collection);
             }
         }
 
         /// <inheritdoc/>
-        internal override void UpdatePositions(GlyphPositioningCollection collection, KerningMode kerningMode)
+        internal override void UpdatePositions(GlyphPositioningCollection collection)
         {
             bool kerned = false;
+            KerningMode kerningMode = collection.TextOptions.KerningMode;
             if (this.gPosTable != null)
             {
-                this.gPosTable.TryUpdatePositions(this, collection, kerningMode, out kerned);
+                this.gPosTable.TryUpdatePositions(this, collection, out kerned);
             }
 
             if (!kerned && kerningMode != KerningMode.None && this.kerningTable != null)

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/FeatureTags.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/FeatureTags.cs
@@ -4,10 +4,10 @@
 namespace SixLabors.Fonts.Tables.AdvancedTypographic
 {
     /// <summary>
-    /// Enum for the different font features.
-    /// <see href="https://docs.microsoft.com/en-us/typography/opentype/otspec183/features_ae"/>
+    /// Provides enumeration for the different font features.
+    /// <see href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"/>
     /// </summary>
-    internal enum FeatureTag : uint
+    public enum FeatureTags : uint
     {
         /// <summary>
         /// Access All Alternates. Shortcode: aalt.

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/AnchorTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/AnchorTable.cs
@@ -109,9 +109,9 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
 
             public override AnchorXY GetAnchor(FontMetrics fontMetrics, GlyphShapingData data, GlyphPositioningCollection collection)
             {
-                if (collection.ApplyHinting)
+                if (collection.TextOptions.ApplyHinting)
                 {
-                    foreach (GlyphMetrics metric in fontMetrics.GetGlyphMetrics(data.CodePoint, collection.ColorFontSupport))
+                    foreach (GlyphMetrics metric in fontMetrics.GetGlyphMetrics(data.CodePoint, collection.TextOptions.ColorFontSupport))
                     {
                         ReadOnlyMemory<Vector2> points = metric.GetOutline().ControlPoints;
                         if (this.anchorPointIndex < points.Length)

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
@@ -100,7 +100,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
             return new GPosTable(scriptList, featureList, lookupList);
         }
 
-        public bool TryUpdatePositions(FontMetrics fontMetrics, GlyphPositioningCollection collection, KerningMode kerningMode, out bool kerned)
+        public bool TryUpdatePositions(FontMetrics fontMetrics, GlyphPositioningCollection collection, out bool kerned)
         {
             kerned = false;
             bool updated = false;
@@ -112,7 +112,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                 }
 
                 ScriptClass current = CodePoint.GetScriptClass(collection.GetGlyphShapingData(i).CodePoint);
-                BaseShaper shaper = ShaperFactory.Create(current, kerningMode);
+                BaseShaper shaper = ShaperFactory.Create(current, collection.TextOptions);
 
                 ushort index = i;
                 ushort count = 1;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSubTable.cs
@@ -96,14 +96,14 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
             return new GSubTable(scriptList, featureList, lookupList);
         }
 
-        public void ApplySubstitution(FontMetrics fontMetrics, GlyphSubstitutionCollection collection, KerningMode kerningMode)
+        public void ApplySubstitution(FontMetrics fontMetrics, GlyphSubstitutionCollection collection)
         {
             for (ushort i = 0; i < collection.Count; i++)
             {
                 // Choose a shaper based on the script.
                 // This determines which features to apply to which glyphs.
                 ScriptClass current = CodePoint.GetScriptClass(collection.GetGlyphShapingData(i).CodePoint);
-                BaseShaper shaper = ShaperFactory.Create(current, kerningMode);
+                BaseShaper shaper = ShaperFactory.Create(current, collection.TextOptions);
 
                 ushort index = i;
                 ushort count = 1;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ArabicShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ArabicShaper.cs
@@ -74,8 +74,8 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
             { new byte[] { None, None, 0 }, new byte[] { None, Isol, 2 }, new byte[] { None, Isol, 1 }, new byte[] { None, Isol, 2 }, new byte[] { None, Fin3, 5 }, new byte[] { None, Isol, 6 } },
         };
 
-        public ArabicShaper(KerningMode kerningMode)
-            : base(MarkZeroingMode.PostGpos, kerningMode)
+        public ArabicShaper(TextOptions textOptions)
+            : base(MarkZeroingMode.PostGpos, textOptions)
         {
         }
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/DefaultShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/DefaultShaper.cs
@@ -62,15 +62,18 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
 
         private readonly KerningMode kerningMode;
 
-        internal DefaultShaper(KerningMode kerningMode)
-            : this(MarkZeroingMode.PostGpos, kerningMode)
+        private readonly IReadOnlyList<Tag> featureTags;
+
+        internal DefaultShaper(TextOptions textOptions)
+            : this(MarkZeroingMode.PostGpos, textOptions)
         {
         }
 
-        protected DefaultShaper(MarkZeroingMode markZeroingMode, KerningMode kerningMode)
+        protected DefaultShaper(MarkZeroingMode markZeroingMode, TextOptions textOptions)
         {
             this.MarkZeroingMode = markZeroingMode;
-            this.kerningMode = kerningMode;
+            this.kerningMode = textOptions.KerningMode;
+            this.featureTags = textOptions.FeatureTags;
         }
 
         /// <inheritdoc />
@@ -162,6 +165,12 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                     this.AddFeature(collection, i, 1, FracTag);
                     i = end - 1;
                 }
+            }
+
+            // Add user defined features.
+            foreach (Tag feature in this.featureTags)
+            {
+                this.AddFeature(collection, index, count, feature);
             }
         }
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ShaperFactory.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ShaperFactory.cs
@@ -11,9 +11,9 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
         /// Creates a Shaper based on the given script language.
         /// </summary>
         /// <param name="script">The script language.</param>
-        /// <param name="kerningMode">The kerning mode.</param>
+        /// <param name="textOptions">The text options.</param>
         /// <returns>A shaper for the given script.</returns>
-        public static BaseShaper Create(ScriptClass script, KerningMode kerningMode)
+        public static BaseShaper Create(ScriptClass script, TextOptions textOptions)
             => script switch
             {
                 ScriptClass.Arabic
@@ -23,8 +23,8 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                 or ScriptClass.PhagsPa
                 or ScriptClass.Mandaic
                 or ScriptClass.Manichaean
-                or ScriptClass.PsalterPahlavi => new ArabicShaper(kerningMode),
-                _ => new DefaultShaper(kerningMode),
+                or ScriptClass.PsalterPahlavi => new ArabicShaper(textOptions),
+                _ => new DefaultShaper(textOptions),
             };
     }
 }

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Tag.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Tag.cs
@@ -27,6 +27,8 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public static implicit operator Tag(uint value) => new(value);
 
+        public static implicit operator Tag(FeatureTags value) => new((uint)value);
+
         public static bool operator ==(Tag left, Tag right) => left.Equals(right);
 
         public static bool operator !=(Tag left, Tag right) => !(left == right);

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -58,7 +58,7 @@ namespace SixLabors.Fonts
             }
 
             LayoutMode layoutMode = options.LayoutMode;
-            GlyphSubstitutionCollection substitutions = new(layoutMode);
+            GlyphSubstitutionCollection substitutions = new(options);
             GlyphPositioningCollection positionings = new(options);
 
             // Analyse the text for bidi directional runs.
@@ -113,10 +113,10 @@ namespace SixLabors.Fonts
             // Update the positions of the glyphs in the completed collection.
             // Each set of metrics is associated with single font and will only be updated
             // by that font so it's safe to use a single collection.
-            mainFont.UpdatePositions(positionings, options.KerningMode);
+            mainFont.UpdatePositions(positionings);
             foreach (FontMetrics font in fallbackFonts)
             {
-                font.UpdatePositions(positionings, options.KerningMode);
+                font.UpdatePositions(positionings);
             }
 
             return BreakLines(text, options, bidiRuns, bidiMap, positionings, layoutMode);
@@ -448,7 +448,7 @@ namespace SixLabors.Fonts
             // Apply the simple and complex substitutions.
             // TODO: Investigate HarfBuzz normlizer.
             SubstituteBidiMirrors(fontMetrics, substitutions);
-            fontMetrics.ApplySubstitution(substitutions, options.KerningMode);
+            fontMetrics.ApplySubstitution(substitutions);
 
             return positionings.TryAddOrUpdate(fontMetrics, substitutions);
         }

--- a/src/SixLabors.Fonts/TextOptions.cs
+++ b/src/SixLabors.Fonts/TextOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using SixLabors.Fonts.Tables.AdvancedTypographic;
 
 namespace SixLabors.Fonts
 {
@@ -46,6 +47,7 @@ namespace SixLabors.Fonts
             this.LayoutMode = options.LayoutMode;
             this.KerningMode = options.KerningMode;
             this.ColorFontSupport = options.ColorFontSupport;
+            this.FeatureTags = new List<Tag>(options.FeatureTags);
         }
 
         /// <summary>
@@ -174,5 +176,10 @@ namespace SixLabors.Fonts
         /// Gets or sets a value indicating whether to enable various color font formats.
         /// </summary>
         public ColorFontSupport ColorFontSupport { get; set; } = ColorFontSupport.MicrosoftColrFormat;
+
+        /// <summary>
+        /// Gets or sets the collection of additional feature tags to apply during glyph shaping.
+        /// </summary>
+        public IReadOnlyList<Tag> FeatureTags { get; set; } = Array.Empty<Tag>();
     }
 }

--- a/tests/SixLabors.Fonts.Tests/TextOptionsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextOptionsTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Generic;
 using System.Numerics;
+using SixLabors.Fonts.Tables.AdvancedTypographic;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests
@@ -302,7 +304,8 @@ namespace SixLabors.Fonts.Tests
                 TabWidth = 3F,
                 LineSpacing = -1F,
                 VerticalAlignment = VerticalAlignment.Bottom,
-                WrappingLength = 42F
+                WrappingLength = 42F,
+                FeatureTags = new List<Tag> { FeatureTags.OldstyleFigures }
             };
 
             TextOptions actual = new(expected);
@@ -314,6 +317,7 @@ namespace SixLabors.Fonts.Tests
             Assert.Equal(expected.TabWidth, actual.TabWidth);
             Assert.Equal(expected.VerticalAlignment, actual.VerticalAlignment);
             Assert.Equal(expected.WrappingLength, actual.WrappingLength);
+            Assert.Equal(expected.FeatureTags, actual.FeatureTags);
         }
 
         [Fact]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds the ability to pass custom feature tags via the `TextOptions` type to enable open type features. See #229 

```c#
new TextOptions(new Font(font, pointSize))
{
    // Implicit cast between FeatureTags enum and Tag type.
    FeatureTags = new List<Tag>() { FeatureTags.OldstyleFigures }
},
```

Here's some example output using the [`onum`](https://otf.show/onum) feature with EB Garamond 

Default
![10Broad36](https://user-images.githubusercontent.com/385879/155885485-6276435f-0422-42f1-b07b-c70d83fb9f32.png)

Onum
![10Broad36-onum](https://user-images.githubusercontent.com/385879/155885487-df6af808-0ed4-41f6-b48b-8ef7830ddd68.png)

cc\ @senneschall
<!-- Thanks for contributing to SixLabors.Fonts! -->
