### PR TITLE
Add exposed function to retrieve all unicode codepoints defined in fonts

### DIFF
--- a/src/SixLabors.Fonts/FileFontMetrics.cs
+++ b/src/SixLabors.Fonts/FileFontMetrics.cs
@@ -138,7 +138,7 @@ namespace SixLabors.Fonts
             => this.metrics.Value.GetGlyphMetrics(codePoint, glyphId, support);
 
         /// <inheritdoc />
-        internal override IEnumerable<CodePoint> GetAvailableCodePoints()
+        internal override IReadOnlyList<CodePoint> GetAvailableCodePoints()
             => this.metrics.Value.GetAvailableCodePoints();
 
         /// <inheritdoc/>

--- a/src/SixLabors.Fonts/FileFontMetrics.cs
+++ b/src/SixLabors.Fonts/FileFontMetrics.cs
@@ -137,6 +137,10 @@ namespace SixLabors.Fonts
         internal override IEnumerable<GlyphMetrics> GetGlyphMetrics(CodePoint codePoint, ushort glyphId, ColorFontSupport support)
             => this.metrics.Value.GetGlyphMetrics(codePoint, glyphId, support);
 
+        /// <inheritdoc />
+        internal override IEnumerable<CodePoint> GetAvailableCodePoints()
+            => this.metrics.Value.GetAvailableCodePoints();
+
         /// <inheritdoc/>
         internal override void ApplySubstitution(GlyphSubstitutionCollection collection)
             => this.metrics.Value.ApplySubstitution(collection);

--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -167,6 +167,13 @@ namespace SixLabors.Fonts
             }
         }
 
+        /// <summary>
+        /// Gets the unicode codepoints for which a glyph exists in the font.
+        /// </summary>
+        /// <returns>An enumerable containing all available codepoints.</returns>
+        public IEnumerable<CodePoint> GetAvailableCodePoints()
+            => this.FontMetrics.GetAvailableCodePoints();
+
         private string LoadFontName()
             => this.metrics.Value?.Description.FontName(this.Family.Culture) ?? string.Empty;
 

--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -167,13 +167,6 @@ namespace SixLabors.Fonts
             }
         }
 
-        /// <summary>
-        /// Gets the unicode codepoints for which a glyph exists in the font.
-        /// </summary>
-        /// <returns>An enumerable containing all available codepoints.</returns>
-        public IEnumerable<CodePoint> GetAvailableCodePoints()
-            => this.FontMetrics.GetAvailableCodePoints();
-
         private string LoadFontName()
             => this.metrics.Value?.Description.FontName(this.Family.Culture) ?? string.Empty;
 

--- a/src/SixLabors.Fonts/FontMetrics.cs
+++ b/src/SixLabors.Fonts/FontMetrics.cs
@@ -192,6 +192,12 @@ namespace SixLabors.Fonts
         public abstract IEnumerable<GlyphMetrics> GetGlyphMetrics(CodePoint codePoint, ColorFontSupport support);
 
         /// <summary>
+        /// Gets the unicode codepoints for which a glyph exists in the font.
+        /// </summary>
+        /// <returns>An enumerable containing all available codepoints.</returns>
+        internal abstract IEnumerable<CodePoint> GetAvailableCodePoints();
+
+        /// <summary>
         /// Gets the glyph metrics for a given code point and glyph id.
         /// </summary>
         /// <param name="codePoint">The Unicode codepoint.</param>

--- a/src/SixLabors.Fonts/FontMetrics.cs
+++ b/src/SixLabors.Fonts/FontMetrics.cs
@@ -194,8 +194,8 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Gets the unicode codepoints for which a glyph exists in the font.
         /// </summary>
-        /// <returns>An enumerable containing all available codepoints.</returns>
-        internal abstract IEnumerable<CodePoint> GetAvailableCodePoints();
+        /// <returns>The <see cref="IReadOnlyList{CodePoint}"/>.</returns>
+        internal abstract IReadOnlyList<CodePoint> GetAvailableCodePoints();
 
         /// <summary>
         /// Gets the glyph metrics for a given code point and glyph id.

