### PR TITLE
Implement Hangul Shaper

### DIFF
--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.Tables.General.Glyphs;
 using SixLabors.Fonts.Unicode;
@@ -458,12 +459,14 @@ namespace SixLabors.Fonts
             surface.EndGlyph();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ShouldSkipGlyphRendering(CodePoint codePoint)
         {
             uint value = (uint)codePoint.Value;
             return UnicodeUtility.IsDefaultIgnorableCodePoint(value) && !ShouldRenderWhiteSpaceOnly(codePoint);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ShouldRenderWhiteSpaceOnly(CodePoint codePoint)
         {
             if (CodePoint.IsWhiteSpace(codePoint))

--- a/src/SixLabors.Fonts/GlyphPositioningCollection.cs
+++ b/src/SixLabors.Fonts/GlyphPositioningCollection.cs
@@ -145,6 +145,8 @@ namespace SixLabors.Fonts
                 ushort[] glyphIds = data.GlyphIds;
                 var m = new List<GlyphMetrics>(glyphIds.Length);
 
+                ushort shiftXY = 0;
+                bool doShift = data.OffsetGlyphs;
                 foreach (ushort id in glyphIds)
                 {
                     // Perform a semi-deep clone (FontMetrics is not cloned) so we can continue to
@@ -159,9 +161,25 @@ namespace SixLabors.Fonts
                             break;
                         }
 
+                        // Clone and offset the glyph based on it's position in the glyphId array.
                         // We slip the text run in here while we clone so we have
                         // it available to the renderer.
-                        m.Add(GlyphMetrics.CloneForRendering(gm, data.TextRun, codePoint));
+                        var clone = GlyphMetrics.CloneForRendering(gm, data.TextRun, codePoint);
+                        if (doShift)
+                        {
+                            if (!this.IsVerticalLayoutMode)
+                            {
+                                clone.ApplyOffset((short)shiftXY, 0);
+                                shiftXY += clone.AdvanceWidth;
+                            }
+                            else
+                            {
+                                clone.ApplyOffset(0, (short)shiftXY);
+                                shiftXY += clone.AdvanceHeight;
+                            }
+                        }
+
+                        m.Add(clone);
                     }
                 }
 
@@ -205,6 +223,8 @@ namespace SixLabors.Fonts
                 ushort[] glyphIds = data.GlyphIds;
                 var m = new List<GlyphMetrics>(glyphIds.Length);
 
+                ushort shiftXY = 0;
+                bool doShift = data.OffsetGlyphs;
                 foreach (ushort id in glyphIds)
                 {
                     // Perform a semi-deep clone (FontMetrics is not cloned) so we can continue to
@@ -216,9 +236,25 @@ namespace SixLabors.Fonts
                             hasFallBacks = true;
                         }
 
+                        // Clone and offset the glyph based on it's position in the glyphId array.
                         // We slip the text run in here while we clone so we have
                         // it available to the renderer.
-                        m.Add(GlyphMetrics.CloneForRendering(gm, data.TextRun, codePoint));
+                        var clone = GlyphMetrics.CloneForRendering(gm, data.TextRun, codePoint);
+                        if (doShift)
+                        {
+                            if (!this.IsVerticalLayoutMode)
+                            {
+                                clone.ApplyOffset((short)shiftXY, 0);
+                                shiftXY += clone.AdvanceWidth;
+                            }
+                            else
+                            {
+                                clone.ApplyOffset(0, (short)shiftXY);
+                                shiftXY += clone.AdvanceHeight;
+                            }
+                        }
+
+                        m.Add(clone);
                     }
                 }
 

--- a/src/SixLabors.Fonts/GlyphPositioningCollection.cs
+++ b/src/SixLabors.Fonts/GlyphPositioningCollection.cs
@@ -72,6 +72,19 @@ namespace SixLabors.Fonts
             }
         }
 
+        /// <inheritdoc />
+        public void DisableShapingFeature(int index, Tag feature)
+        {
+            foreach (TagEntry tagEntry in this.glyphs[index].Features)
+            {
+                if (tagEntry.Tag == feature)
+                {
+                    tagEntry.Enabled = false;
+                    break;
+                }
+            }
+        }
+
         /// <summary>
         /// Gets the glyph metrics at the given codepoint offset.
         /// </summary>

--- a/src/SixLabors.Fonts/GlyphPositioningCollection.cs
+++ b/src/SixLabors.Fonts/GlyphPositioningCollection.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using SixLabors.Fonts.Tables.AdvancedTypographic;
 using SixLabors.Fonts.Unicode;
 
@@ -15,20 +15,9 @@ namespace SixLabors.Fonts
     internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
     {
         /// <summary>
-        /// Contains a map between the index of a map within the collection, it's codepoint
-        /// and glyph ids.
+        /// Contains a map the index of a map within the collection, non-sequential codepoint offsets, and their glyph ids, point size, and mtrics.
         /// </summary>
-        private readonly List<GlyphShapingData> glyphs = new();
-
-        /// <summary>
-        /// Contains a map between the index of a map within the collection and its offset.
-        /// </summary>
-        private readonly List<int> offsets = new();
-
-        /// <summary>
-        /// Contains a map between non-sequential codepoint offsets and their glyphs.
-        /// </summary>
-        private readonly Dictionary<int, PointSizeMetricsPair> map = new();
+        private readonly List<GlyphPositioningData> glyphs = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GlyphPositioningCollection"/> class.
@@ -41,7 +30,7 @@ namespace SixLabors.Fonts
         }
 
         /// <inheritdoc />
-        public int Count => this.offsets.Count;
+        public int Count => this.glyphs.Count;
 
         /// <inheritdoc />
         public bool IsVerticalLayoutMode { get; }
@@ -50,23 +39,31 @@ namespace SixLabors.Fonts
         public TextOptions TextOptions { get; }
 
         /// <inheritdoc />
-        public ReadOnlySpan<ushort> this[int index] => this.glyphs[index].GlyphIds;
+        public ushort this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this.glyphs[index].Data.GlyphId;
+        }
 
         /// <inheritdoc />
-        public GlyphShapingData GetGlyphShapingData(int index) => this.glyphs[index];
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public GlyphShapingData GetGlyphShapingData(int index) => this.glyphs[index].Data;
 
         /// <inheritdoc />
         public void AddShapingFeature(int index, TagEntry feature)
