### PR TITLE
Make ScriptList optional

### DIFF
--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/ScriptList.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/ScriptList.cs
@@ -19,7 +19,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
 
         private ScriptList(Tag scriptTag) => this.scriptTag = scriptTag;
 
-        public static ScriptList Load(BigEndianBinaryReader reader, long offset)
+        public static ScriptList? Load(BigEndianBinaryReader reader, long offset)
         {
             // ScriptListTable
             // +--------------+----------------------------+-------------------------------------------------------------+
@@ -57,7 +57,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                 scriptList!.Add(scriptTag, scriptTable);
             }
 
-            return scriptList!;
+            return scriptList;
         }
 
         // Dictionaries are unordered.


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [ ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #266 

Handles when a ScriptListTable ScriptCount is 0.

<!-- Thanks for contributing to SixLabors.Fonts! -->
