### PR TITLE
Add underline and strikeout rendering on top of `TextRun`s

### DIFF
--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -42,11 +42,12 @@ namespace SixLabors.Fonts.DrawWithImageSharp
             FontFamily tahoma = SystemFonts.Get("Tahoma");
             var textRuns = new List<TextRun>
             {
-                new TextRun { Start = 4, End = 9, Font = uiFont.CreateFont(32, FontStyle.Bold) },
-                new TextRun { Start = 26, End = 30, Font = uiFont.CreateFont(32, FontStyle.Italic) }
+                new TextRun { Start = 4, End = 9, Font = uiFont.CreateFont(32, FontStyle.Bold), TextAttributes = TextAttribute.Strikethrough },
+                new TextRun { Start = 26, End = 30, Font = uiFont.CreateFont(32, FontStyle.Italic), TextAttributes = TextAttribute.Underline }
             };
 
             RenderText(uiFont, "The quick brown fox jumps over the lazy dog", 32, textRuns: textRuns);
+
             return;
             RenderText(font2, "\uFB01", pointSize: 11.25F);
             RenderText(fontWoff2, "\uFB01", pointSize: 11.25F);

--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -341,10 +341,10 @@ namespace SixLabors.Fonts
 
                     Vector2 scale = new Vector2(scaledPoint) / this.ScaleFactor * MirrorScale;
 
-                    var tl = (new Vector2(0, top) * scale) + location;
-                    var tr = (new Vector2(this.AdvanceWidth, top) * scale) + location;
-                    var br = (new Vector2(this.AdvanceWidth, bottom) * scale) + location;
-                    var bl = (new Vector2(0, bottom) * scale) + location;
+                    var tl = (new Vector2(-this.LeftSideBearing, top) * scale) + location;
+                    var tr = (new Vector2(this.AdvanceWidth + this.LeftSideBearing, top) * scale) + location;
+                    var br = (new Vector2(this.AdvanceWidth + this.LeftSideBearing, bottom) * scale) + location;
+                    var bl = (new Vector2(-this.LeftSideBearing, bottom) * scale) + location;
 
                     tl.Y = MathF.Ceiling(tl.Y);
                     tr.Y = MathF.Ceiling(tr.Y);

--- a/src/SixLabors.Fonts/GlyphRendererParameters.cs
+++ b/src/SixLabors.Fonts/GlyphRendererParameters.cs
@@ -102,6 +102,7 @@ namespace SixLabors.Fonts
             && other.Dpi == this.Dpi
             && other.GlyphIndex == this.GlyphIndex
             && other.GlyphType == this.GlyphType
+            && other.TextRun == this.TextRun
             && other.GlyphColor.Equals(this.GlyphColor)
             && ((other.Font is null && this.Font is null)
             || (other.Font?.Equals(this.Font, StringComparison.OrdinalIgnoreCase) == true));
@@ -118,6 +119,7 @@ namespace SixLabors.Fonts
                 this.GlyphType,
                 this.GlyphColor,
                 this.FontStyle,
-                this.Dpi);
+                this.Dpi,
+                this.TextRun);
     }
 }

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -167,7 +167,7 @@ namespace SixLabors.Fonts
             this.StrikeoutPosition = os2.StrikeoutPosition;
 
             this.UnderlinePosition = postTable.UnderlinePosition;
-            this.UnderlinePosition = postTable.UnderlinePosition;
+            this.UnderlineThickness = postTable.UnderlineThickness;
             this.ItalicAngle = postTable.ItalicAngle;
 
             this.kerningTable = kern;

--- a/src/SixLabors.Fonts/TextRenderer.cs
+++ b/src/SixLabors.Fonts/TextRenderer.cs
@@ -59,10 +59,10 @@ namespace SixLabors.Fonts
 
             foreach (GlyphLayout g in glyphsToRender)
             {
-                if (g.IsWhiteSpace())
-                {
-                    continue;
-                }
+                //if (g.IsWhiteSpace())
+                //{
+                //    continue;
+                //}
 
                 g.Glyph.RenderTo(this.renderer, g.Location, options);
             }

--- a/src/SixLabors.Fonts/TextRenderer.cs
+++ b/src/SixLabors.Fonts/TextRenderer.cs
@@ -59,11 +59,6 @@ namespace SixLabors.Fonts
 
             foreach (GlyphLayout g in glyphsToRender)
             {
-                //if (g.IsWhiteSpace())
-                //{
-                //    continue;
-                //}
-
                 g.Glyph.RenderTo(this.renderer, g.Location, options);
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
@JimBobSquarePants this expands on your branch fixing a bog where you had set the `UnderlinePosition` position twice. 
It draws the underline/strike out in the context of the fonts itself. 

![The quick brown fox jumps over the lazy dog](https://user-images.githubusercontent.com/166440/156827224-b4ca28b2-fcd0-4fcc-9ad7-21045efa7bd8.png)