### PR TITLE
Better FontHinting Control.

### DIFF
--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -269,12 +269,7 @@ namespace SixLabors.Fonts
                         var transform = Matrix3x2.CreateScale(scale);
                         transform.Translation = this.offset * scale * MirrorScale;
                         scaledVector = GlyphVector.Transform(this.vector, transform);
-
-                        if (options.ApplyHinting)
-                        {
-                            this.FontMetrics.ApplyHinting(this, ref scaledVector, scale, scaledPPEM);
-                        }
-
+                        this.FontMetrics.ApplyHinting(options.HintingMode, this, ref scaledVector, scale, scaledPPEM);
                         this.scaledVector[scaledPPEM] = scaledVector;
                     }
 

--- a/src/SixLabors.Fonts/HintingMode.cs
+++ b/src/SixLabors.Fonts/HintingMode.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.Fonts
+{
+    /// <summary>
+    /// Defines modes to determine how to apply hinting. The use of mathematical instructions
+    /// to adjust the display of an outline font so that it lines up with a rasterized grid.
+    /// </summary>
+    public enum HintingMode
+    {
+        /// <summary>
+        /// Do not hint the glyphs.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Hint the glyphs in a vertical direction only. <see href="http://agg.sourceforge.net/antigrain.com/research/font_rasterization/"/>.
+        /// </summary>
+        HintY,
+
+        /// <summary>
+        /// Hint the glyphs in both directions.
+        /// </summary>
+        HintXY
+    }
+}

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -478,8 +478,13 @@ namespace SixLabors.Fonts
             return fonts;
         }
 
