### PR TITLE
Ensure cache access is thread safe and fix calculated glyph bounds

### DIFF
--- a/src/SixLabors.Fonts/GlyphPositioningCollection.cs
+++ b/src/SixLabors.Fonts/GlyphPositioningCollection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -200,7 +201,15 @@ namespace SixLabors.Fonts
                             }
 
                             // Track the number of inserted glyphs at the offset so we can correctly increment our position.
-                            this.glyphs.Insert(i += replacementCount, new(offset, new(shape, true) { Bounds = new(0, 0, metrics[0].AdvanceWidth, metrics[0].AdvanceHeight) }, pointSize, metrics.ToArray()));
+                            ushort maxAdvancedWidth = 0;
+                            ushort maxAdvancedHeight = 0;
+                            for (int k = 0; k < metrics.Count; k++)
+                            {
+                                maxAdvancedWidth = Math.Max(maxAdvancedWidth, metrics[k].AdvanceWidth);
+                                maxAdvancedHeight = Math.Max(maxAdvancedHeight, metrics[k].AdvanceHeight);
+                            }
+
+                            this.glyphs.Insert(i += replacementCount, new(offset, new(shape, true) { Bounds = new(0, 0, maxAdvancedWidth, maxAdvancedHeight) }, pointSize, metrics.ToArray()));
                             replacementCount++;
                         }
                     }

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -30,8 +31,8 @@ namespace SixLabors.Fonts
         private readonly OutlineType outlineType;
 
         // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#font-tables
-        private readonly GlyphMetrics[][] glyphCache;
-        private readonly GlyphMetrics[][]? colorGlyphCache;
+        private readonly ConcurrentDictionary<ushort, GlyphMetrics[]> glyphCache;
+        private readonly ConcurrentDictionary<ushort, GlyphMetrics[]>? colorGlyphCache;
         private readonly FontDescription description;
         private ushort unitsPerEm;
         private float scaleFactor;
@@ -64,10 +65,10 @@ namespace SixLabors.Fonts
             this.trueTypeFontTables = tables;
             this.outlineType = OutlineType.TrueType;
             this.description = new FontDescription(tables.Name, tables.Os2, tables.Head);
-            this.glyphCache = new GlyphMetrics[tables.Glyf.GlyphCount][];
+            this.glyphCache = new();
             if (tables.Colr is not null)
             {
-                this.colorGlyphCache = new GlyphMetrics[tables.Glyf.GlyphCount][];
+                this.colorGlyphCache = new();
             }
 
             this.Initialize(tables);
@@ -82,10 +83,10 @@ namespace SixLabors.Fonts
             this.compactFontTables = tables;
             this.outlineType = OutlineType.CFF;
             this.description = new FontDescription(tables.Name, tables.Os2, tables.Head);
-            this.glyphCache = new GlyphMetrics[tables.Cff.GlyphCount][];
+            this.glyphCache = new();
             if (tables.Colr is not null)
             {
-                this.colorGlyphCache = new GlyphMetrics[tables.Cff.GlyphCount][];
+                this.colorGlyphCache = new();
             }
 
             this.Initialize(tables);
@@ -220,19 +221,15 @@ namespace SixLabors.Fonts
             }
 
             // We overwrite the cache entry for this type should the attributes change.
-            GlyphMetrics[]? cached = this.glyphCache[glyphId];
-            if (cached is null)
-            {
-                this.glyphCache[glyphId] = new[]
+            return this.glyphCache.GetOrAdd(
+                glyphId,
+                id => new[]
                 {
                     this.CreateGlyphMetrics(
                     codePoint,
-                    glyphId,
+                    id,
                     glyphType)
-                };
-            }
-
-            return this.glyphCache[glyphId];
+                });
         }
 
         /// <inheritdoc/>
@@ -450,25 +447,23 @@ namespace SixLabors.Fonts
                 return false;
             }
 
