### PR TITLE
Fix rendering font size and overline position.

### DIFF
--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -297,13 +297,7 @@ namespace SixLabors.Fonts
                 }
             }
 
-            // There's no built in metrics for these values so we will need to infer them from the other metrics.
-            float overlineThickness = this.FontMetrics.UnderlineThickness;
-
-            // TODO: Check this. Segoe UI glyphs live outside the metrics so the overline covers the glyph.
-            float overlinePosition = this.FontMetrics.Ascender - (overlineThickness * .5F);
-
-            // Allow the renderer to override the decorations to attach
+            // Allow the renderer to override the decorations to attach.
             TextDecorations decorations = renderer.EnabledDecorations();
             if ((decorations & TextDecorations.Underline) == TextDecorations.Underline)
             {
@@ -317,7 +311,9 @@ namespace SixLabors.Fonts
 
             if ((decorations & TextDecorations.Overline) == TextDecorations.Overline)
             {
-                SetDecoration(TextDecorations.Overline, overlineThickness, overlinePosition);
+                // There's no built in metrics for overline thickness so use underline.
+                // CSS uses the ascender as the position.
+                SetDecoration(TextDecorations.Overline, this.FontMetrics.UnderlineThickness, this.FontMetrics.Ascender);
             }
         }
 

--- a/src/SixLabors.Fonts/Tables/Cff/CffGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/Tables/Cff/CffGlyphMetrics.cs
@@ -106,7 +106,7 @@ namespace SixLabors.Fonts.Tables.Cff
                 return;
             }
 
-            float pointSize = options.Font.Size;
+            float pointSize = this.TextRun.Font?.Size ?? options.Font.Size;
             float dpi = options.Dpi;
             location *= dpi;
             float scaledPPEM = this.GetScaledSize(pointSize, dpi);

--- a/src/SixLabors.Fonts/Tables/TrueType/TrueTypeGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/Tables/TrueType/TrueTypeGlyphMetrics.cs
@@ -113,7 +113,7 @@ namespace SixLabors.Fonts.Tables.TrueType
                 return;
             }
 
-            float pointSize = options.Font.Size;
+            float pointSize = this.TextRun.Font?.Size ?? options.Font.Size;
             float dpi = options.Dpi;
             location *= dpi;
             float scaledPPEM = this.GetScaledSize(pointSize, dpi);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes a regression where the current run font size was not being used for rendering. Also fixed overline position to match CSS

<!-- Thanks for contributing to SixLabors.Fonts! -->
