### PR TITLE
Adding android OS support to SystemFontCollection

### DIFF
--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -56,6 +56,13 @@ namespace SixLabors.Fonts
                     "/Network/Library/Fonts/",
                 };
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android")))
+            {
+                StandardFontLocations = new[]
+                {
+                    "/system/fonts/"
+                };
+            }
             else
             {
                 StandardFontLocations = Array.Empty<string>();

--- a/tests/SixLabors.Fonts.Tests/SystemFontCollectionTests.cs
+++ b/tests/SixLabors.Fonts.Tests/SystemFontCollectionTests.cs
@@ -156,6 +156,11 @@ namespace SixLabors.Fonts.Tests
                 Assert.Contains(@"/Library/Fonts/", exception.Message, StringComparison.OrdinalIgnoreCase);
                 Assert.Contains(exception.SearchDirectories, e => e.IndexOf("Library/Fonts", StringComparison.OrdinalIgnoreCase) != -1);
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("Android")))
+            {
+                Assert.Contains(@"/system/fonts/", exception.Message, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains(exception.SearchDirectories, e => e.IndexOf("/system/fonts/", StringComparison.OrdinalIgnoreCase) != -1);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Android ttf files are located in /system/fonts

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adding Android fonts path to support them in MAUI project
<!-- Thanks for contributing to SixLabors.Fonts! -->