-            // We overwrite the cache entry for this type should the attributes change.
-            metrics = this.colorGlyphCache[glyphId];
-            if (metrics is null)
+            // We overwrite the cache entry for this type should the attributes change
+            metrics = this.colorGlyphCache.GetOrAdd(glyphId, id =>
             {
-                Span<LayerRecord> indexes = colr.GetLayers(glyphId);
+                GlyphMetrics[] m = Array.Empty<GlyphMetrics>();
+                Span<LayerRecord> indexes = colr.GetLayers(id);
                 if (indexes.Length > 0)
                 {
-                    metrics = new GlyphMetrics[indexes.Length];
+                    m = new GlyphMetrics[indexes.Length];
                     for (int i = 0; i < indexes.Length; i++)
                     {
-                        LayerRecord? layer = indexes[i];
-
-                        metrics[i] = this.CreateGlyphMetrics(codePoint, layer.GlyphId, GlyphType.ColrLayer, layer.PaletteIndex);
+                        LayerRecord layer = indexes[i];
+                        m[i] = this.CreateGlyphMetrics(codePoint, layer.GlyphId, GlyphType.ColrLayer, layer.PaletteIndex);
                     }
                 }
 
-                metrics ??= Array.Empty<GlyphMetrics>();
-                this.colorGlyphCache[glyphId] = metrics;
-            }
+                return m;
+            });
 
             return metrics.Length > 0;
         }

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -894,15 +894,18 @@ namespace SixLabors.Fonts
                     float ascender = metric.FontMetrics.Ascender * scaleY;
 
                     // Adjust ascender for glyphs with a negative tsb. e.g. emoji to prevent cutoff.
-                    short tsbOffset = 0;
-                    for (int i = 0; i < metrics.Count; i++)
+                    if (!CodePoint.IsWhiteSpace(codePoint))
                     {
-                        tsbOffset = Math.Min(tsbOffset, metrics[i].TopSideBearing);
-                    }
+                        short tsbOffset = 0;
+                        for (int i = 0; i < metrics.Count; i++)
+                        {
+                            tsbOffset = Math.Min(tsbOffset, metrics[i].TopSideBearing);
+                        }
 
-                    if (tsbOffset < 0)
-                    {
-                        ascender -= tsbOffset * scaleY;
+                        if (tsbOffset < 0)
+                        {
+                            ascender -= tsbOffset * scaleY;
+                        }
                     }
 
                     float descender = Math.Abs(metric.FontMetrics.Descender * scaleY);

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -302,7 +302,7 @@ namespace SixLabors.Fonts.Tests
             });
         }
 
+#endif
         private CodePoint AsCodePoint(string text) => CodePoint.DecodeFromUtf16At(text.AsSpan(), 0);
     }
-#endif
 }

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Threading.Tasks;
 using Moq;
 using SixLabors.Fonts.Tables.TrueType;
 using SixLabors.Fonts.Tables.TrueType.Glyphs;
@@ -280,6 +281,28 @@ namespace SixLabors.Fonts.Tests
         }
 #endif
 
+#if OS_WINDOWS
+        [Theory]
+        [InlineData("Arial")]
+        [InlineData("Segoe UI Emoji")]
+        public void RendererIsThreadsafe(string fontName)
+        {
+            const int threadCount = 10;
+            Parallel.For(0, threadCount, _ =>
+            {
+                ColorGlyphRenderer renderer1 = new();
+                TextRenderer.RenderTextTo(renderer1, "A 🙂 ", new TextOptions(SystemFonts.CreateFont(fontName, 15)));
+
+                ColorGlyphRenderer renderer2 = new();
+                TextRenderer.RenderTextTo(renderer2, "A 🙂 ", new TextOptions(SystemFonts.CreateFont(fontName, 15)));
+
+                Assert.True(renderer1.ControlPoints.Count > 0);
+                Assert.True(renderer2.ControlPoints.Count > 0);
+                Assert.True(renderer1.ControlPoints.SequenceEqual(renderer2.ControlPoints));
+            });
+        }
+
         private CodePoint AsCodePoint(string text) => CodePoint.DecodeFromUtf16At(text.AsSpan(), 0);
     }
+#endif
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #321 

<!-- Thanks for contributing to SixLabors.Fonts! -->
