### PR TITLE
Always ensure the line is at least 1px thick.

### DIFF
--- a/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
+++ b/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14.8" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -205,7 +205,8 @@ namespace SixLabors.Fonts
                 Vector2 tr = new(offset.X + (width * scale.X), offset.Y);
                 Vector2 bl = new(offset.X, offset.Y + (thickness * scale.Y));
 
-                return (tl, tr, bl.Y - tl.Y);
+                // Always ensure the line is at least 1px thick.
+                return (tl, tr, Math.Max(2, bl.Y - tl.Y));
             }
 
             void DrawLine(float thickness, float position)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
At small font sizes text decoration were not rendered as the calculated line thickness would fall under 1px width. This PR ensures a minimum of 1px thickness at all times.

<!-- Thanks for contributing to SixLabors.Fonts! -->