-        internal void ApplyHinting(GlyphMetrics metrics, ref GlyphVector glyphVector, Vector2 scaleXY, float scaledPPEM)
+        internal void ApplyHinting(HintingMode hintingMode, GlyphMetrics metrics, ref GlyphVector glyphVector, Vector2 scaleXY, float scaledPPEM)
         {
+            if (hintingMode == HintingMode.None)
+            {
+                return;
+            }
+
             if (this.interpreter == null)
             {
                 this.interpreter = new Hinting.Interpreter(
@@ -505,7 +510,7 @@ namespace SixLabors.Fonts
             var pp3 = new Vector2(0, bounds.Max.Y + (metrics.TopSideBearing * scaleXY.Y));
             var pp4 = new Vector2(0, pp3.Y - (metrics.AdvanceHeight * scaleXY.Y));
 
-            GlyphVector.Hint(ref glyphVector, this.interpreter, pp1, pp2, pp3, pp4);
+            GlyphVector.Hint(hintingMode, ref glyphVector, this.interpreter, pp1, pp2, pp3, pp4);
         }
 
         private bool TryGetColoredMetrics(CodePoint codePoint, ushort glyphId, [NotNullWhen(true)] out GlyphMetrics[]? metrics)

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/AnchorTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/AnchorTable.cs
@@ -109,7 +109,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
 
             public override AnchorXY GetAnchor(FontMetrics fontMetrics, GlyphShapingData data, GlyphPositioningCollection collection)
             {
-                if (collection.TextOptions.ApplyHinting)
+                if (collection.TextOptions.HintingMode != HintingMode.None)
                 {
                     foreach (GlyphMetrics metric in fontMetrics.GetGlyphMetrics(data.CodePoint, collection.TextOptions.ColorFontSupport))
                     {

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/GlyphVector.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/GlyphVector.cs
@@ -4,6 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+#if SUPPORTS_RUNTIME_INTRINSICS
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
 using SixLabors.Fonts.Hinting;
 
 namespace SixLabors.Fonts.Tables.General.Glyphs
@@ -122,14 +128,20 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
         /// <summary>
         /// Applies True Type hinting to the specified glyph vector.
         /// </summary>
+        /// <param name="hintingMode">The hinting mode.</param>
         /// <param name="glyph">The glyph vector to hint.</param>
         /// <param name="interpreter">The True Type interpreter.</param>
         /// <param name="pp1">The first phantom point.</param>
         /// <param name="pp2">The second phantom point.</param>
         /// <param name="pp3">The third phantom point.</param>
         /// <param name="pp4">The fourth phantom point.</param>
-        public static void Hint(ref GlyphVector glyph, Interpreter interpreter, Vector2 pp1, Vector2 pp2, Vector2 pp3, Vector2 pp4)
+        public static void Hint(HintingMode hintingMode, ref GlyphVector glyph, Interpreter interpreter, Vector2 pp1, Vector2 pp2, Vector2 pp3, Vector2 pp4)
         {
+            if (hintingMode == HintingMode.None)
+            {
+                return;
+            }
+
             for (int i = 0; i < glyph.entries.Count; i++)
             {
                 GlyphTableEntry entry = glyph.entries[i];
@@ -142,11 +154,67 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
                 controlPoints[controlPoints.Length - 1] = pp4;
                 entry.ControlPoints.AsSpan().CopyTo(controlPoints.AsSpan());
 
+                // To keep vertical hinting but discard horizontal we simply cheat the hinter.
+                // We stretch the symbols horizontally so that the hinter would have to work with high accuracy in the X direction.
+                if (hintingMode == HintingMode.HintY)
+                {
+                    ScaleX(controlPoints, 1000F);
+                }
+
                 var withPhantomPoints = new GlyphTableEntry(controlPoints, entry.OnCurves, entry.EndPoints, entry.Bounds, entry.Instructions);
                 interpreter.HintGlyph(withPhantomPoints);
 
+                if (hintingMode == HintingMode.HintY)
+                {
+                    ScaleX(controlPoints, 1F / 1000F);
+                }
+
                 controlPoints.AsSpan(0, entry.ControlPoints.Length).CopyTo(entry.ControlPoints.AsSpan());
                 glyph.entries[i] = entry;
+            }
+        }
+
+        private static void ScaleX(Span<Vector2> controlPoints, float scale)
+        {
+            int remainder = 0;
+#if SUPPORTS_RUNTIME_INTRINSICS
+            if (Avx.IsSupported)
+            {
+                ref Vector256<float> controlPointsBase = ref Unsafe.As<Vector2, Vector256<float>>(ref MemoryMarshal.GetReference(controlPoints));
+                int length = controlPoints.Length;
+                nint n = length * 2 / Vector256<float>.Count;
+                if (n >= 1)
+                {
+                    remainder = length - (ModuloP2(length, Vector256<float>.Count) / 2);
+                    Vector256<float> mutiplier = Avx.UnpackLow(Vector256.Create(scale), Vector256.Create(1F));
+                    for (nint i = 0; i < n; i++)
+                    {
+                        ref Vector256<float> original = ref Unsafe.Add(ref controlPointsBase, i);
+                        original = Avx.Multiply(original, mutiplier);
+                    }
+                }
+            }
+            else if (Sse.IsSupported)
+            {
+                ref Vector128<float> controlPointsBase = ref Unsafe.As<Vector2, Vector128<float>>(ref MemoryMarshal.GetReference(controlPoints));
+                int length = controlPoints.Length;
+                nint n = length * 2 / Vector128<float>.Count;
+                if (n >= 1)
+                {
+                    remainder = length - (ModuloP2(length, Vector128<float>.Count) / 2);
+                    Vector128<float> mutiplier = Sse.UnpackLow(Vector128.Create(scale), Vector128.Create(1F));
+                    for (nint i = 0; i < n; i++)
+                    {
+                        ref Vector128<float> original = ref Unsafe.Add(ref controlPointsBase, i);
+                        original = Sse.Multiply(original, mutiplier);
+                    }
+                }
+            }
+#endif
+            Vector2 v = new(scale, 1F);
+            for (int i = remainder; i < controlPoints.Length; i++)
+            {
+                controlPoints[i] *= v;
             }
         }
 
@@ -216,5 +284,13 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
         /// <returns>The <see cref="GlyphVector"/>.</returns>
         public static GlyphVector WithCompositeBounds(GlyphVector src, Bounds bounds)
             => new(src.entries, bounds);
+#if SUPPORTS_RUNTIME_INTRINSICS
+        /// <summary>
+        /// Fast (x mod m) calculator, with the restriction that
+        /// <paramref name="m"/> should be power of 2.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ModuloP2(int x, int m) => x & (m - 1);
+#endif
     }
 }

--- a/src/SixLabors.Fonts/Tables/General/Glyphs/GlyphVector.cs
+++ b/src/SixLabors.Fonts/Tables/General/Glyphs/GlyphVector.cs
@@ -180,34 +180,24 @@ namespace SixLabors.Fonts.Tables.General.Glyphs
 #if SUPPORTS_RUNTIME_INTRINSICS
             if (Avx.IsSupported)
             {
-                ref Vector256<float> controlPointsBase = ref Unsafe.As<Vector2, Vector256<float>>(ref MemoryMarshal.GetReference(controlPoints));
                 int length = controlPoints.Length;
-                nint n = length * 2 / Vector256<float>.Count;
-                if (n >= 1)
+                remainder = length - (ModuloP2(length * 2, Vector256<float>.Count) / 2);
+                Span<Vector256<float>> vectors = MemoryMarshal.Cast<Vector2, Vector256<float>>(controlPoints);
+                Vector256<float> mutiplier = Avx.UnpackLow(Vector256.Create(scale), Vector256.Create(1F));
+                for (int i = 0; i < vectors.Length; i++)
                 {
-                    remainder = length - (ModuloP2(length, Vector256<float>.Count) / 2);
-                    Vector256<float> mutiplier = Avx.UnpackLow(Vector256.Create(scale), Vector256.Create(1F));
-                    for (nint i = 0; i < n; i++)
-                    {
-                        ref Vector256<float> original = ref Unsafe.Add(ref controlPointsBase, i);
-                        original = Avx.Multiply(original, mutiplier);
-                    }
+                    vectors[i] = Avx.Multiply(vectors[i], mutiplier);
                 }
             }
             else if (Sse.IsSupported)
             {
-                ref Vector128<float> controlPointsBase = ref Unsafe.As<Vector2, Vector128<float>>(ref MemoryMarshal.GetReference(controlPoints));
                 int length = controlPoints.Length;
-                nint n = length * 2 / Vector128<float>.Count;
-                if (n >= 1)
+                remainder = length - (ModuloP2(length * 2, Vector128<float>.Count) / 2);
+                Span<Vector128<float>> vectors = MemoryMarshal.Cast<Vector2, Vector128<float>>(controlPoints);
+                Vector128<float> mutiplier = Sse.UnpackLow(Vector128.Create(scale), Vector128.Create(1F));
+                for (int i = 0; i < vectors.Length; i++)
                 {
-                    remainder = length - (ModuloP2(length, Vector128<float>.Count) / 2);
-                    Vector128<float> mutiplier = Sse.UnpackLow(Vector128.Create(scale), Vector128.Create(1F));
-                    for (nint i = 0; i < n; i++)
-                    {
-                        ref Vector128<float> original = ref Unsafe.Add(ref controlPointsBase, i);
-                        original = Sse.Multiply(original, mutiplier);
-                    }
+                    vectors[i] = Sse.Multiply(vectors[i], mutiplier);
                 }
             }
 #endif

--- a/src/SixLabors.Fonts/TextOptions.cs
+++ b/src/SixLabors.Fonts/TextOptions.cs
@@ -34,7 +34,7 @@ namespace SixLabors.Fonts
             this.Font = options.Font;
             this.FallbackFontFamilies = new List<FontFamily>(options.FallbackFontFamilies);
             this.TabWidth = options.TabWidth;
-            this.ApplyHinting = options.ApplyHinting;
+            this.HintingMode = options.HintingMode;
             this.Dpi = options.Dpi;
             this.LineSpacing = options.LineSpacing;
             this.Origin = options.Origin;
@@ -106,7 +106,7 @@ namespace SixLabors.Fonts
         /// Gets or sets a value indicating whether to apply hinting - The use of mathematical instructions
         /// to adjust the display of an outline font so that it lines up with a rasterized grid.
         /// </summary>
-        public bool ApplyHinting { get; set; }
+        public HintingMode HintingMode { get; set; }
 
         /// <summary>
         /// Gets or sets the line spacing. Applied as a multiple of the line height.

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -171,14 +171,14 @@ namespace SixLabors.Fonts.Tests
             TextRenderer.RenderTextTo(rendererTtf, testStr, new TextOptions(fontTtf)
             {
                 KerningMode = applyKerning ? KerningMode.Normal : KerningMode.None,
-                ApplyHinting = applyHinting,
+                HintingMode = applyHinting ? HintingMode.HintXY : HintingMode.None,
                 ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
             });
             var rendererWoff = new ColorGlyphRenderer();
             TextRenderer.RenderTextTo(rendererWoff, testStr, new TextOptions(fontWoff)
             {
                 KerningMode = applyKerning ? KerningMode.Normal : KerningMode.None,
-                ApplyHinting = applyHinting,
+                HintingMode = applyHinting ? HintingMode.HintXY : HintingMode.None,
                 ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
             });
 
@@ -200,13 +200,13 @@ namespace SixLabors.Fonts.Tests
             var rendererTtf = new ColorGlyphRenderer();
             TextRenderer.RenderTextTo(rendererTtf, testStr, new TextOptions(fontTtf)
             {
-                ApplyHinting = true,
+                HintingMode = HintingMode.HintY,
                 ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
             });
             var rendererWoff = new ColorGlyphRenderer();
             TextRenderer.RenderTextTo(rendererWoff, testStr, new TextOptions(fontWoff)
             {
-                ApplyHinting = true,
+                HintingMode = HintingMode.HintY,
                 ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
             });
 
@@ -230,14 +230,14 @@ namespace SixLabors.Fonts.Tests
             TextRenderer.RenderTextTo(rendererTtf, testStr, new TextOptions(fontTtf)
             {
                 KerningMode = applyKerning ? KerningMode.Normal : KerningMode.None,
-                ApplyHinting = applyHinting,
+                HintingMode = applyHinting ? HintingMode.HintXY : HintingMode.None,
                 ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
             });
             var rendererWoff2 = new ColorGlyphRenderer();
             TextRenderer.RenderTextTo(rendererWoff2, testStr, new TextOptions(fontWoff2)
             {
                 KerningMode = applyKerning ? KerningMode.Normal : KerningMode.None,
-                ApplyHinting = applyHinting,
+                HintingMode = applyHinting ? HintingMode.HintXY : HintingMode.None,
                 ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
             });
 
@@ -259,13 +259,13 @@ namespace SixLabors.Fonts.Tests
             var rendererTtf = new ColorGlyphRenderer();
             TextRenderer.RenderTextTo(rendererTtf, testStr, new TextOptions(fontTtf)
             {
-                ApplyHinting = true,
+                HintingMode = HintingMode.HintY,
                 ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
             });
             var rendererWoff2 = new ColorGlyphRenderer();
             TextRenderer.RenderTextTo(rendererWoff2, testStr, new TextOptions(fontWoff2)
             {
-                ApplyHinting = true,
+                HintingMode = HintingMode.HintY,
                 ColorFontSupport = ColorFontSupport.MicrosoftColrFormat
             });
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This PR replaces the `TextOptions.ApplyHinting` boolean with a new enum `HintingMode` which allows a new hinting option to hint in the Y direction only. This is based upon the work in Antigrain Geometry described here. http://agg.sourceforge.net/antigrain.com/research/font_rasterization/

The following images represent Tahoma rendered using 11.25pt at 72dpi original size and zoomed at 400%

Left HintingMode.None : Right HintingMode.HintY
![image](https://user-images.githubusercontent.com/385879/160350431-ea14cee0-6581-4db6-8efa-aef9ab04c3c5.png)
![image](https://user-images.githubusercontent.com/385879/160349226-8925d62f-6107-44d8-b617-7eae17782d5d.png)

Left HintingMode.None : Right HintingMode.HintXY
![image](https://user-images.githubusercontent.com/385879/160350570-00bb73e1-3471-49d0-b924-bf680dfa23e9.png)
![image](https://user-images.githubusercontent.com/385879/160349451-e26f1db9-31fb-4385-b230-6577af6dd5a6.png)

Left HintingMode.HintY : Right HintingMode.HintXY
![image](https://user-images.githubusercontent.com/385879/160350696-b52b6b74-e32f-418d-b569-2cac0294014e.png)
![image](https://user-images.githubusercontent.com/385879/160349976-a08f7128-854a-427a-b6a2-a1b365505bd3.png)


<!-- Thanks for contributing to SixLabors.Fonts! -->