-            => this.glyphs[index].Features.Add(feature);
+            => this.glyphs[index].Data.Features.Add(feature);
 
         /// <inheritdoc />
         public void EnableShapingFeature(int index, Tag feature)
         {
-            foreach (TagEntry tagEntry in this.glyphs[index].Features)
+            List<TagEntry> features = this.glyphs[index].Data.Features;
+            for (int i = 0; i < features.Count; i++)
             {
+                TagEntry tagEntry = features[i];
                 if (tagEntry.Tag == feature)
                 {
                     tagEntry.Enabled = true;
+                    features[i] = tagEntry;
                     break;
                 }
             }
@@ -75,11 +72,14 @@ namespace SixLabors.Fonts
         /// <inheritdoc />
         public void DisableShapingFeature(int index, Tag feature)
         {
-            foreach (TagEntry tagEntry in this.glyphs[index].Features)
+            List<TagEntry> features = this.glyphs[index].Data.Features;
+            for (int i = 0; i < features.Count; i++)
             {
+                TagEntry tagEntry = features[i];
                 if (tagEntry.Tag == feature)
                 {
                     tagEntry.Enabled = false;
+                    features[i] = tagEntry;
                     break;
                 }
             }
@@ -96,18 +96,27 @@ namespace SixLabors.Fonts
         /// This parameter is passed uninitialized.
         /// </param>
         /// <returns>The metrics.</returns>
-        public bool TryGetGlyphMetricsAtOffset(int offset, out float pointSize, [NotNullWhen(true)] out GlyphMetrics[]? metrics)
+        public bool TryGetGlyphMetricsAtOffset(int offset, out float pointSize, [NotNullWhen(true)] out IReadOnlyList<GlyphMetrics>? metrics)
         {
-            if (this.map.TryGetValue(offset, out PointSizeMetricsPair? entry))
+            List<GlyphMetrics> match = new();
+            pointSize = 0;
+            for (int i = 0; i < this.glyphs.Count; i++)
             {
-                pointSize = entry.PointSize;
-                metrics = entry.Metrics;
-                return true;
+                if (this.glyphs[i].Offset == offset)
+                {
+                    GlyphPositioningData glyph = this.glyphs[i];
+                    pointSize = glyph.PointSize;
+                    match.AddRange(glyph.Metrics);
+                }
+                else if (match.Count > 0)
+                {
+                    // Offsets, though non-sequential, are sorted, so we can stop searching.
+                    break;
+                }
             }
 
-            pointSize = 0;
-            metrics = null;
-            return false;
+            metrics = match;
+            return match.Count > 0;
         }
 
         /// <summary>
@@ -122,83 +131,75 @@ namespace SixLabors.Fonts
             FontMetrics fontMetrics = font.FontMetrics;
             ColorFontSupport colorFontSupport = this.TextOptions.ColorFontSupport;
             bool hasFallBacks = false;
-            List<int> orphans = new();
-            for (int i = 0; i < this.offsets.Count; i++)
+            for (int i = 0; i < this.glyphs.Count; i++)
             {
-                int offset = this.offsets[i];
-                if (!collection.TryGetGlyphShapingDataAtOffset(offset, out GlyphShapingData? data))
-                {
-                    // If a font had glyphs but a follow up font also has them and can substitute. e.g ligatures
-                    // then we end up with orphaned fallbacks. We need to remove them.
-                    orphans.Add(i);
-                    continue;
-                }
-
-                PointSizeMetricsPair pair = this.map[offset];
-                if (pair.Metrics[0].GlyphType != GlyphType.Fallback)
+                GlyphPositioningData current = this.glyphs[i];
+                if (current.Metrics[0].GlyphType != GlyphType.Fallback)
                 {
                     // We've already got the correct glyph.
                     continue;
                 }
 
-                CodePoint codePoint = data.CodePoint;
-                ushort[] glyphIds = data.GlyphIds;
-                var m = new List<GlyphMetrics>(glyphIds.Length);
-
-                ushort shiftXY = 0;
-                bool doShift = data.OffsetGlyphs;
-                foreach (ushort id in glyphIds)
+                int offset = current.Offset;
+                float pointSize = current.PointSize;
+                if (collection.TryGetGlyphShapingDataAtOffset(offset, out IReadOnlyList<GlyphShapingData>? data))
                 {
-                    // Perform a semi-deep clone (FontMetrics is not cloned) so we can continue to
-                    // cache the original in the font metrics and only update our collection.
-                    foreach (GlyphMetrics gm in fontMetrics.GetGlyphMetrics(codePoint, id, colorFontSupport))
+                    ushort shiftXY = 0;
+                    int replacementCount = 0;
+                    for (int j = 0; j < data.Count; j++)
                     {
-                        if (gm.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
+                        GlyphShapingData shape = data[j];
+                        ushort id = shape.GlyphId;
+                        CodePoint codePoint = shape.CodePoint;
+                        bool doShift = shape.OffsetGlyph;
+
+                        // Perform a semi-deep clone (FontMetrics is not cloned) so we can continue to
+                        // cache the original in the font metrics and only update our collection.
+                        var metrics = new List<GlyphMetrics>(data.Count);
+                        foreach (GlyphMetrics gm in fontMetrics.GetGlyphMetrics(codePoint, id, colorFontSupport))
                         {
-                            // If the glyphs are fallbacks we don't want them as
-                            // we've already captured them on the first run.
-                            hasFallBacks = true;
-                            break;
+                            if (gm.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
+                            {
+                                // If the glyphs are fallbacks we don't want them as
+                                // we've already captured them on the first run.
+                                hasFallBacks = true;
+                                break;
+                            }
+
+                            // Clone and offset the glyph based on it's position in the offset group.
+                            // We slip the text run in here while we clone so we have it available to the renderer.
+                            var clone = GlyphMetrics.CloneForRendering(gm, shape.TextRun, codePoint);
+                            if (doShift)
+                            {
+                                if (!this.IsVerticalLayoutMode)
+                                {
+                                    clone.ApplyOffset((short)shiftXY, 0);
+                                    shiftXY += clone.AdvanceWidth;
+                                }
+                                else
+                                {
+                                    clone.ApplyOffset(0, (short)shiftXY);
+                                    shiftXY += clone.AdvanceHeight;
+                                }
+                            }
+
+                            metrics.Add(clone);
                         }
 
-                        // Clone and offset the glyph based on it's position in the glyphId array.
-                        // We slip the text run in here while we clone so we have
-                        // it available to the renderer.
-                        var clone = GlyphMetrics.CloneForRendering(gm, data.TextRun, codePoint);
-                        if (doShift)
+                        if (metrics.Count > 0)
                         {
-                            if (!this.IsVerticalLayoutMode)
+                            if (j == 0)
                             {
-                                clone.ApplyOffset((short)shiftXY, 0);
-                                shiftXY += clone.AdvanceWidth;
+                                // There should only be a single fallback glyph at this position from the previous collection.
+                                this.glyphs.RemoveAt(i);
                             }
-                            else
-                            {
-                                clone.ApplyOffset(0, (short)shiftXY);
-                                shiftXY += clone.AdvanceHeight;
-                            }
-                        }
 
-                        m.Add(clone);
+                            // Track the number of inserted glyphs at the offset so we can correctly increment our position.
+                            this.glyphs.Insert(i += replacementCount, new(offset, new(shape, true) { Bounds = new(0, 0, metrics[0].AdvanceWidth, metrics[0].AdvanceHeight) }, pointSize, metrics.ToArray()));
+                            replacementCount++;
+                        }
                     }
                 }
-
-                if (m.Count > 0)
-                {
-                    GlyphMetrics[] gm = m.ToArray();
-                    this.map[offset] = new(pair.PointSize, gm);
-                    this.glyphs[i] = new(data, true) { Bounds = new(0, 0, gm[0].AdvanceWidth, gm[0].AdvanceHeight) };
-                    this.offsets[i] = offset;
-                }
-            }
-
-            // Remove any orphans.
-            for (int i = orphans.Count - 1; i >= 0; i--)
-            {
-                int idx = orphans[i];
-                this.map.Remove(this.offsets[idx]);
-                this.offsets.RemoveAt(idx);
-                this.glyphs.RemoveAt(idx);
             }
 
             return !hasFallBacks;
@@ -220,58 +221,53 @@ namespace SixLabors.Fonts
             {
                 GlyphShapingData data = collection.GetGlyphShapingData(i, out int offset);
                 CodePoint codePoint = data.CodePoint;
-                ushort[] glyphIds = data.GlyphIds;
-                var m = new List<GlyphMetrics>(glyphIds.Length);
+                ushort id = data.GlyphId;
+                List<GlyphMetrics> metrics = new();
 
                 ushort shiftXY = 0;
-                bool doShift = data.OffsetGlyphs;
-                foreach (ushort id in glyphIds)
+                bool doShift = data.OffsetGlyph;
+
+                // Perform a semi-deep clone (FontMetrics is not cloned) so we can continue to
+                // cache the original in the font metrics and only update our collection.
+                foreach (GlyphMetrics gm in fontMetrics.GetGlyphMetrics(codePoint, id, colorFontSupport))
                 {
-                    // Perform a semi-deep clone (FontMetrics is not cloned) so we can continue to
-                    // cache the original in the font metrics and only update our collection.
-                    foreach (GlyphMetrics gm in fontMetrics.GetGlyphMetrics(codePoint, id, colorFontSupport))
+                    if (gm.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
                     {
-                        if (gm.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
-                        {
-                            hasFallBacks = true;
-                        }
-
-                        // Clone and offset the glyph based on it's position in the glyphId array.
-                        // We slip the text run in here while we clone so we have
-                        // it available to the renderer.
-                        var clone = GlyphMetrics.CloneForRendering(gm, data.TextRun, codePoint);
-                        if (doShift)
-                        {
-                            if (!this.IsVerticalLayoutMode)
-                            {
-                                clone.ApplyOffset((short)shiftXY, 0);
-                                shiftXY += clone.AdvanceWidth;
-                            }
-                            else
-                            {
-                                clone.ApplyOffset(0, (short)shiftXY);
-                                shiftXY += clone.AdvanceHeight;
-                            }
-                        }
-
-                        m.Add(clone);
+                        hasFallBacks = true;
                     }
+
+                    // Clone and offset the glyph based on it's position in the glyphId array.
+                    // We slip the text run in here while we clone so we have
+                    // it available to the renderer.
+                    var clone = GlyphMetrics.CloneForRendering(gm, data.TextRun, codePoint);
+                    if (doShift)
+                    {
+                        if (!this.IsVerticalLayoutMode)
+                        {
+                            clone.ApplyOffset((short)shiftXY, 0);
+                            shiftXY += clone.AdvanceWidth;
+                        }
+                        else
+                        {
+                            clone.ApplyOffset(0, (short)shiftXY);
+                            shiftXY += clone.AdvanceHeight;
+                        }
+                    }
+
+                    metrics.Add(clone);
                 }
 
-                if (m.Count > 0)
+                if (metrics.Count > 0)
                 {
-                    GlyphMetrics[] gm = m.ToArray();
-                    this.map[offset] = new(font.Size, gm);
+                    GlyphMetrics[] gm = metrics.ToArray();
                     if (this.IsVerticalLayoutMode)
                     {
-                        this.glyphs.Add(new(data, true) { Bounds = new(0, 0, 0, gm[0].AdvanceHeight) });
+                        this.glyphs.Add(new(offset, new(data, true) { Bounds = new(0, 0, 0, gm[0].AdvanceHeight) }, font.Size, gm));
                     }
                     else
                     {
-                        this.glyphs.Add(new(data, true) { Bounds = new(0, 0, gm[0].AdvanceWidth, 0) });
+                        this.glyphs.Add(new(offset, new(data, true) { Bounds = new(0, 0, gm[0].AdvanceWidth, 0) }, font.Size, gm));
                     }
-
-                    this.offsets.Add(offset);
                 }
             }
 
@@ -293,8 +289,8 @@ namespace SixLabors.Fonts
                 return;
             }
 
-            ushort glyphId = data.GlyphIds[0];
-            foreach (GlyphMetrics m in this.map[this.offsets[index]].Metrics)
+            ushort glyphId = data.GlyphId;
+            foreach (GlyphMetrics m in this.glyphs[index].Metrics)
             {
                 if (m.GlyphId == glyphId && fontMetrics == m.FontMetrics)
                 {
@@ -323,7 +319,7 @@ namespace SixLabors.Fonts
         /// <param name="dy">The delta y-advance.</param>
         public void Advance(FontMetrics fontMetrics, ushort index, ushort glyphId, short dx, short dy)
         {
-            foreach (GlyphMetrics m in this.map[this.offsets[index]].Metrics)
+            foreach (GlyphMetrics m in this.glyphs[index].Metrics)
             {
                 if (m.GlyphId == glyphId && fontMetrics == m.FontMetrics)
                 {
@@ -336,18 +332,24 @@ namespace SixLabors.Fonts
         /// Returns a value indicating whether the element at the given index should be processed.
         /// </summary>
         /// <param name="fontMetrics">The font face with metrics.</param>
-        /// <param name="index">The zero-based index of the elements to offset.</param>
+        /// <param name="index">The zero-based index of the elements to position.</param>
         /// <returns><see langword="true"/> if the element should be processed; otherwise, <see langword="false"/>.</returns>
         public bool ShouldProcess(FontMetrics fontMetrics, ushort index)
-            => this.map[this.offsets[index]].Metrics[0].FontMetrics == fontMetrics;
+            => this.glyphs[index].Metrics[0].FontMetrics == fontMetrics;
 
-        private class PointSizeMetricsPair
+        private class GlyphPositioningData
         {
-            public PointSizeMetricsPair(float pointSize, GlyphMetrics[] metrics)
+            public GlyphPositioningData(int offset, GlyphShapingData data, float pointSize, GlyphMetrics[] metrics)
             {
+                this.Offset = offset;
+                this.Data = data;
                 this.PointSize = pointSize;
                 this.Metrics = metrics;
             }
+
+            public int Offset { get; set; }
+
+            public GlyphShapingData Data { get; set; }
 
             public float PointSize { get; set; }
 

--- a/src/SixLabors.Fonts/GlyphShapingData.cs
+++ b/src/SixLabors.Fonts/GlyphShapingData.cs
@@ -36,7 +36,7 @@ namespace SixLabors.Fonts
             this.LigatureComponent = data.LigatureComponent;
             this.MarkAttachment = data.MarkAttachment;
             this.CursiveAttachment = data.CursiveAttachment;
-            this.OffsetGlyph = data.OffsetGlyph;
+            this.IsDecomposed = data.IsDecomposed;
 
             if (!clearFeatures)
             {
@@ -102,12 +102,12 @@ namespace SixLabors.Fonts
         public GlyphShapingBounds Bounds { get; set; } = new(0, 0, 0, 0);
 
         /// <summary>
-        /// Gets or sets a value indicating whether this glyph should be positioned at the advance of the preceding glyph at the same codepoint offset.
+        /// Gets or sets a value indicating whether this glyph is the result of a decomposition substitution
         /// </summary>
-        public bool OffsetGlyph { get; set; }
+        public bool IsDecomposed { get; set; }
 
         private string DebuggerDisplay
             => FormattableString
-            .Invariant($" {this.GlyphId} : {this.CodePoint.ToDebuggerDisplay()} : {CodePoint.GetScriptClass(this.CodePoint)} : {this.Direction} : {this.TextRun.TextAttributes} : {this.LigatureId} : {this.LigatureComponent} : {this.OffsetGlyph}");
+            .Invariant($" {this.GlyphId} : {this.CodePoint.ToDebuggerDisplay()} : {CodePoint.GetScriptClass(this.CodePoint)} : {this.Direction} : {this.TextRun.TextAttributes} : {this.LigatureId} : {this.LigatureComponent} : {this.IsDecomposed}");
     }
 }

--- a/src/SixLabors.Fonts/GlyphShapingData.cs
+++ b/src/SixLabors.Fonts/GlyphShapingData.cs
@@ -27,24 +27,29 @@ namespace SixLabors.Fonts
         /// <param name="clearFeatures">Whether to clear features.</param>
         public GlyphShapingData(GlyphShapingData data, bool clearFeatures = false)
         {
+            this.GlyphId = data.GlyphId;
             this.CodePoint = data.CodePoint;
             this.CodePointCount = data.CodePointCount;
             this.Direction = data.Direction;
             this.TextRun = data.TextRun;
-            this.GlyphIds = data.GlyphIds;
             this.LigatureId = data.LigatureId;
             this.LigatureComponent = data.LigatureComponent;
             this.MarkAttachment = data.MarkAttachment;
             this.CursiveAttachment = data.CursiveAttachment;
-            this.OffsetGlyphs = data.OffsetGlyphs;
+            this.OffsetGlyph = data.OffsetGlyph;
 
             if (!clearFeatures)
             {
-                this.Features = data.Features;
+                this.Features = new(data.Features);
             }
 
             this.Bounds = data.Bounds;
         }
+
+        /// <summary>
+        /// Gets or sets the glyph id.
+        /// </summary>
+        public ushort GlyphId { get; set; }
 
         /// <summary>
         /// Gets or sets the leading codepoint.
@@ -65,11 +70,6 @@ namespace SixLabors.Fonts
         /// Gets or sets the text run this glyph belongs to.
         /// </summary>
         public TextRun TextRun { get; set; }
-
-        /// <summary>
-        /// Gets or sets the collection of glyph ids.
-        /// </summary>
-        public ushort[] GlyphIds { get; set; } = Array.Empty<ushort>();
 
         /// <summary>
         /// Gets or sets the id of any ligature this glyph is a member of.
@@ -102,12 +102,12 @@ namespace SixLabors.Fonts
         public GlyphShapingBounds Bounds { get; set; } = new(0, 0, 0, 0);
 
         /// <summary>
-        /// Gets or sets a value indicating whether individual glyph in the <see cref="GlyphIds"/> collection should be offset from the preceding glyph.
+        /// Gets or sets a value indicating whether this glyph should be positioned at the advance of the preceding glyph at the same codepoint offset.
         /// </summary>
-        public bool OffsetGlyphs { get; set; }
+        public bool OffsetGlyph { get; set; }
 
         private string DebuggerDisplay
             => FormattableString
-            .Invariant($"{this.CodePoint.ToDebuggerDisplay()} : {CodePoint.GetScriptClass(this.CodePoint)} : {this.Direction} : {this.TextRun.TextAttributes} : {this.LigatureId} : {this.LigatureComponent} : [{string.Join(",", this.GlyphIds)}] : {this.OffsetGlyphs}");
+            .Invariant($" {this.GlyphId} : {this.CodePoint.ToDebuggerDisplay()} : {CodePoint.GetScriptClass(this.CodePoint)} : {this.Direction} : {this.TextRun.TextAttributes} : {this.LigatureId} : {this.LigatureComponent} : {this.OffsetGlyph}");
     }
 }

--- a/src/SixLabors.Fonts/GlyphShapingData.cs
+++ b/src/SixLabors.Fonts/GlyphShapingData.cs
@@ -36,6 +36,7 @@ namespace SixLabors.Fonts
             this.LigatureComponent = data.LigatureComponent;
             this.MarkAttachment = data.MarkAttachment;
             this.CursiveAttachment = data.CursiveAttachment;
+            this.OffsetGlyphs = data.OffsetGlyphs;
 
             if (!clearFeatures)
             {
@@ -100,8 +101,13 @@ namespace SixLabors.Fonts
         /// </summary>
         public GlyphShapingBounds Bounds { get; set; } = new(0, 0, 0, 0);
 
+        /// <summary>
+        /// Gets or sets a value indicating whether individual glyph in the <see cref="GlyphIds"/> collection should be offset from the preceding glyph.
+        /// </summary>
+        public bool OffsetGlyphs { get; set; }
+
         private string DebuggerDisplay
             => FormattableString
-            .Invariant($"{this.CodePoint.ToDebuggerDisplay()} : {CodePoint.GetScriptClass(this.CodePoint)} : {this.Direction} : {this.TextRun.TextAttributes} : {this.LigatureId} : {this.LigatureComponent} : [{string.Join(",", this.GlyphIds)}]");
+            .Invariant($"{this.CodePoint.ToDebuggerDisplay()} : {CodePoint.GetScriptClass(this.CodePoint)} : {this.Direction} : {this.TextRun.TextAttributes} : {this.LigatureId} : {this.LigatureComponent} : [{string.Join(",", this.GlyphIds)}] : {this.OffsetGlyphs}");
     }
 }

--- a/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
+++ b/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
@@ -263,8 +263,7 @@ namespace SixLabors.Fonts
         /// </summary>
         /// <param name="index">The zero-based index of the element to replace.</param>
         /// <param name="glyphIds">The collection of replacement glyph ids.</param>
-        /// <param name="offset">Whether the additional glyphs should be positioned at the advance of the preceding glyph at the same codepoint offset.</param>
-        public void Replace(int index, ReadOnlySpan<ushort> glyphIds, bool offset)
+        public void Replace(int index, ReadOnlySpan<ushort> glyphIds)
         {
             if (glyphIds.Length > 0)
             {
@@ -274,9 +273,9 @@ namespace SixLabors.Fonts
                 current.LigatureComponent = 0;
                 current.MarkAttachment = -1;
                 current.CursiveAttachment = -1;
-                current.OffsetGlyph = offset;
+                current.IsDecomposed = true;
 
-                // Add additional glyphs to the end of the sequence.
+                // Add additional glyphs from the rest of the sequence.
                 if (glyphIds.Length > 1)
                 {
                     glyphIds = glyphIds.Slice(1);
@@ -285,10 +284,7 @@ namespace SixLabors.Fonts
                         GlyphShapingData data = new(current, false);
                         data.GlyphId = glyphIds[i];
                         data.LigatureComponent = i + 1;
-
-                        // TODO: We may have to shift the offset of the following glyphs.
-                        int o = offset ? pair.Offset + i + 1 : pair.Offset;
-                        this.glyphs.Insert(++index, new(o, data));
+                        this.glyphs.Insert(++index, new(pair.Offset, data));
                     }
                 }
             }

--- a/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
+++ b/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
@@ -83,6 +83,19 @@ namespace SixLabors.Fonts
             }
         }
 
+        /// <inheritdoc />
+        public void DisableShapingFeature(int index, Tag feature)
+        {
+            foreach (TagEntry tagEntry in this.glyphs[index].Data.Features)
+            {
+                if (tagEntry.Tag == feature)
+                {
+                    tagEntry.Enabled = false;
+                    break;
+                }
+            }
+        }
+
         /// <summary>
         /// Adds the glyph id and the codepoint it represents to the collection.
         /// </summary>
@@ -99,9 +112,33 @@ namespace SixLabors.Fonts
                 GlyphIds = new[] { glyphId },
             }));
 
-        // TODO: This can be made specific to the Hangul shaper.
+        /// <summary>
+        /// Moves the specified glyph to the specified position.
+        /// </summary>
+        /// <param name="fromIndex">The index to move from.</param>
+        /// <param name="toIndex">The index to move to.</param>
         public void MoveGlyph(int fromIndex, int toIndex)
-            => this.glyphs[toIndex].Data = this.glyphs[fromIndex].Data;
+        {
+            GlyphShapingData data = this.GetGlyphShapingData(fromIndex);
+            if (fromIndex > toIndex)
+            {
+                int idx = fromIndex;
+                while (idx > toIndex)
+                {
+                    this.glyphs[idx].Data = this.glyphs[idx - 1].Data;
+                }
+            }
+            else
+            {
+                int idx = toIndex;
+                while (idx > fromIndex)
+                {
+                    this.glyphs[idx - 1].Data = this.glyphs[idx].Data;
+                }
+            }
+
+            this.glyphs[toIndex].Data = data;
+        }
 
         /// <summary>
         /// Removes all elements from the collection.

--- a/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
+++ b/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
@@ -155,8 +155,6 @@ namespace SixLabors.Fonts
         public void Replace(int index, ReadOnlySpan<int> removalIndices, ushort glyphId, int ligatureId)
         {
             // Remove the glyphs at each index.
-            // TODO: We will have to offset these indices by the leading index of the collection
-            // that the current shaper is working against.
             int codePointCount = 0;
             for (int i = removalIndices.Length - 1; i >= 0; i--)
             {
@@ -173,6 +171,36 @@ namespace SixLabors.Fonts
             current.CodePointCount += codePointCount;
             current.GlyphIds = new[] { glyphId };
             current.LigatureId = ligatureId;
+            current.LigatureComponent = -1;
+            current.MarkAttachment = -1;
+            current.CursiveAttachment = -1;
+        }
+
+        /// <summary>
+        /// Performs a 1:1 replacement of a glyph id at the given position while removing a series of glyph ids.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to replace.</param>
+        /// <param name="count">The number of glyphs to remove.</param>
+        /// <param name="glyphId">The replacement glyph id.</param>
+        public void Replace(int index, int count, ushort glyphId)
+        {
+            // Remove the glyphs at each index.
+            int codePointCount = 0;
+            for (int i = count - 1; i >= 0; i--)
+            {
+                int match = index + i;
+                int matchOffset = this.offsets[match];
+                codePointCount += this.glyphs[matchOffset].CodePointCount;
+                this.glyphs.Remove(matchOffset);
+                this.offsets.RemoveAt(match);
+            }
+
+            // Assign our new id at the index.
+            int offset = this.offsets[index];
+            GlyphShapingData current = this.glyphs[offset];
+            current.CodePointCount += codePointCount;
+            current.GlyphIds = new[] { glyphId };
+            current.LigatureId = 0;
             current.LigatureComponent = -1;
             current.MarkAttachment = -1;
             current.CursiveAttachment = -1;

--- a/src/SixLabors.Fonts/IGlyphShapingCollection.cs
+++ b/src/SixLabors.Fonts/IGlyphShapingCollection.cs
@@ -53,5 +53,12 @@ namespace SixLabors.Fonts
         /// <param name="index">The zero-based index of the element.</param>
         /// <param name="feature">The feature to enable.</param>
         void EnableShapingFeature(int index, Tag feature);
+
+        /// <summary>
+        /// Disables a previously added shaping feature.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element.</param>
+        /// <param name="feature">The feature to disable.</param>
+        void DisableShapingFeature(int index, Tag feature);
     }
 }

--- a/src/SixLabors.Fonts/IGlyphShapingCollection.cs
+++ b/src/SixLabors.Fonts/IGlyphShapingCollection.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
 using SixLabors.Fonts.Tables.AdvancedTypographic;
 
 namespace SixLabors.Fonts
@@ -27,11 +26,11 @@ namespace SixLabors.Fonts
         TextOptions TextOptions { get; }
 
         /// <summary>
-        /// Gets the glyph ids at the specified index.
+        /// Gets the glyph id at the specified index.
         /// </summary>
         /// <param name="index">The zero-based index of the elements to get.</param>
-        /// <returns>The <see cref="ReadOnlySpan{UInt16}"/>.</returns>
-        ReadOnlySpan<ushort> this[int index] { get; }
+        /// <returns>The <see cref="ushort"/>.</returns>
+        ushort this[int index] { get; }
 
         /// <summary>
         /// Gets the shaping data at the specified position.

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/AdvancedTypographicUtils.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/AdvancedTypographicUtils.cs
@@ -86,7 +86,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                         return false;
                     }
 
