### PR TITLE
Add android font support on SystemFontCollection

### DIFF
--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -56,13 +56,6 @@ namespace SixLabors.Fonts
                     "/Network/Library/Fonts/",
                 };
             }
-            else if(RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android")))
-            {
-                StandardFontLocations = new[]
-                {
-                    "/system/fonts/"
-                };
-            }
             else
             {
                 StandardFontLocations = Array.Empty<string>();

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -56,6 +56,13 @@ namespace SixLabors.Fonts
                     "/Network/Library/Fonts/",
                 };
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android")))
+            {
+                StandardFontLocations = new[]
+                {
+                    "/system/fonts/"
+                };
+            }
             else
             {
                 StandardFontLocations = Array.Empty<string>();

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -56,6 +56,13 @@ namespace SixLabors.Fonts
                     "/Network/Library/Fonts/",
                 };
             }
+            else if(RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android")))
+            {
+                StandardFontLocations = new[]
+                {
+                    "/system/fonts/"
+                };
+            }
             else
             {
                 StandardFontLocations = Array.Empty<string>();


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [ ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to SixLabors.Fonts! -->
