### PR TITLE
Fix reading compressed WOFF data

### DIFF
--- a/src/SixLabors.Fonts/Tables/Woff/WoffTableHeader.cs
+++ b/src/SixLabors.Fonts/Tables/Woff/WoffTableHeader.cs
@@ -26,15 +26,17 @@ namespace SixLabors.Fonts.Tables.Woff
             using var compressedStream = new IO.ZlibInflateStream(stream);
             byte[] uncompressedBytes = new byte[this.Length];
             int totalBytesRead = 0;
+            int bytesLeftToRead = uncompressedBytes.Length;
             while (totalBytesRead < this.Length)
             {
-                int bytesRead = compressedStream.Read(uncompressedBytes, 0, uncompressedBytes.Length);
+                int bytesRead = compressedStream.Read(uncompressedBytes, totalBytesRead, bytesLeftToRead);
                 if (bytesRead <= 0)
                 {
                     throw new InvalidFontFileException($"Could not read compressed data! Expected bytes: {this.Length}, bytes read: {totalBytesRead}");
                 }
 
                 totalBytesRead += bytesRead;
+                bytesLeftToRead -= bytesRead;
             }
 
             var memoryStream = new MemoryStream(uncompressedBytes);

--- a/src/SixLabors.Fonts/Tables/Woff/WoffTableHeader.cs
+++ b/src/SixLabors.Fonts/Tables/Woff/WoffTableHeader.cs
@@ -25,10 +25,16 @@ namespace SixLabors.Fonts.Tables.Woff
             stream.Seek(this.Offset, SeekOrigin.Begin);
             using var compressedStream = new IO.ZlibInflateStream(stream);
             byte[] uncompressedBytes = new byte[this.Length];
-            int bytesRead = compressedStream.Read(uncompressedBytes, 0, uncompressedBytes.Length);
-            if (bytesRead < this.Length)
+            int totalBytesRead = 0;
+            while (totalBytesRead < this.Length)
             {
-                throw new InvalidFontFileException($"Could not read compressed data! Expected bytes: {this.Length}, bytes read: {bytesRead}");
+                int bytesRead = compressedStream.Read(uncompressedBytes, 0, uncompressedBytes.Length);
+                if (bytesRead <= 0)
+                {
+                    throw new InvalidFontFileException($"Could not read compressed data! Expected bytes: {this.Length}, bytes read: {totalBytesRead}");
+                }
+
+                totalBytesRead += bytesRead;
             }
 
             var memoryStream = new MemoryStream(uncompressedBytes);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

This PR fixes reading compressed woff data: Read data in a loop. The first read does not ensure all data is read.

Fix issue #296

Note: I cant use the font file provided in #296 for a unit test. Not sure howto make a test without a sample file.
