### PR TITLE
Only skip non-dirty glyphs when updating positions.

### DIFF
--- a/src/SixLabors.Fonts/GlyphPositioningCollection.cs
+++ b/src/SixLabors.Fonts/GlyphPositioningCollection.cs
@@ -225,6 +225,11 @@ namespace SixLabors.Fonts
         public void UpdatePosition(FontMetrics fontMetrics, ushort index)
         {
             GlyphShapingData data = this.GetGlyphShapingData(index);
+            if (!data.Bounds.IsDirty)
+            {
+                return;
+            }
+
             ushort glyphId = data.GlyphIds[0];
             foreach (GlyphMetrics m in this.map[this.offsets[index]])
             {

--- a/src/SixLabors.Fonts/GlyphShapingBounds.cs
+++ b/src/SixLabors.Fonts/GlyphShapingBounds.cs
@@ -13,23 +13,67 @@ namespace SixLabors.Fonts
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal class GlyphShapingBounds
     {
+        private int x;
+        private int y;
+        private int width;
+        private int height;
+
         public GlyphShapingBounds(int x, int y, int width, int height)
         {
-            this.X = x;
-            this.Y = y;
-            this.Width = width;
-            this.Height = height;
+            this.x = x;
+            this.y = y;
+            this.width = width;
+            this.height = height;
+            this.IsDirty = false;
         }
 
-        public int X { get; set; }
+        public int X
+        {
+            get => this.x;
 
-        public int Y { get; set; }
+            set
+            {
+                this.x = value;
+                this.IsDirty = true;
+            }
+        }
 
-        public int Width { get; set; }
+        public int Y
+        {
+            get => this.y;
 
-        public int Height { get; set; }
+            set
+            {
+                this.y = value;
+                this.IsDirty = true;
+            }
+        }
+
+        public int Width
+        {
+            get => this.width;
+
+            set
+            {
+                this.width = value;
+                this.IsDirty = true;
+            }
+        }
+
+        public int Height
+        {
+            get => this.height;
+
+            set
+            {
+                this.height = value;
+                this.IsDirty = true;
+            }
+        }
+
+        public bool IsDirty { get; private set; }
 
         private string DebuggerDisplay
-            => FormattableString.Invariant($"{this.X} : {this.Y} : {this.Width} : {this.Height}");
+            => FormattableString.Invariant($"{this.X} : {this.Y} : {this.Width} : {this.Height} : {this.IsDirty}");
     }
 }

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
@@ -179,10 +179,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
 
                 FixCursiveAttachment(collection, index, count);
                 FixMarkAttachment(collection, index, count);
-                if (updated)
-                {
-                    UpdatePositions(fontMetrics, collection, index, count);
-                }
+                UpdatePositions(fontMetrics, collection, index, count);
             }
 
             return updated;

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -508,7 +508,7 @@ namespace SixLabors.Fonts
             float wrappingLength = shouldWrap ? options.WrappingLength / options.Dpi : float.MaxValue;
             bool breakAll = options.WordBreaking == WordBreaking.BreakAll;
             bool keepAll = options.WordBreaking == WordBreaking.KeepAll;
-            bool isHorizontal = (layoutMode & LayoutMode.VerticalLeftRight) == 0;
+            bool isHorizontal = !layoutMode.IsVertical();
 
             float scaledMaxAscender = 0;
             float scaledMaxDescender = 0;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This is an update fixing up a quick hack to ensure horizontal fonts with no (few) vertical features are displayed properly when rendering the fonts using a vertical layout mode. 

The previous fix would incorrectly apply positional advances to glyphs where no advance had been resolved. This could potentially cause offset issues. This updated fix applied advances to glyphs whose bounds have been altered by positioning features.


<!-- Thanks for contributing to SixLabors.Fonts! -->