-                    return component == data.GlyphIds[0];
+                    return component == data.GlyphId;
                 },
                 matches);
 
@@ -108,7 +108,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                 increment,
                 sequence,
                 iterator,
-                (component, data) => component == data.GlyphIds[0],
+                (component, data) => component == data.GlyphId,
                 default);
 
         public static bool MatchClassSequence(
@@ -120,7 +120,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                 increment,
                 sequence,
                 iterator,
-                (component, data) => component == classDefinitionTable.ClassIndexOf(data.GlyphIds[0]),
+                (component, data) => component == classDefinitionTable.ClassIndexOf(data.GlyphId),
                 default);
 
         public static bool MatchCoverageSequence(
@@ -131,7 +131,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                 increment,
                 coverageTable,
                 iterator,
-                (component, data) => component.CoverageIndexOf(data.GlyphIds[0]) >= 0,
+                (component, data) => component.CoverageIndexOf(data.GlyphId) >= 0,
                 default);
 
         public static bool ApplyChainedSequenceRule(SkippingGlyphIterator iterator, ChainedSequenceRuleTable rule)

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType1SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType1SubTable.cs
@@ -74,7 +74,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;
@@ -145,7 +145,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType2SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType2SubTable.cs
@@ -101,7 +101,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                     return false;
                 }
 
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
@@ -111,7 +111,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 if (coverage > -1)
                 {
                     PairSetTable pairSet = this.pairSets[coverage];
-                    ushort glyphId2 = collection[index + 1][0];
+                    ushort glyphId2 = collection[index + 1];
                     if (glyphId2 == 0)
                     {
                         return false;
@@ -266,7 +266,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                     return false;
                 }
 
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
@@ -276,7 +276,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 if (coverage > -1)
                 {
                     int classDef1 = this.classDefinitionTable1.ClassIndexOf(glyphId);
-                    ushort glyphId2 = collection[index + 1][0];
+                    ushort glyphId2 = collection[index + 1];
                     if (glyphId2 == 0)
                     {
                         return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType3SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType3SubTable.cs
@@ -88,14 +88,14 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
 
                 // Implements Cursive Attachment Positioning Subtable:
                 // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-3-cursive-attachment-positioning-subtable
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
                 }
 
                 ushort nextIndex = (ushort)(index + 1);
-                ushort nextGlyphId = collection[nextIndex][0];
+                ushort nextGlyphId = collection[nextIndex];
                 if (nextGlyphId == 0)
                 {
                     return false;
@@ -180,9 +180,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 int yOffset = entryXY.YCoordinate - exitXY.YCoordinate;
                 if (this.LookupFlags.HasFlag(LookupFlags.RightToLeft))
                 {
-                    int temp = child;
-                    child = parent;
-                    parent = temp;
+                    (parent, child) = (child, parent);
 
                     xOffset = -xOffset;
                     yOffset = -yOffset;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType4SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType4SubTable.cs
@@ -91,7 +91,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
             {
                 // Mark-to-Base Attachment Positioning Subtable.
                 // Implements: https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
@@ -108,7 +108,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 while (--baseGlyphIndex >= 0)
                 {
                     GlyphShapingData data = collection.GetGlyphShapingData(baseGlyphIndex);
-                    if (!AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, data.GlyphIds[0], data) && !(data.LigatureComponent > 0))
+                    if (!AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, data.GlyphId, data) && !(data.LigatureComponent > 0))
                     {
                         break;
                     }
@@ -119,7 +119,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                     return false;
                 }
 
-                ushort baseGlyphId = collection[baseGlyphIndex][0];
+                ushort baseGlyphId = collection[baseGlyphIndex];
                 int baseIndex = this.baseCoverage.CoverageIndexOf(baseGlyphId);
                 if (baseIndex < 0)
                 {

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType5SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType5SubTable.cs
@@ -95,7 +95,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
             {
                 // Mark-to-Ligature Attachment Positioning.
                 // Implements: https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-5-mark-to-ligature-attachment-positioning-subtable
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
@@ -112,7 +112,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 while (--baseGlyphIndex >= 0)
                 {
                     GlyphShapingData data = collection.GetGlyphShapingData(baseGlyphIndex);
-                    if (!AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, data.GlyphIds[0], data))
+                    if (!AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, data.GlyphId, data))
                     {
                         break;
                     }
@@ -123,7 +123,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                     return false;
                 }
 
-                ushort baseGlyphId = collection[baseGlyphIndex][0];
+                ushort baseGlyphId = collection[baseGlyphIndex];
                 int ligatureIndex = this.ligatureCoverage.CoverageIndexOf(baseGlyphId);
                 if (ligatureIndex < 0)
                 {

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType6SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType6SubTable.cs
@@ -93,7 +93,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
             {
                 // Mark to mark positioning.
                 // Implements: https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-6-mark-to-mark-attachment-positioning-subtable
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
@@ -112,7 +112,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 }
 
                 int prevIdx = index - 1;
-                ushort prevGlyphId = collection[prevIdx][0];
+                ushort prevGlyphId = collection[prevIdx];
                 GlyphShapingData prevGlyph = collection.GetGlyphShapingData(prevIdx);
                 if (!AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, prevGlyphId, prevGlyph))
                 {

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType7SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType7SubTable.cs
@@ -55,7 +55,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 ushort index,
                 int count)
             {
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
@@ -134,7 +134,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 ushort index,
                 int count)
             {
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
@@ -210,7 +210,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 ushort index,
                 int count)
             {
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType8SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType8SubTable.cs
@@ -59,7 +59,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
             {
                 // Implements Chained Contexts Substitution, Format 1:
                 // https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#61-chained-contexts-substitution-format-1-simple-glyph-contexts
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
@@ -160,7 +160,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
             {
                 // Implements Chained Contexts Substitution for Format 2:
                 // https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#62-chained-contexts-substitution-format-2-class-based-glyph-contexts
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;
@@ -252,7 +252,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GPos
                 ushort index,
                 int count)
             {
-                ushort glyphId = collection[index][0];
+                ushort glyphId = collection[index];
                 if (glyphId == 0)
                 {
                     return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
@@ -320,7 +320,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
             {
                 int currentIndex = i + index;
                 GlyphShapingData data = collection.GetGlyphShapingData(currentIndex);
-                if (AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, data.GlyphIds[0], data))
+                if (AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, data.GlyphId, data))
                 {
                     data.Bounds.Width = 0;
                     data.Bounds.Height = 0;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType1SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType1SubTable.cs
@@ -68,7 +68,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;
@@ -127,7 +127,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType2SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType2SubTable.cs
@@ -101,9 +101,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
 
             if (offset > -1)
             {
-                // TODO: Looks like we should remove the glyph if the substitutes
-                // length = 0;
-                collection.Replace(index, this.sequenceTables[offset].SubstituteGlyphs);
+                collection.Replace(index, this.sequenceTables[offset].SubstituteGlyphs, false);
                 return true;
             }
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType2SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType2SubTable.cs
@@ -91,7 +91,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType2SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType2SubTable.cs
@@ -101,7 +101,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
 
             if (offset > -1)
             {
-                collection.Replace(index, this.sequenceTables[offset].SubstituteGlyphs, false);
+                collection.Replace(index, this.sequenceTables[offset].SubstituteGlyphs);
                 return true;
             }
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType3SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType3SubTable.cs
@@ -90,7 +90,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType4SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType4SubTable.cs
@@ -120,7 +120,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;
@@ -183,7 +183,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
                 for (int j = 0; j < matches.Length && isMarkLigature; j++)
                 {
                     GlyphShapingData match = collection.GetGlyphShapingData(matches[j]);
-                    if (!AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, match.GlyphIds[0], match))
+                    if (!AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, match.GlyphId, match))
                     {
                         isBaseLigature = false;
                         isMarkLigature = false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType5SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType5SubTable.cs
@@ -54,7 +54,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;
@@ -133,7 +133,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;
@@ -211,7 +211,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType6SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType6SubTable.cs
@@ -55,7 +55,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
         {
             // Implements Chained Contexts Substitution, Format 1:
             // https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#61-chained-contexts-substitution-format-1-simple-glyph-contexts
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;
@@ -147,7 +147,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
         {
             // Implements Chained Contexts Substitution for Format 2:
             // https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#62-chained-contexts-substitution-format-2-class-based-glyph-contexts
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;
@@ -234,7 +234,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             ushort index,
             int count)
         {
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType8SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSub/LookupType8SubTable.cs
@@ -107,7 +107,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
             int count)
         {
             // https://docs.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts
-            ushort glyphId = collection[index][0];
+            ushort glyphId = collection[index];
             if (glyphId == 0)
             {
                 return false;
@@ -121,7 +121,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
 
             for (int i = 0; i < this.backtrackCoverageTables.Length; ++i)
             {
-                ushort id = collection[index - 1 - i][0];
+                ushort id = collection[index - 1 - i];
                 if (id == 0 || this.backtrackCoverageTables[i].CoverageIndexOf(id) < 0)
                 {
                     return false;
@@ -130,7 +130,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.GSub
 
             for (int i = 0; i < this.lookaheadCoverageTables.Length; ++i)
             {
-                ushort id = collection[index + i][0];
+                ushort id = collection[index + i];
                 if (id == 0 || this.lookaheadCoverageTables[i].CoverageIndexOf(id) < 0)
                 {
                     return false;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSubTable.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using SixLabors.Fonts.Tables.AdvancedTypographic.GSub;
 using SixLabors.Fonts.Tables.AdvancedTypographic.Shapers;
@@ -125,6 +126,10 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
 
                 // Assign Substitution features to each glyph.
                 shaper.AssignFeatures(collection, index, count);
+
+                // Shapers can adjust the count.
+                count = (ushort)Math.Min(count, collection.Count - index);
+
                 IEnumerable<Tag> stageFeatures = shaper.GetShapingStageFeatures();
 
                 int currentCount = collection.Count;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ArabicShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ArabicShaper.cs
@@ -12,10 +12,6 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
     /// </summary>
     internal sealed class ArabicShaper : DefaultShaper
     {
-        private static readonly Tag CcmpTag = Tag.Parse("ccmp");
-
-        private static readonly Tag LoclTag = Tag.Parse("locl");
-
         private static readonly Tag MsetTag = Tag.Parse("mset");
 
         private static readonly Tag FinaTag = Tag.Parse("fina");

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/DefaultShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/DefaultShaper.cs
@@ -12,47 +12,47 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
     /// </summary>
     internal class DefaultShaper : BaseShaper
     {
-        private static readonly Tag RvnrTag = Tag.Parse("rvrn");
+        protected static readonly Tag RvnrTag = Tag.Parse("rvrn");
 
-        private static readonly Tag LtraTag = Tag.Parse("ltra");
+        protected static readonly Tag LtraTag = Tag.Parse("ltra");
 
-        private static readonly Tag LtrmTag = Tag.Parse("ltrm");
+        protected static readonly Tag LtrmTag = Tag.Parse("ltrm");
 
-        private static readonly Tag RtlaTag = Tag.Parse("rtla");
+        protected static readonly Tag RtlaTag = Tag.Parse("rtla");
 
-        private static readonly Tag RtlmTag = Tag.Parse("rtlm");
+        protected static readonly Tag RtlmTag = Tag.Parse("rtlm");
 
-        private static readonly Tag FracTag = Tag.Parse("frac");
+        protected static readonly Tag FracTag = Tag.Parse("frac");
 
-        private static readonly Tag NumrTag = Tag.Parse("numr");
+        protected static readonly Tag NumrTag = Tag.Parse("numr");
 
-        private static readonly Tag DnomTag = Tag.Parse("dnom");
+        protected static readonly Tag DnomTag = Tag.Parse("dnom");
 
-        private static readonly Tag CcmpTag = Tag.Parse("ccmp");
+        protected static readonly Tag CcmpTag = Tag.Parse("ccmp");
 
-        private static readonly Tag LoclTag = Tag.Parse("locl");
+        protected static readonly Tag LoclTag = Tag.Parse("locl");
 
-        private static readonly Tag RligTag = Tag.Parse("rlig");
+        protected static readonly Tag RligTag = Tag.Parse("rlig");
 
-        private static readonly Tag MarkTag = Tag.Parse("mark");
+        protected static readonly Tag MarkTag = Tag.Parse("mark");
 
-        private static readonly Tag MkmkTag = Tag.Parse("mkmk");
+        protected static readonly Tag MkmkTag = Tag.Parse("mkmk");
 
-        private static readonly Tag CaltTag = Tag.Parse("calt");
+        protected static readonly Tag CaltTag = Tag.Parse("calt");
 
-        private static readonly Tag CligTag = Tag.Parse("clig");
+        protected static readonly Tag CligTag = Tag.Parse("clig");
 
-        private static readonly Tag LigaTag = Tag.Parse("liga");
+        protected static readonly Tag LigaTag = Tag.Parse("liga");
 
-        private static readonly Tag RcltTag = Tag.Parse("rclt");
+        protected static readonly Tag RcltTag = Tag.Parse("rclt");
 
-        private static readonly Tag CursTag = Tag.Parse("curs");
+        protected static readonly Tag CursTag = Tag.Parse("curs");
 
-        private static readonly Tag KernTag = Tag.Parse("kern");
+        protected static readonly Tag KernTag = Tag.Parse("kern");
 
-        private static readonly Tag VertTag = Tag.Parse("vert");
+        protected static readonly Tag VertTag = Tag.Parse("vert");
 
-        private static readonly Tag VKernTag = Tag.Parse("vkrn");
+        protected static readonly Tag VKernTag = Tag.Parse("vkrn");
 
         private static readonly CodePoint FractionSlash = new(0x2044);
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
@@ -133,7 +133,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                         case Invalid:
 
                             // Tone mark has no valid syllable to attach to, so insert a dotted circle.
-                            this.InsertDottedCircle(substitutionCollection, data, i);
+                            i = this.InsertDottedCircle(substitutionCollection, data, i);
                             break;
                     }
                 }
@@ -234,7 +234,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                 ii[0] = ljmo;
                 ii[1] = vjmo;
 
-                collection.Replace(index, ii, true);
+                collection.Replace(index, ii);
                 collection.EnableShapingFeature(index, LjmoTag);
                 collection.EnableShapingFeature(index + 1, VjmoTag);
                 return index + 1;
@@ -245,7 +245,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
             iii[1] = vjmo;
             iii[2] = tjmo;
 
-            collection.Replace(index, iii, true);
+            collection.Replace(index, iii);
             collection.EnableShapingFeature(index, LjmoTag);
             collection.EnableShapingFeature(index + 1, VjmoTag);
             collection.EnableShapingFeature(index + 2, TjmoTag);
@@ -398,7 +398,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                     glyphs[1] = data.GlyphId;
                 }
 
-                collection.Replace(index, glyphs, true);
+                collection.Replace(index, glyphs);
                 return index + 1;
             }
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
@@ -1,0 +1,306 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.Fonts.Unicode;
+
+namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
+{
+    /// <summary>
+    /// This is a shaper for the Hangul script, used by the Korean language.
+    /// The shaping state machine was ported from fontkit.
+    /// <see href="https://github.com/foliojs/fontkit/blob/master/src/opentype/shapers/HangulShaper.js"/>
+    /// </summary>
+    internal sealed class HangulShaper : DefaultShaper
+    {
+        private static readonly Tag LjmoTag = Tag.Parse("ljmo");
+
+        private static readonly Tag VjmoTag = Tag.Parse("vjmo");
+
+        private static readonly Tag TjmoTag = Tag.Parse("tjmo");
+
+        private const int HANGUL_BASE = 0xac00;
+        private const int HANGUL_END = 0xd7a4;
+        private const int HANGUL_COUNT = HANGUL_END - HANGUL_BASE + 1;
+        private const int L_BASE = 0x1100; // lead
+        private const int V_BASE = 0x1161; // vowel
+        private const int T_BASE = 0x11a7; // trail
+        private const int L_COUNT = 19;
+        private const int V_COUNT = 21;
+        private const int T_COUNT = 28;
+        private const int L_END = L_BASE + L_COUNT - 1;
+        private const int V_END = V_BASE + V_COUNT - 1;
+        private const int T_END = T_BASE + T_COUNT - 1;
+        private const int DOTTED_CIRCLE = 0x25cc;
+
+        // Character categories
+        private const byte X = 0; // Other character
+        private const byte L = 1; // Leading consonant
+        private const byte V = 2; // Medial vowel
+        private const byte T = 3; // Trailing consonant
+        private const byte LV = 4; // Composed <LV> syllable
+        private const byte LVT = 5; // Composed <LVT> syllable
+        private const byte M = 6; // Tone mark
+
+        // State machine actions
+        private const byte None = 0;
+        private const byte Decompose = 1;
+        private const byte Compose = 2;
+        private const byte ToneMark = 4;
+        private const byte Invalid = 5;
+
+        // Build a state machine that accepts valid syllables, and applies actions along the way.
+        // The logic this is implementing is documented at the top of the file.
+        private static readonly byte[,][] StateTable =
+        {
+            // #             X                       L                       V                       T                       LV                           LVT                          M
+            // State 0: start state
+            { new byte[] { None, 0 }, new byte[] { None, 1 }, new byte[] { None, 0 }, new byte[] { None, 0 }, new byte[] { Decompose, 2 }, new byte[] { Decompose, 3 }, new byte[] { Invalid, 0 } },
+
+            // State 1: <L>
+            { new byte[] { None, 0 }, new byte[] { None, 1 }, new byte[] { Compose, 2 }, new byte[] { None, 0 }, new byte[] { Decompose, 2 }, new byte[] { Decompose, 3 }, new byte[] { Invalid, 0 } },
+
+            // State 2: <L,V> or <LV>
+            { new byte[] { None, 0 }, new byte[] { None, 1 }, new byte[] { None, 0 }, new byte[] { Compose, 3 }, new byte[] { Decompose, 2 }, new byte[] { Decompose, 3 }, new byte[] { ToneMark, 0 } },
+
+            // State 3: <L,V,T> or <LVT>
+            { new byte[] { None, 0 }, new byte[] { None, 1 }, new byte[] { None, 0 }, new byte[] { None, 0 }, new byte[] { Decompose, 2 }, new byte[] { Decompose, 3 }, new byte[] { ToneMark, 0 } },
+        };
+
+        public HangulShaper(TextOptions textOptions)
+            : base(MarkZeroingMode.None, textOptions)
+        {
+        }
+
+        public override void AssignFeatures(IGlyphShapingCollection collection, int index, int count)
+        {
+            this.AddFeature(collection, index, count, LjmoTag, false);
+            this.AddFeature(collection, index, count, VjmoTag, false);
+            this.AddFeature(collection, index, count, TjmoTag, false);
+
+            base.AssignFeatures(collection, index, count);
+
+            // Apply the state machine to map glyphs to features.
+            if (collection is GlyphSubstitutionCollection substitutionCollection)
+            {
+                // GSub
+                int state = 0;
+                for (int i = 0; i < count; i++)
+                {
+                    GlyphShapingData data = substitutionCollection.GetGlyphShapingData(i + index);
+                    CodePoint codePoint = data.CodePoint;
+                    int type = GetType(codePoint);
+                    byte[] actionsWithState = StateTable[state, type];
+                    byte action = actionsWithState[0];
+                    state = actionsWithState[1];
+                    switch (action)
+                    {
+                        case Decompose:
+
+                            // Decompose the composed syllable if it is not supported by the font.
+                            if (!data.TextRun.Font!.FontMetrics.TryGetGlyphId(codePoint, out ushort _))
+                            {
+                                i = this.DecomposeGlyph(substitutionCollection, data, i);
+                            }
+
+                            break;
+
+                        case Compose:
+
+                            // Found a decomposed syllable. Try to compose if supported by the font.
+                            i = this.ComposeGlyph(substitutionCollection, data, i, type);
+                            break;
+
+                        case ToneMark:
+
+                            // Got a valid syllable, followed by a tone mark. Move the tone mark to the beginning of the syllable.
+                            this.ReOrderToneMark(data, i);
+                            break;
+
+                        case Invalid:
+                            // Tone mark has no valid syllable to attach to, so insert a dotted circle
+                            i = this.InsertDottedCircle(data, i);
+                            break;
+                    }
+                }
+            }
+            else
+            {
+                // GPos
+                // Simply loop and enable based on type.
+                // Glyph substitution has handled [de]composition.
+            }
+        }
+
+        private static int GetType(CodePoint codePoint)
+        {
+            GraphemeClusterClass type = CodePoint.GetGraphemeClusterClass(codePoint);
+            int value = codePoint.Value;
+
+            return type switch
+            {
+                GraphemeClusterClass.HangulLead => L,
+                GraphemeClusterClass.HangulVowel => V,
+                GraphemeClusterClass.HangulTail => T,
+                GraphemeClusterClass.HangulLeadVowel => LV,
+                GraphemeClusterClass.HangulLeadVowelTail => LVT,
+
+                // HANGUL SINGLE DOT TONE MARK
+                // HANGUL DOUBLE DOT TONE MARK
+                _ => value is >= 0x302E and <= 0x302F ? M : X,
+            };
+        }
+
+        private int DecomposeGlyph(GlyphSubstitutionCollection collection, GlyphShapingData data, int index)
+        {
+            // Decompose the syllable into a sequence of glyphs.
+            int s = data.CodePoint.Value - HANGUL_BASE;
+            int t = T_BASE + (s % T_COUNT);
+            s = (s / T_COUNT) | 0;
+            int l = (L_BASE + (s / V_COUNT)) | 0;
+            int v = V_BASE + (s % V_COUNT);
+
+            FontMetrics metrics = data.TextRun.Font!.FontMetrics;
+
+            // Don't decompose if all of the components are not available
+            if (!metrics.TryGetGlyphId(new(l), out ushort _) ||
+                !metrics.TryGetGlyphId(new(v), out ushort _) ||
+                (t != T_BASE && !metrics.TryGetGlyphId(new(t), out ushort _)))
+            {
+                return index;
+            }
+
+            // Replace the current glyph with decomposed L, V, and T glyphs,
+            // and apply the proper OpenType features to each component.
+            GlyphShapingData ljmo = collection.GetGlyphShapingData(l);
+            collection.EnableShapingFeature(l, LjmoTag);
+
+            GlyphShapingData vjmo = collection.GetGlyphShapingData(v);
+            collection.EnableShapingFeature(v, VjmoTag);
+
+            if (t <= T_BASE)
+            {
+                Span<ushort> ii = stackalloc ushort[2];
+                ii[0] = ljmo.GlyphIds[0];
+                ii[1] = vjmo.GlyphIds[0];
+
+                collection.Replace(index, ii);
+                return index + 1;
+            }
+
+            GlyphShapingData tjmo = collection.GetGlyphShapingData(t);
+            collection.EnableShapingFeature(t, TjmoTag);
+            Span<ushort> iii = stackalloc ushort[3];
+            iii[0] = ljmo.GlyphIds[0];
+            iii[1] = vjmo.GlyphIds[0];
+            iii[2] = tjmo.GlyphIds[0];
+
+            collection.Replace(index, iii);
+            return index + 2;
+        }
+
+        private int ComposeGlyph(GlyphSubstitutionCollection collection, GlyphShapingData data, int i, int type)
+        {
+            GlyphShapingData prev = collection.GetGlyphShapingData(i - 1);
+            CodePoint prevCodePoint = prev.CodePoint;
+            int prevType = GetType(prevCodePoint);
+
+            // Figure out what type of syllable we're dealing with
+            CodePoint lv = default;
+            GlyphShapingData? ljmo = null, vjmo = null, tjmo = null;
+
+            if (prevType == LV && type == T)
+            {
+                // <LV,T>
+                lv = prevCodePoint;
+                tjmo = data;
+            }
+            else
+            {
+                if (type == V)
+                {
+                    // <L,V>
+                    ljmo = prev;
+                    vjmo = data;
+                }
+                else
+                {
+                    // <L,V,T>
+                    ljmo = collection.GetGlyphShapingData(i - 2);
+                    vjmo = prev;
+                    tjmo = data;
+                }
+
+                CodePoint l = ljmo.CodePoint;
+                CodePoint v = vjmo.CodePoint;
+
+                // Make sure L and V are combining characters
+                if (isCombiningL(l) && isCombiningV(v))
+                {
+                    lv = new CodePoint(HANGUL_BASE + ((((l.Value - L_BASE) * V_COUNT) + (v.Value - V_BASE)) * T_COUNT));
+                }
+
+                CodePoint t = tjmo?.CodePoint ?? new CodePoint(T_BASE);
+                if ((lv != default) && (t.Value == T_BASE || isCombiningT(t)))
+                {
+                    CodePoint s = new(lv.Value + (t.Value - T_BASE));
+
+                    // Replace with a composed glyph if supported by the font,
+                    // otherwise apply the proper OpenType features to each component.
+                    FontMetrics metrics = data.TextRun.Font!.FontMetrics;
+                    if (metrics.TryGetGlyphId(s, out ushort id))
+                    {
+                        int del = prevType == V ? 3 : 2;
+                        int idx = i - del + 1;
+                        collection.Replace(idx, del, id);
+                        return idx;
+                    }
+                }
+            }
+
+            // Didn't compose (either a non-combining component or unsupported by font).
+            if (ljmo != null)
+            {
+                collection.EnableShapingFeature(ljmo.GlyphIds[0], LjmoTag);
+            }
+
+            if (vjmo != null)
+            {
+                collection.EnableShapingFeature(vjmo.GlyphIds[0], VjmoTag);
+            }
+
+            if (tjmo != null)
+            {
+                collection.EnableShapingFeature(tjmo.GlyphIds[0], TjmoTag);
+            }
+
+            if (prevType == LV)
+            {
+                // Sequence was originally <L,V>, which got combined earlier.
+                // Either the T was non-combining, or the LVT glyph wasn't supported.
+                // Decompose the glyph again and apply OT features.
+                data = collection.GetGlyphShapingData(i - 1);
+                this.DecomposeGlyph(collection, data, i - 1);
+                return i + 1;
+            }
+
+            return i;
+        }
+
+        private int ReOrderToneMark(GlyphShapingData data, int i)
+        {
+            throw new NotImplementedException();
+        }
+
+        private int InsertDottedCircle(GlyphShapingData data, int i)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static bool isCombiningL(CodePoint code) => UnicodeUtility.IsInRangeInclusive((uint)code.Value, L_BASE, L_END);
+
+        private static bool isCombiningV(CodePoint code) => UnicodeUtility.IsInRangeInclusive((uint)code.Value, V_BASE, V_END);
+
+        private static bool isCombiningT(CodePoint code) => UnicodeUtility.IsInRangeInclusive((uint)code.Value, T_BASE + 1, T_END);
+    }
+}

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
@@ -89,7 +89,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                 {
                     GlyphShapingData data = substitutionCollection.GetGlyphShapingData(i + index);
                     CodePoint codePoint = data.CodePoint;
-                    int type = GetType(codePoint);
+                    int type = GetSyllableType(codePoint);
                     byte[] actionsWithState = StateTable[state, type];
                     byte action = actionsWithState[0];
                     state = actionsWithState[1];
@@ -114,7 +114,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                         case ToneMark:
 
                             // Got a valid syllable, followed by a tone mark. Move the tone mark to the beginning of the syllable.
-                            this.ReOrderToneMark(data, i);
+                            this.ReOrderToneMark(substitutionCollection, data, i);
                             break;
 
                         case Invalid:
@@ -132,7 +132,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
             }
         }
 
-        private static int GetType(CodePoint codePoint)
+        private static int GetSyllableType(CodePoint codePoint)
         {
             GraphemeClusterClass type = CodePoint.GetGraphemeClusterClass(codePoint);
             int value = codePoint.Value;
@@ -151,6 +151,15 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
             };
         }
 
+        private static int GetSyllableLength(CodePoint codePoint)
+            => GetSyllableType(codePoint) switch
+            {
+                LV or LVT => 1,
+                V => 2,
+                T => 3,
+                _ => 0,
+            };
+
         private int DecomposeGlyph(GlyphSubstitutionCollection collection, GlyphShapingData data, int index)
         {
             // Decompose the syllable into a sequence of glyphs.
@@ -163,47 +172,52 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
             FontMetrics metrics = data.TextRun.Font!.FontMetrics;
 
             // Don't decompose if all of the components are not available
-            if (!metrics.TryGetGlyphId(new(l), out ushort _) ||
-                !metrics.TryGetGlyphId(new(v), out ushort _) ||
-                (t != T_BASE && !metrics.TryGetGlyphId(new(t), out ushort _)))
+            if (!metrics.TryGetGlyphId(new(l), out ushort ljmo) ||
+                !metrics.TryGetGlyphId(new(v), out ushort vjmo) ||
+                (!metrics.TryGetGlyphId(new(t), out ushort tjmo) && t != T_BASE))
             {
                 return index;
             }
 
+            // TODO: Check the insertion here.
+            // We likely need to add the features separately to each of the newly
+            // embedded glyph ids.
+            //
             // Replace the current glyph with decomposed L, V, and T glyphs,
             // and apply the proper OpenType features to each component.
-            GlyphShapingData ljmo = collection.GetGlyphShapingData(l);
-            collection.EnableShapingFeature(l, LjmoTag);
-
-            GlyphShapingData vjmo = collection.GetGlyphShapingData(v);
-            collection.EnableShapingFeature(v, VjmoTag);
+            collection.EnableShapingFeature(index, LjmoTag);
+            collection.EnableShapingFeature(index, VjmoTag);
 
             if (t <= T_BASE)
             {
                 Span<ushort> ii = stackalloc ushort[2];
-                ii[0] = ljmo.GlyphIds[0];
-                ii[1] = vjmo.GlyphIds[0];
+                ii[0] = ljmo;
+                ii[1] = vjmo;
 
                 collection.Replace(index, ii);
-                return index + 1;
+                return index;
             }
 
-            GlyphShapingData tjmo = collection.GetGlyphShapingData(t);
-            collection.EnableShapingFeature(t, TjmoTag);
+            collection.EnableShapingFeature(index, TjmoTag);
             Span<ushort> iii = stackalloc ushort[3];
-            iii[0] = ljmo.GlyphIds[0];
-            iii[1] = vjmo.GlyphIds[0];
-            iii[2] = tjmo.GlyphIds[0];
+            iii[0] = ljmo;
+            iii[1] = vjmo;
+            iii[2] = tjmo;
 
             collection.Replace(index, iii);
-            return index + 2;
+            return index;
         }
 
-        private int ComposeGlyph(GlyphSubstitutionCollection collection, GlyphShapingData data, int i, int type)
+        private int ComposeGlyph(GlyphSubstitutionCollection collection, GlyphShapingData data, int index, int type)
         {
-            GlyphShapingData prev = collection.GetGlyphShapingData(i - 1);
+            if (index == 0)
+            {
+                return index;
+            }
+
+            GlyphShapingData prev = collection.GetGlyphShapingData(index - 1);
             CodePoint prevCodePoint = prev.CodePoint;
-            int prevType = GetType(prevCodePoint);
+            int prevType = GetSyllableType(prevCodePoint);
 
             // Figure out what type of syllable we're dealing with
             CodePoint lv = default;
@@ -226,7 +240,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                 else
                 {
                     // <L,V,T>
-                    ljmo = collection.GetGlyphShapingData(i - 2);
+                    ljmo = collection.GetGlyphShapingData(index - 2);
                     vjmo = prev;
                     tjmo = data;
                 }
@@ -239,22 +253,22 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                 {
                     lv = new CodePoint(HANGUL_BASE + ((((l.Value - L_BASE) * V_COUNT) + (v.Value - V_BASE)) * T_COUNT));
                 }
+            }
 
-                CodePoint t = tjmo?.CodePoint ?? new CodePoint(T_BASE);
-                if ((lv != default) && (t.Value == T_BASE || isCombiningT(t)))
+            CodePoint t = tjmo?.CodePoint ?? new CodePoint(T_BASE);
+            if ((lv != default) && (t.Value == T_BASE || isCombiningT(t)))
+            {
+                CodePoint s = new(lv.Value + (t.Value - T_BASE));
+
+                // Replace with a composed glyph if supported by the font,
+                // otherwise apply the proper OpenType features to each component.
+                FontMetrics metrics = data.TextRun.Font!.FontMetrics;
+                if (metrics.TryGetGlyphId(s, out ushort id))
                 {
-                    CodePoint s = new(lv.Value + (t.Value - T_BASE));
-
-                    // Replace with a composed glyph if supported by the font,
-                    // otherwise apply the proper OpenType features to each component.
-                    FontMetrics metrics = data.TextRun.Font!.FontMetrics;
-                    if (metrics.TryGetGlyphId(s, out ushort id))
-                    {
-                        int del = prevType == V ? 3 : 2;
-                        int idx = i - del + 1;
-                        collection.Replace(idx, del, id);
-                        return idx;
-                    }
+                    int del = prevType == V ? 3 : 2;
+                    int idx = index - del + 1;
+                    collection.Replace(idx, del, id);
+                    return idx;
                 }
             }
 
@@ -279,22 +293,42 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                 // Sequence was originally <L,V>, which got combined earlier.
                 // Either the T was non-combining, or the LVT glyph wasn't supported.
                 // Decompose the glyph again and apply OT features.
-                data = collection.GetGlyphShapingData(i - 1);
-                this.DecomposeGlyph(collection, data, i - 1);
-                return i + 1;
+                data = collection.GetGlyphShapingData(index - 1);
+                this.DecomposeGlyph(collection, data, index - 1);
             }
 
-            return i;
+            return index;
         }
 
-        private int ReOrderToneMark(GlyphShapingData data, int i)
+        private int ReOrderToneMark(GlyphSubstitutionCollection collection, GlyphShapingData data, int index)
         {
+            if (index == 0)
+            {
+                return index;
+            }
+
+            // Move tone mark to the beginning of the previous syllable, unless it is zero width
+            // We don't have access to the glyphs metrics as an array when substituting so we have to loop.
+            FontMetrics metrics = data.TextRun.Font!.FontMetrics;
+            foreach (GlyphMetrics gm in metrics.GetGlyphMetrics(data.CodePoint, collection.TextOptions.ColorFontSupport))
+            {
+                if (gm.Width == 0)
+                {
+                    return index;
+                }
+            }
+
+            GlyphShapingData prev = collection.GetGlyphShapingData(index - 1);
+            int len = GetSyllableLength(prev.CodePoint);
+            collection.MoveGlyph(index, index - len);
             throw new NotImplementedException();
         }
 
         private int InsertDottedCircle(GlyphShapingData data, int i)
         {
-            throw new NotImplementedException();
+            // TODO: Implement.
+            // We need to find a way to do this that doesn't require increasing the length of the collection.
+            return i;
         }
 
         private static bool isCombiningL(CodePoint code) => UnicodeUtility.IsInRangeInclusive((uint)code.Value, L_BASE, L_END);

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
@@ -20,8 +20,6 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
         private static readonly Tag TjmoTag = Tag.Parse("tjmo");
 
         private const int HangulBase = 0xac00;
-        private const int HangulEnd = 0xd7a4;
-        private const int HangulCount = HangulEnd - HangulBase + 1;
         private const int LBase = 0x1100; // lead
         private const int VBase = 0x1161; // vowel
         private const int TBase = 0x11a7; // trail

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ShaperFactory.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ShaperFactory.cs
@@ -24,6 +24,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers
                 or ScriptClass.Mandaic
                 or ScriptClass.Manichaean
                 or ScriptClass.PsalterPahlavi => new ArabicShaper(textOptions),
+                ScriptClass.Hangul => new HangulShaper(textOptions),
                 _ => new DefaultShaper(textOptions),
             };
     }

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/TagEntry.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/TagEntry.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 namespace SixLabors.Fonts.Tables.AdvancedTypographic
 {
     [DebuggerDisplay("Tag: {Tag}, Enabled: {Enabled}")]
-    internal class TagEntry
+    internal struct TagEntry
     {
         public TagEntry(Tag tag, bool enabled)
         {

--- a/src/SixLabors.Fonts/Tables/General/KerningTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/KerningTable.cs
@@ -59,8 +59,8 @@ namespace SixLabors.Fonts.Tables.General
 
         public void UpdatePositions(FontMetrics fontMetrics, GlyphPositioningCollection collection, ushort left, ushort right)
         {
-            ushort previous = collection[left][0];
-            ushort current = collection[right][0];
+            ushort previous = collection[left];
+            ushort current = collection[right];
             if (previous == 0 || current == 0)
             {
                 return;

--- a/src/SixLabors.Fonts/Tables/SkippingGlyphIterator.cs
+++ b/src/SixLabors.Fonts/Tables/SkippingGlyphIterator.cs
@@ -73,7 +73,7 @@ namespace SixLabors.Fonts.Tables
         private bool ShouldIgnore(int index)
         {
             GlyphShapingData data = this.Collection.GetGlyphShapingData(index);
-            GlyphShapingClass shapingClass = AdvancedTypographicUtils.GetGlyphShapingClass(this.fontMetrics, data.GlyphIds[0], data);
+            GlyphShapingClass shapingClass = AdvancedTypographicUtils.GetGlyphShapingClass(this.fontMetrics, data.GlyphId, data);
             return (this.ignoreMarks && shapingClass.IsMark) ||
                 (this.ignoreBaseGlypghs && shapingClass.IsBase) ||
                 (this.ignoreLigatures && shapingClass.IsLigature) ||

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -713,7 +713,7 @@ namespace SixLabors.Fonts
                 var codePointEnumerator = new SpanCodePointEnumerator(graphemeEnumerator.Current);
                 while (codePointEnumerator.MoveNext())
                 {
-                    if (!positionings.TryGetGlyphMetricsAtOffset(codePointIndex, out float pointSize, out IReadOnlyList<GlyphMetrics>? metrics))
+                    if (!positionings.TryGetGlyphMetricsAtOffset(codePointIndex, out float pointSize, out bool isDecomposed, out IReadOnlyList<GlyphMetrics>? metrics))
                     {
                         // Codepoint was skipped during original enumeration.
                         codePointIndex++;
@@ -746,13 +746,18 @@ namespace SixLabors.Fonts
                     }
                     else if (!CodePoint.IsNewLine(codePoint))
                     {
-                        // Standard text. Use the largest advance for the metrics.
+                        // Standard text.
+                        // If decomposed we need to add the advance; otherwise, use the largest advance for the metrics.
                         if (isHorizontal)
                         {
                             for (int i = 1; i < metrics.Count; i++)
                             {
                                 float a = metrics[i].AdvanceWidth;
-                                if (a > glyphAdvance)
+                                if (isDecomposed)
+                                {
+                                    glyphAdvance += a;
+                                }
+                                else if (a > glyphAdvance)
                                 {
                                     glyphAdvance = a;
                                 }
@@ -763,7 +768,11 @@ namespace SixLabors.Fonts
                             for (int i = 1; i < metrics.Count; i++)
                             {
                                 float a = metrics[i].AdvanceHeight;
-                                if (a > glyphAdvance)
+                                if (isDecomposed)
+                                {
+                                    glyphAdvance += a;
+                                }
+                                else if (a > glyphAdvance)
                                 {
                                     glyphAdvance = a;
                                 }

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -713,7 +713,7 @@ namespace SixLabors.Fonts
                 var codePointEnumerator = new SpanCodePointEnumerator(graphemeEnumerator.Current);
                 while (codePointEnumerator.MoveNext())
                 {
-                    if (!positionings.TryGetGlyphMetricsAtOffset(codePointIndex, out float pointSize, out GlyphMetrics[]? metrics))
+                    if (!positionings.TryGetGlyphMetricsAtOffset(codePointIndex, out float pointSize, out IReadOnlyList<GlyphMetrics>? metrics))
                     {
                         // Codepoint was skipped during original enumeration.
                         codePointIndex++;
@@ -736,7 +736,7 @@ namespace SixLabors.Fonts
                     {
                         glyphAdvance *= options.TabWidth;
                     }
-                    else if (metrics.Length == 1 && (CodePoint.IsZeroWidthJoiner(codePoint) || CodePoint.IsZeroWidthNonJoiner(codePoint)))
+                    else if (metrics.Count == 1 && (CodePoint.IsZeroWidthJoiner(codePoint) || CodePoint.IsZeroWidthNonJoiner(codePoint)))
                     {
                         // The zero-width joiner characters should be ignored when determining word or
                         // line break boundaries so are safe to skip here. Any existing instances are the result of font error
@@ -749,7 +749,7 @@ namespace SixLabors.Fonts
                         // Standard text. Use the largest advance for the metrics.
                         if (isHorizontal)
                         {
-                            for (int i = 1; i < metrics.Length; i++)
+                            for (int i = 1; i < metrics.Count; i++)
                             {
                                 float a = metrics[i].AdvanceWidth;
                                 if (a > glyphAdvance)
@@ -760,7 +760,7 @@ namespace SixLabors.Fonts
                         }
                         else
                         {
-                            for (int i = 1; i < metrics.Length; i++)
+                            for (int i = 1; i < metrics.Count; i++)
                             {
                                 float a = metrics[i].AdvanceHeight;
                                 if (a > glyphAdvance)
@@ -959,7 +959,7 @@ namespace SixLabors.Fonts
             public GlyphLayoutData this[int index] => this.data[index];
 
             public void Add(
-                GlyphMetrics[] metrics,
+                IReadOnlyList<GlyphMetrics> metrics,
                 float pointSize,
                 float scaledAdvance,
                 float scaledLineHeight,
@@ -1213,7 +1213,7 @@ namespace SixLabors.Fonts
             internal readonly struct GlyphLayoutData
             {
                 public GlyphLayoutData(
-                    GlyphMetrics[] metrics,
+                    IReadOnlyList<GlyphMetrics> metrics,
                     float pointSize,
                     float scaledAdvance,
                     float scaledLineHeight,
@@ -1238,7 +1238,7 @@ namespace SixLabors.Fonts
 
                 public CodePoint CodePoint => this.Metrics[0].CodePoint;
 
-                public GlyphMetrics[] Metrics { get; }
+                public IReadOnlyList<GlyphMetrics> Metrics { get; }
 
                 public float PointSize { get; }
 

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -884,10 +884,17 @@ namespace SixLabors.Fonts
                     GlyphMetrics metric = metrics[0];
                     float scaleY = pointSize / metric.ScaleFactor.Y;
                     float ascender = metric.FontMetrics.Ascender * scaleY;
-                    if (metric.TopSideBearing < 0)
+
+                    // Adjust ascender for glyphs with a negative tsb. e.g. emoji to prevent cutoff.
+                    short tsbOffset = 0;
+                    for (int i = 0; i < metrics.Count; i++)
                     {
-                        // Adjust for glyphs with a negative tsb. e.g. emoji.
-                        ascender -= metric.TopSideBearing * scaleY;
+                        tsbOffset = Math.Min(tsbOffset, metrics[i].TopSideBearing);
+                    }
+
+                    if (tsbOffset < 0)
+                    {
+                        ascender -= tsbOffset * scaleY;
                     }
 
                     float descender = Math.Abs(metric.FontMetrics.Descender * scaleY);

--- a/src/SixLabors.Fonts/Unicode/UnicodeUtility.cs
+++ b/src/SixLabors.Fonts/Unicode/UnicodeUtility.cs
@@ -231,6 +231,180 @@ namespace SixLabors.Fonts.Unicode
         }
 
         /// <summary>
+        /// Returns <see langword="true"/> if <paramref name="value"/> is a Default Ignorable Code Point.
+        /// </summary>
+        /// <remarks>
+        /// <see href="http://www.unicode.org/reports/tr44/#Default_Ignorable_Code_Point"/>
+        /// <see href="https://www.unicode.org/Public/14.0.0/ucd/DerivedCoreProperties.txt"/>
+        /// </remarks>
+        public static bool IsDefaultIgnorableCodePoint(uint value)
+        {
+            // SOFT HYPHEN
+            if (value == 0x00AD)
+            {
+                return true;
+            }
+
+            // COMBINING GRAPHEME JOINER
+            if (value == 0x034F)
+            {
+                return true;
+            }
+
+            // COMBINING GRAPHEME JOINER
+            if (value == 0x061C)
+            {
+                return true;
+            }
+
+            // HANGUL CHOSEONG FILLER..HANGUL JUNGSEONG FILLER
+            if (IsInRangeInclusive(value, 0x115F, 0x1160))
+            {
+                return true;
+            }
+
+            // KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
+            if (IsInRangeInclusive(value, 0x17B4, 0x17B5))
+            {
+                return true;
+            }
+
+            // MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
+            if (IsInRangeInclusive(value, 0x180B, 0x180D))
+            {
+                return true;
+            }
+
+            // MONGOLIAN VOWEL SEPARATOR
+            if (value == 0x180E)
+            {
+                return true;
+            }
+
+            // MONGOLIAN FREE VARIATION SELECTOR FOUR
+            if (value == 0x180F)
+            {
+                return true;
+            }
+
+            // ZERO WIDTH SPACE..RIGHT-TO-LEFT MARK
+            if (IsInRangeInclusive(value, 0x200B, 0x200F))
+            {
+                return true;
+            }
+
+            // LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
+            if (IsInRangeInclusive(value, 0x202A, 0x202E))
+            {
+                return true;
+            }
+
+            // WORD JOINER..INVISIBLE PLUS
+            if (IsInRangeInclusive(value, 0x2060, 0x2064))
+            {
+                return true;
+            }
+
+            // <reserved-2065>
+            if (value == 0x2065)
+            {
+                return true;
+            }
+
+            // LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
+            if (IsInRangeInclusive(value, 0x2066, 0x206F))
+            {
+                return true;
+            }
+
+            // HANGUL FILLER
+            if (value == 0x3164)
+            {
+                return true;
+            }
+
+            // VARIATION SELECTOR-1..VARIATION SELECTOR-16
+            if (IsInRangeInclusive(value, 0xFE00, 0xFE0F))
+            {
+                return true;
+            }
+
+            // ZERO WIDTH NO-BREAK SPACE
+            if (value == 0xFEFF)
+            {
+                return true;
+            }
+
+            // HALFWIDTH HANGUL FILLER
+            if (value == 0xFFA0)
+            {
+                return true;
+            }
+
+            // <reserved-FFF0>..<reserved-FFF8>
+            if (IsInRangeInclusive(value, 0xFFF0, 0xFFF8))
+            {
+                return true;
+            }
+
+            // SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
+            if (IsInRangeInclusive(value, 0x1BCA0, 0x1BCA3))
+            {
+                return true;
+            }
+
+            // MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
+            if (IsInRangeInclusive(value, 0x1D173, 0x1D17A))
+            {
+                return true;
+            }
+
+            // <reserved-E0000>
+            if (value == 0xE0000)
+            {
+                return true;
+            }
+
+            // LANGUAGE TAG
+            if (value == 0xE0001)
+            {
+                return true;
+            }
+
+            // <reserved-E0002>..<reserved-E001F>
+            if (IsInRangeInclusive(value, 0xE0002, 0xE001F))
+            {
+                return true;
+            }
+
+            // TAG SPACE..CANCEL TAG
+            if (IsInRangeInclusive(value, 0xE0020, 0xE007F))
+            {
+                return true;
+            }
+
+            // <reserved-E0080>..<reserved-E00FF>
+            if (IsInRangeInclusive(value, 0xE0080, 0xE00FF))
+            {
+                return true;
+            }
+
+            // VARIATION SELECTOR-17..VARIATION SELECTOR-256
+            if (IsInRangeInclusive(value, 0xE0100, 0xE01EF))
+            {
+                return true;
+            }
+
+            // <reserved-E01F0>..<reserved-E0FFF>
+            if (IsInRangeInclusive(value, 0xE01F0, 0xE0FFF))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Returns the Unicode plane (0 through 16, inclusive) which contains this code point.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/UnicodeTrieGenerator/Rules/README.md
+++ b/src/UnicodeTrieGenerator/Rules/README.md
@@ -1,3 +1,3 @@
 Files sourced from:
 
-https://www.unicode.org/Public/13.0.0/ucd/
+https://www.unicode.org/Public/14.0.0/ucd/

--- a/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.Hangul.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.Hangul.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using Xunit;
+
+namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.Gsub
+{
+    /// <content>
+    /// Tests adapted from <see href="https://github.com/foliojs/fontkit/blob/417af0c79c5664271a07a783574ec7fac7ebad0c/test/shaping.js"/>.
+    /// </content>
+    public partial class GSubTableTests
+    {
+        // TODO: Switch to NotoSansKR-Regular when we have CFF support.
+#if OS_WINDOWS
+        private readonly Font hangulFont = SystemFonts.CreateFont("Malgun Gothic", 12);
+
+        [Fact]
+        public void ShouldUseComposedSyllables()
+        {
+            // arrange
+            const string input = "\uD734\uAC00\u0020\uAC00\u002D\u002D\u0020\u0028\uC624\u002D\u002D\u0029";
+            ColorGlyphRenderer renderer = new();
+            int[] expectedGlyphIndices = { 2953, 636, 3, 636, 16, 16, 3, 11, 2077, 16, 16, 12 };
+
+            // act
+            TextRenderer.RenderTextTo(renderer, input, new TextOptions(this.hangulFont));
+
+            // assert
+            Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
+            for (int i = 0; i < expectedGlyphIndices.Length; i++)
+            {
+                Assert.Equal(expectedGlyphIndices[i], renderer.GlyphKeys[i].GlyphIndex);
+            }
+        }
+
+        [Fact]
+        public void ShouldComposeDecomposedSyllables()
+        {
+            // arrange
+            const string input = "\u1112\u1172\u1100\u1161\u0020\u1100\u1161\u002D\u002D\u0020\u0028\u110B\u1169\u002D\u002D\u0029";
+            ColorGlyphRenderer renderer = new();
+            int[] expectedGlyphIndices = { 2953, 636, 3, 636, 16, 16, 3, 11, 2077, 16, 16, 12 };
+
+            // act
+            TextRenderer.RenderTextTo(renderer, input, new TextOptions(this.hangulFont));
+
+            // assert
+            Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
+            for (int i = 0; i < expectedGlyphIndices.Length; i++)
+            {
+                Assert.Equal(expectedGlyphIndices[i], renderer.GlyphKeys[i].GlyphIndex);
+            }
+        }
+
+        [Fact]
+        public void ShouldUseOTFeaturesForNonCombining_L_V_T()
+        {
+            // arrange
+            const string input = "\ua960\ud7b0\ud7cb";
+            ColorGlyphRenderer renderer = new();
+            int[] expectedGlyphIndices = { 21150, 21436, 21569 };
+
+            // act
+            TextRenderer.RenderTextTo(renderer, input, new TextOptions(this.hangulFont));
+
+            // assert
+            Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
+            for (int i = 0; i < expectedGlyphIndices.Length; i++)
+            {
+                Assert.Equal(expectedGlyphIndices[i], renderer.GlyphKeys[i].GlyphIndex);
+            }
+        }
+
+        [Fact]
+        public void ShouldDecompose_LV_T_To_L_V_T_If_LVT_IsNotSupported()
+        {
+            // <L,V> combine at first, but the T is non-combining, so this
+            // tests that the <LV> gets decomposed again in this case.
+
+            // arrange
+            const string input = "\u1100\u1161\ud7cb";
+            ColorGlyphRenderer renderer = new();
+            int[] expectedGlyphIndices = { 20667, 21294, 21569 };
+
+            // act
+            TextRenderer.RenderTextTo(renderer, input, new TextOptions(this.hangulFont));
+
+            // assert
+            Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
+            for (int i = 0; i < expectedGlyphIndices.Length; i++)
+            {
+                Assert.Equal(expectedGlyphIndices[i], renderer.GlyphKeys[i].GlyphIndex);
+            }
+        }
+
+        [Fact]
+        public void ShouldReorderToneMarksToBeginningOf_L_V_Syllables()
+        {
+            // arrange
+            const string input = "\ua960\ud7b0\u302f";
+            ColorGlyphRenderer renderer = new();
+            int[] expectedGlyphIndices = { 20665, 21150, 21435 };
+
+            // act
+            TextRenderer.RenderTextTo(renderer, input, new TextOptions(this.hangulFont));
+
+            // assert
+            Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
+            for (int i = 0; i < expectedGlyphIndices.Length; i++)
+            {
+                Assert.Equal(expectedGlyphIndices[i], renderer.GlyphKeys[i].GlyphIndex);
+            }
+        }
+
+        [Fact]
+        public void ShouldReorderToneMarksToBeginningOf_L_V_T_Syllables()
+        {
+            // arrange
+            const string input = "\ua960\ud7b0\ud7cb\u302f";
+            ColorGlyphRenderer renderer = new();
+            int[] expectedGlyphIndices = { 20665, 21150, 21436, 21569 };
+
+            // act
+            TextRenderer.RenderTextTo(renderer, input, new TextOptions(this.hangulFont));
+
+            // assert
+            Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
+            for (int i = 0; i < expectedGlyphIndices.Length; i++)
+            {
+                Assert.Equal(expectedGlyphIndices[i], renderer.GlyphKeys[i].GlyphIndex);
+            }
+        }
+
+        [Fact]
+        public void ShouldReorderToneMarksToBeginningOf_LV_Syllables()
+        {
+            // arrange
+            const string input = "\uac00\u302f";
+            ColorGlyphRenderer renderer = new();
+            int[] expectedGlyphIndices = { 20665, 636 };
+
+            // act
+            TextRenderer.RenderTextTo(renderer, input, new TextOptions(this.hangulFont));
+
+            // assert
+            Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
+            for (int i = 0; i < expectedGlyphIndices.Length; i++)
+            {
+                Assert.Equal(expectedGlyphIndices[i], renderer.GlyphKeys[i].GlyphIndex);
+            }
+        }
+
+        [Fact]
+        public void ShouldReorderToneMarksToBeginningOf_LVT_Syllables()
+        {
+            // arrange
+            const string input = "\uac01\u302f";
+            ColorGlyphRenderer renderer = new();
+            int[] expectedGlyphIndices = { 20665, 637 };
+
+            // act
+            TextRenderer.RenderTextTo(renderer, input, new TextOptions(this.hangulFont));
+
+            // assert
+            Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
+            for (int i = 0; i < expectedGlyphIndices.Length; i++)
+            {
+                Assert.Equal(expectedGlyphIndices[i], renderer.GlyphKeys[i].GlyphIndex);
+            }
+        }
+
+        [Fact]
+        public void ShouldInsertDottedCircleForInvalidToneMarks()
+        {
+            // arrange
+            const string input = "\u1100\u302f\u1161";
+            ColorGlyphRenderer renderer = new();
+            int[] expectedGlyphIndices = { 2986, 20665, 21620, 3078 };
+
+            // act
+            TextRenderer.RenderTextTo(renderer, input, new TextOptions(this.hangulFont));
+
+            // assert
+            Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
+            for (int i = 0; i < expectedGlyphIndices.Length; i++)
+            {
+                Assert.Equal(expectedGlyphIndices[i], renderer.GlyphKeys[i].GlyphIndex);
+            }
+        }
+#endif
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GSub
 {
-    public class GSubTableTests
+    public partial class GSubTableTests
     {
         [Theory]
         [InlineData("ا", 139)]

--- a/tests/SixLabors.Fonts.Tests/Unicode/UnicodeUtilityTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Unicode/UnicodeUtilityTests.cs
@@ -39,5 +39,51 @@ namespace SixLabors.Fonts.Tests.Unicode
                 Assert.False(UnicodeUtility.IsCJKCodePoint(i));
             }
         }
+
+        [Theory]
+        [InlineData(0x00AD, 0x00AD)]
+        [InlineData(0x034F, 0x034F)]
+        [InlineData(0x061C, 0x061C)]
+        [InlineData(0x115F, 0x1160)]
+        [InlineData(0x17B4, 0x17B5)]
+        [InlineData(0x180B, 0x180D)]
+        [InlineData(0x180E, 0x180E)]
+        [InlineData(0x180F, 0x180F)]
+        [InlineData(0x200B, 0x200F)]
+        [InlineData(0x202A, 0x202E)]
+        [InlineData(0x2060, 0x2064)]
+        [InlineData(0x2065, 0x2065)]
+        [InlineData(0x2066, 0x206F)]
+        [InlineData(0x3164, 0x3164)]
+        [InlineData(0xFE00, 0xFE0F)]
+        [InlineData(0xFEFF, 0xFEFF)]
+        [InlineData(0xFFA0, 0xFFA0)]
+        [InlineData(0xFFF0, 0xFFF8)]
+        [InlineData(0x1BCA0, 0x1BCA3)]
+        [InlineData(0x1D173, 0x1D17A)]
+        [InlineData(0xE0000, 0xE0000)]
+        [InlineData(0xE0001, 0xE0001)]
+        [InlineData(0xE0002, 0xE001F)]
+        [InlineData(0xE0020, 0xE007F)]
+        [InlineData(0xE0080, 0xE00FF)]
+        [InlineData(0xE0100, 0xE01EF)]
+        [InlineData(0xE01F0, 0xE0FFF)]
+        public void CanDetectDefaultIgnorableCodePoint(uint min, uint max)
+        {
+            for (uint i = min; i <= max; i++)
+            {
+                Assert.True(UnicodeUtility.IsDefaultIgnorableCodePoint(i));
+            }
+        }
+
+        [Theory]
+        [InlineData(0x0u, 0x7Fu)] // ASCII
+        public void NoFalsePositiveDefaultIgnorableCodePoint(uint min, uint max)
+        {
+            for (uint i = min; i <= max; i++)
+            {
+                Assert.False(UnicodeUtility.IsDefaultIgnorableCodePoint(i));
+            }
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #213 

Adds the Hangul Shaper to the shaping collection.

TODO
- [x] Complete shaper
- [x] Add tests (@brianpopow if you have any time available it'd be great if you could help out there.) 

<!-- Thanks for contributing to SixLabors.Fonts! -->
