### PR TITLE
Fix #316 include open type font(otf) in system font collection.

### DIFF
--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -93,7 +93,8 @@ namespace SixLabors.Fonts
                 paths = existingDirectories
                     .SelectMany(x => Directory.EnumerateFiles(x, "*.*", SearchOption.AllDirectories))
                     .Where(x => Path.GetExtension(x).Equals(".ttf", StringComparison.OrdinalIgnoreCase)
-                                || Path.GetExtension(x).Equals(".ttc", StringComparison.OrdinalIgnoreCase));
+                                || Path.GetExtension(x).Equals(".ttc", StringComparison.OrdinalIgnoreCase)
+                                || Path.GetExtension(x).Equals(".otf", StringComparison.OrdinalIgnoreCase));
 
                 this.searchDirectories = existingDirectories;
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)
### Description
<!-- A description of the changes proposed in the pull-request -->
Fix  #316 
Add otf extension to system font collection allowed extension.
This test needs installing font to system font directory so I couldn't provide test case in unit test.

1. install otf font in os system font directory. (e.x Fonts/tests/SixLabors.Fonts.Tests/Fonts/NotoSansKR-Regular.otf)
2. list font by this code.

        [Fact]
        public void SystemFonts_HasOTF()
        {
            IEnumerable<FontFamily> matched = SystemFonts.Collection.Families.Where(x => x.Name == "Noto Sans KR");
            Assert.True(matched.Count() != 0);
        }

<!-- Thanks for contributing to SixLabors.Fonts! -->