--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -124,7 +124,7 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Gets the glyph Id.
         /// </summary>
-        internal ushort GlyphId { get; }
+        public ushort GlyphId { get; }
 
         /// <summary>
         /// Performs a semi-deep clone (FontMetrics are not cloned) for rendering

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -233,7 +233,7 @@ namespace SixLabors.Fonts
         }
 
         /// <inheritdoc />
-        internal override IEnumerable<CodePoint> GetAvailableCodePoints()
+        internal override IReadOnlyList<CodePoint> GetAvailableCodePoints()
         {
             CMapTable cmap = this.outlineType == OutlineType.TrueType
                 ? this.trueTypeFontTables!.Cmap

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -235,6 +235,16 @@ namespace SixLabors.Fonts
             return this.glyphCache[glyphId];
         }
 
+        /// <inheritdoc />
+        internal override IEnumerable<CodePoint> GetAvailableCodePoints()
+        {
+            CMapTable cmap = this.outlineType == OutlineType.TrueType
+                ? this.trueTypeFontTables!.Cmap
+                : this.compactFontTables!.Cmap;
+
+            return cmap.GetAvailableCodePoints();
+        }
+
         /// <inheritdoc/>
         internal override void ApplySubstitution(GlyphSubstitutionCollection collection)
         {

--- a/src/SixLabors.Fonts/Tables/General/CMap/CMapSubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/CMapSubTable.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Collections.Generic;
 using SixLabors.Fonts.Unicode;
 using SixLabors.Fonts.WellKnownIds;
 
@@ -26,5 +27,7 @@ namespace SixLabors.Fonts.Tables.General.CMap
         public ushort Encoding { get; }
 
         public abstract bool TryGetGlyphId(CodePoint codePoint, out ushort glyphId);
+
+        public abstract IEnumerable<int> GetAvailableCodePoints();
     }
 }

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format0SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format0SubTable.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
+using System.Linq;
 using SixLabors.Fonts.Unicode;
 using SixLabors.Fonts.WellKnownIds;
 
@@ -32,6 +33,9 @@ namespace SixLabors.Fonts.Tables.General.CMap
             glyphId = this.GlyphIds[b];
             return true;
         }
+
+        public override IEnumerable<int> GetAvailableCodePoints()
+            => Enumerable.Range(0, this.GlyphIds.Length);
 
         public static IEnumerable<Format0SubTable> Load(IEnumerable<EncodingRecord> encodings, BigEndianBinaryReader reader)
         {

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format12SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format12SubTable.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
+using System.Linq;
 using SixLabors.Fonts.Unicode;
 using SixLabors.Fonts.WellKnownIds;
 
@@ -38,6 +39,14 @@ namespace SixLabors.Fonts.Tables.General.CMap
             glyphId = 0;
             return false;
         }
+
+        public override IEnumerable<int> GetAvailableCodePoints()
+            => this.SequentialMapGroups.SelectMany(segment =>
+            {
+                int start = (int)segment.StartCodePoint;
+                int end = (int)segment.EndCodePoint;
+                return Enumerable.Range(start, end - start + 1);
+            });
 
         public static IEnumerable<Format12SubTable> Load(IEnumerable<EncodingRecord> encodings, BigEndianBinaryReader reader)
         {

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format14SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format14SubTable.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using SixLabors.Fonts.Unicode;
@@ -137,6 +138,9 @@ namespace SixLabors.Fonts.Tables.General.CMap
             glyphId = 0;
             return false;
         }
+
+        public override IEnumerable<int> GetAvailableCodePoints()
+            => Array.Empty<int>();
 
         public ushort CharacterPairToGlyphId(CodePoint codePoint, ushort defaultGlyphIndex, CodePoint nextCodePoint)
         {

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format4SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format4SubTable.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using SixLabors.Fonts.Unicode;
 using SixLabors.Fonts.WellKnownIds;
 
@@ -51,6 +52,9 @@ namespace SixLabors.Fonts.Tables.General.CMap
             glyphId = 0;
             return false;
         }
