### PR TITLE
Make fractions optional. 

### DIFF
--- a/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
+++ b/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14.8" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
@@ -82,7 +82,7 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GSub
             int[] expectedGlyphIndices = { 580, 404, 453 };
 
             // act
-            TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new[] { (Tag)FeatureTags.Numerators, (Tag)FeatureTags.Denominators } });
+            TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new Tag[] { FeatureTags.Numerators, FeatureTags.Denominators } });
 
             // assert
             Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
@@ -102,7 +102,7 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GSub
             int[] expectedGlyphIndices = { 580, 404, 453 };
 
             // act
-            TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new[] { (Tag)FeatureTags.Fractions } });
+            TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new Tag[] { FeatureTags.Fractions } });
 
             // assert
             Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);

--- a/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
@@ -82,7 +82,7 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GSub
             int[] expectedGlyphIndices = { 580, 404, 453 };
 
             // act
-            TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font));
+            TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new[] { (Tag)FeatureTags.Numerators, (Tag)FeatureTags.Denominators } });
 
             // assert
             Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
@@ -102,7 +102,7 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GSub
             int[] expectedGlyphIndices = { 580, 404, 453 };
 
             // act
-            TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font));
+            TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new[] { (Tag)FeatureTags.Fractions } });
 
             // assert
             Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Fixes #259

Fractions should not be enabled by default and should be turned on only when user defined features contain.

A. Frac feature tag.
B. Numr and Dnom feature tags.

https://docs.microsoft.com/en-us/typography/opentype/spec/features_fj#tag-frac

<!-- Thanks for contributing to SixLabors.Fonts! -->
