### PR TITLE
Fix indexer offset for post positioning methods

### DIFF
--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
@@ -292,7 +292,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                 GlyphShapingData data = collection.GetGlyphShapingData(currentIndex);
                 if (data.CursiveAttachment != -1)
                 {
-                    int j = data.CursiveAttachment + i;
+                    int j = data.CursiveAttachment + currentIndex;
                     if (j > count)
                     {
                         return;
@@ -327,7 +327,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
 
                     if (data.Direction == TextDirection.LeftToRight)
                     {
-                        for (int k = j; k < i; k++)
+                        for (int k = j; k < currentIndex; k++)
                         {
                             markData = collection.GetGlyphShapingData(k);
                             data.Bounds.X -= markData.Bounds.Width;
@@ -336,7 +336,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
                     }
                     else
                     {
-                        for (int k = j + 1; k < i + 1; k++)
+                        for (int k = j + 1; k < currentIndex + 1; k++)
                         {
                             markData = collection.GetGlyphShapingData(k);
                             data.Bounds.X += markData.Bounds.Width;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
We were failing to offset the lookups for fixing up cursive and mark attachments. Fixes #300 

![Test ดวันโอวัน](https://user-images.githubusercontent.com/385879/192527782-c3de63fe-82a3-4e44-a6e2-b7fc84422029.png)
![ดวันโอวัน](https://user-images.githubusercontent.com/385879/192527792-0965df8e-8241-4e6c-98e0-7e812af1be71.png)


<!-- Thanks for contributing to SixLabors.Fonts! -->