+
+        public override IEnumerable<int> GetAvailableCodePoints()
+            => this.Segments.SelectMany(segment => Enumerable.Range(segment.Start, segment.End - segment.Start + 1));
 
         public static IEnumerable<Format4SubTable> Load(IEnumerable<EncodingRecord> encodings, BigEndianBinaryReader reader)
         {

--- a/src/SixLabors.Fonts/Tables/General/CMapTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMapTable.cs
@@ -16,6 +16,7 @@ namespace SixLabors.Fonts.Tables.General
         internal const string TableName = "cmap";
 
         private readonly Format14SubTable[] format14SubTables = Array.Empty<Format14SubTable>();
+        private CodePoint[]? codepoints;
 
         public CMapTable(IEnumerable<CMapSubTable> tables)
         {
@@ -83,17 +84,22 @@ namespace SixLabors.Fonts.Tables.General
         /// <summary>
         /// Gets the unicode codepoints for which a glyph exists in the font.
         /// </summary>
-        /// <returns>An enumerable containing all available codepoints.</returns>
-        public IEnumerable<CodePoint> GetAvailableCodePoints()
+        /// <returns>The <see cref="IReadOnlyList{CodePoint}"/>.</returns>
+        public IReadOnlyList<CodePoint> GetAvailableCodePoints()
         {
-            var values = new HashSet<int>();
+            if (this.codepoints is not null)
+            {
+                return this.codepoints;
+            }
+
+            HashSet<int> values = new();
 
             foreach (int v in this.Tables.SelectMany(subtable => subtable.GetAvailableCodePoints()))
             {
                 values.Add(v);
             }
 
-            return values.OrderBy(v => v).Select(v => new CodePoint(v));
+            return this.codepoints = values.OrderBy(v => v).Select(v => new CodePoint(v)).ToArray();
         }
 
         public static CMapTable Load(FontReader reader)

--- a/src/SixLabors.Fonts/Tables/General/CMapTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMapTable.cs
@@ -80,6 +80,22 @@ namespace SixLabors.Fonts.Tables.General
             return false;
         }
 
+        /// <summary>
+        /// Gets the unicode codepoints for which a glyph exists in the font.
+        /// </summary>
+        /// <returns>An enumerable containing all available codepoints.</returns>
+        public IEnumerable<CodePoint> GetAvailableCodePoints()
+        {
+            var values = new HashSet<int>();
+
+            foreach (int v in this.Tables.SelectMany(subtable => subtable.GetAvailableCodePoints()))
+            {
+                values.Add(v);
+            }
+
+            return values.OrderBy(v => v).Select(v => new CodePoint(v));
+        }
+
         public static CMapTable Load(FontReader reader)
         {
             using BigEndianBinaryReader binaryReader = reader.GetReaderAtTablePosition(TableName);

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeCmapSubtable.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeCmapSubtable.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
+using System.Linq;
 using SixLabors.Fonts.Tables.General.CMap;
 using SixLabors.Fonts.Unicode;
 
@@ -28,5 +29,8 @@ namespace SixLabors.Fonts.Tests.Fakes
             glyphId = 0;
             return false;
         }
+
+        public override IEnumerable<int> GetAvailableCodePoints()
+            => this.glyphs.Select(x => x.CodePoint.Value);
     }
 }

--- a/tests/SixLabors.Fonts.Tests/FontCodePointsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontCodePointsTests.cs
@@ -17,11 +17,11 @@ namespace SixLabors.Fonts.Tests
             FontFamily family = collection.Add(TestFonts.SimpleFontFile);
             Font font = family.CreateFont(12);
 
-            IEnumerable<CodePoint> codePoints = font.GetAvailableCodePoints();
+            IReadOnlyList<CodePoint> codePoints = font.FontMetrics.GetAvailableCodePoints();
             IEnumerable<int> codePointValues = codePoints.Select(x => x.Value);
 
             // Compare with https://everythingfonts.com/ttfdump
-            Assert.Equal(257, codePoints.Count());
+            Assert.Equal(257, codePoints.Count);
 
             // Compare with https://fontdrop.info/
             Assert.Contains(0x0000, codePointValues);
@@ -49,7 +49,7 @@ namespace SixLabors.Fonts.Tests
             FontFamily family = collection.Add(TestFonts.SimpleFontFileWoff);
             Font font = family.CreateFont(12);
 
-            IEnumerable<CodePoint> codePoints = font.GetAvailableCodePoints();
+            IReadOnlyList<CodePoint> codePoints = font.FontMetrics.GetAvailableCodePoints();
             IEnumerable<int> codePointValues = codePoints.Select(x => x.Value);
 
             // Compare with https://everythingfonts.com/ttfdump

--- a/tests/SixLabors.Fonts.Tests/FontCodePointsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontCodePointsTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using System.Linq;
+using SixLabors.Fonts.Unicode;
+using Xunit;
+
+namespace SixLabors.Fonts.Tests
+{
+    public class FontCodePointsTests
+    {
+        [Fact]
+        public void TtfTest()
+        {
+            var collection = new FontCollection();
+            FontFamily family = collection.Add(TestFonts.SimpleFontFile);
+            Font font = family.CreateFont(12);
+
+            IEnumerable<CodePoint> codePoints = font.GetAvailableCodePoints();
+            IEnumerable<int> codePointValues = codePoints.Select(x => x.Value);
+
+            // Compare with https://everythingfonts.com/ttfdump
+            Assert.Equal(257, codePoints.Count());
+
+            // Compare with https://fontdrop.info/
+            Assert.Contains(0x0000, codePointValues);
+            Assert.Contains(0x000D, codePointValues);
+            Assert.Contains(0x0020, codePointValues);
+            Assert.Contains(0x0041, codePointValues);
+            Assert.Contains(0x0042, codePointValues);
+            Assert.Contains(0x0061, codePointValues);
+            Assert.Contains(0x0062, codePointValues);
+            Assert.Contains(0xFFFF, codePointValues);
+
+            var glyphIds = codePoints
+                .SelectMany(x => font.GetGlyphs(x, ColorFontSupport.None))
+                .Select(x => x.GlyphMetrics.GlyphId)
+                .ToHashSet();
+
+            // Compare with https://fontdrop.info/
+            Assert.Equal(8, glyphIds.Count);
+        }
+
+        [Fact]
+        public void WoffTest()
+        {
+            var collection = new FontCollection();
+            FontFamily family = collection.Add(TestFonts.SimpleFontFileWoff);
+            Font font = family.CreateFont(12);
+
+            IEnumerable<CodePoint> codePoints = font.GetAvailableCodePoints();
+            IEnumerable<int> codePointValues = codePoints.Select(x => x.Value);
+
+            // Compare with https://everythingfonts.com/ttfdump
+            Assert.Equal(257, codePoints.Count());
+
+            // Compare with https://fontdrop.info/
+            Assert.Contains(0x0000, codePointValues);
+            Assert.Contains(0x000D, codePointValues);
+            Assert.Contains(0x0020, codePointValues);
+            Assert.Contains(0x0041, codePointValues);
+            Assert.Contains(0x0042, codePointValues);
+            Assert.Contains(0x0061, codePointValues);
+            Assert.Contains(0x0062, codePointValues);
+            Assert.Contains(0xFFFF, codePointValues);
+
+            var glyphIds = codePoints
+                .SelectMany(x => font.GetGlyphs(x, ColorFontSupport.None))
+                .Select(x => x.GlyphMetrics.GlyphId)
+                .ToHashSet();
+
+            // Compare with https://fontdrop.info/
+            Assert.Equal(8, glyphIds.Count);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #307

As described in the suggestion, exposing this information can make it easier for users to retrieve some extra information about what code points and glyphs are available in a font and how they are being mapped. Whether or not this is the right strategy to allow these queries is of course up for debate.

Changes:
- Added `GetAvailableCodePoints` function to `Font` type which retrieves all defined code points in that particular font.
- Made `GlyphId` field in `GlyphMetrics` public.

<!-- Thanks for contributing to SixLabors.Fonts! -->
