### PR TITLE
Fix vertical metric calculations and layout.

### DIFF
--- a/src/SixLabors.Fonts/Bounds.cs
+++ b/src/SixLabors.Fonts/Bounds.cs
@@ -27,7 +27,7 @@ namespace SixLabors.Fonts
 
         public static bool operator !=(Bounds left, Bounds right) => !(left == right);
 
-        public Vector2 Size() => new(this.Max.X - this.Min.X, this.Max.Y - this.Min.Y);
+        public Vector2 Size() => this.Max - this.Min;
 
         public static Bounds Load(BigEndianBinaryReader reader)
         {

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -36,9 +36,10 @@ namespace SixLabors.Fonts
         /// Renders the glyph to the render surface relative to a top left origin.
         /// </summary>
         /// <param name="surface">The surface.</param>
-        /// <param name="location">The location.</param>
+        /// <param name="location">The location to render the glyph at.</param>
+        /// <param name="offset">The offset of the glyph vector relative to the top-left position of the glyph advance.</param>
         /// <param name="options">The options to render using.</param>
-        internal void RenderTo(IGlyphRenderer surface, Vector2 location, TextOptions options)
-            => this.GlyphMetrics.RenderTo(surface, location, options);
+        internal void RenderTo(IGlyphRenderer surface, Vector2 location, Vector2 offset, TextOptions options)
+            => this.GlyphMetrics.RenderTo(surface, location, offset, options);
     }
 }

--- a/src/SixLabors.Fonts/GlyphLayout.cs
+++ b/src/SixLabors.Fonts/GlyphLayout.cs
@@ -15,6 +15,7 @@ namespace SixLabors.Fonts
         internal GlyphLayout(
             Glyph glyph,
             Vector2 location,
+            Vector2 offset,
             float ascender,
             float descender,
             float linegap,
@@ -27,6 +28,7 @@ namespace SixLabors.Fonts
             this.Glyph = glyph;
             this.CodePoint = glyph.GlyphMetrics.CodePoint;
             this.Location = location;
+            this.Offset = offset;
             this.Ascender = ascender;
             this.Descender = descender;
             this.LineGap = linegap;
@@ -48,9 +50,15 @@ namespace SixLabors.Fonts
         public CodePoint CodePoint { get; }
 
         /// <summary>
-        /// Gets the location.
+        /// Gets the location to render the glyph at.
         /// </summary>
         public Vector2 Location { get; }
+
+        /// <summary>
+        /// Gets the offset of the glyph vector relative to the top-left position of the glyph advance.
+        /// For horizontal layout this will always be <see cref="Vector2.Zero"/>.
+        /// </summary>
+        public Vector2 Offset { get; }
 
         /// <summary>
         /// Gets the ascender

--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -271,7 +271,7 @@ namespace SixLabors.Fonts
         internal void RenderDecorationsTo(IGlyphRenderer renderer, Vector2 location, LayoutMode layoutMode, bool rotated, Matrix3x2 transform, float scaledPPEM)
         {
             bool isVerticalLayout = layoutMode.IsVertical() || layoutMode.IsVerticalMixed();
-            bool ishorizontalGlyph = layoutMode.IsHorizontal() || rotated;
+            bool isHorizontalGlyph = layoutMode.IsHorizontal() || rotated;
             (Vector2 Start, Vector2 End, float Thickness) GetEnds(TextDecorations decorations, float thickness, float decoratorPosition)
             {
                 // For vertical layout we need to draw a vertical line.
@@ -353,18 +353,18 @@ namespace SixLabors.Fonts
             TextDecorations decorations = renderer.EnabledDecorations();
             if ((decorations & TextDecorations.Underline) == TextDecorations.Underline)
             {
-                SetDecoration(TextDecorations.Underline, this.FontMetrics.UnderlineThickness, ishorizontalGlyph ? this.FontMetrics.UnderlinePosition : 0);
+                SetDecoration(TextDecorations.Underline, this.FontMetrics.UnderlineThickness, isHorizontalGlyph ? this.FontMetrics.UnderlinePosition : 0);
             }
 
             if ((decorations & TextDecorations.Strikeout) == TextDecorations.Strikeout)
             {
-                SetDecoration(TextDecorations.Strikeout, this.FontMetrics.StrikeoutSize, ishorizontalGlyph ? this.FontMetrics.StrikeoutPosition : this.FontMetrics.UnitsPerEm * .5F);
+                SetDecoration(TextDecorations.Strikeout, this.FontMetrics.StrikeoutSize, isHorizontalGlyph ? this.FontMetrics.StrikeoutPosition : this.FontMetrics.UnitsPerEm * .5F);
             }
 
             if ((decorations & TextDecorations.Overline) == TextDecorations.Overline)
             {
                 // There's no built in metrics for overline thickness so use underline.
-                SetDecoration(TextDecorations.Overline, this.FontMetrics.UnderlineThickness, ishorizontalGlyph ? this.FontMetrics.HorizontalMetrics.Ascender : this.FontMetrics.UnitsPerEm);
+                SetDecoration(TextDecorations.Overline, this.FontMetrics.UnderlineThickness, isHorizontalGlyph ? this.FontMetrics.HorizontalMetrics.Ascender : this.FontMetrics.UnitsPerEm);
             }
         }
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/AdvancedTypographicUtils.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/AdvancedTypographicUtils.cs
@@ -28,7 +28,12 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic
         /// <returns>The <see cref="bool"/>.</returns>
         public static bool IsVerticalGlyph(CodePoint codePoint, LayoutMode layoutMode)
         {
-            bool isVerticalLayout = layoutMode.IsVertical() || layoutMode.IsVerticalMixed();
+            if (layoutMode.IsVertical())
+            {
+                return true;
+            }
+
+            bool isVerticalLayout = layoutMode.IsVerticalMixed();
             return isVerticalLayout && CodePoint.GetVerticalOrientationType(codePoint) is VerticalOrientationType.Upright or VerticalOrientationType.TransformUpright;
         }
 

--- a/src/SixLabors.Fonts/Tables/Cff/CffEvaluationEngine.cs
+++ b/src/SixLabors.Fonts/Tables/Cff/CffEvaluationEngine.cs
@@ -70,6 +70,8 @@ namespace SixLabors.Fonts.Tables.Cff
             this.transforming = new(finder, Vector2.Zero, new Vector2(1, -1), Vector2.Zero, Matrix3x2.Identity);
 
             // Boolean IGlyphRenderer.BeginGlyph(..) is handled by the caller.
+            this.transforming.BeginFigure();
+
             this.Parse(this.charStrings);
 
             // Some CFF end without closing the latest contour.
@@ -88,6 +90,8 @@ namespace SixLabors.Fonts.Tables.Cff
             this.transforming = new(renderer, origin, scale, offset, transform);
 
             // Boolean IGlyphRenderer.BeginGlyph(..) is handled by the caller.
+            this.transforming.BeginFigure();
+
             this.Parse(this.charStrings);
 
             // Some CFF end without closing the latest contour.
@@ -207,6 +211,11 @@ namespace SixLabors.Fonts.Tables.Cff
                             if (this.stack.Length > 0)
                             {
                                 this.CheckWidth();
+                            }
+
+                            if (this.transforming.IsOpen)
+                            {
+                                this.transforming.EndFigure();
                             }
 
                             endCharEncountered = true;

--- a/src/SixLabors.Fonts/Tables/Cff/TransformingGlyphRenderer.cs
+++ b/src/SixLabors.Fonts/Tables/Cff/TransformingGlyphRenderer.cs
@@ -80,6 +80,7 @@ namespace SixLabors.Fonts.Tables.Cff
             }
 
             this.renderer.MoveTo(this.Transform(point));
+            this.IsOpen = true;
         }
 
         public void CubicBezierTo(Vector2 secondControlPoint, Vector2 thirdControlPoint, Vector2 point)

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -402,6 +402,7 @@ namespace SixLabors.Fonts
                     glyphs.Add(new GlyphLayout(
                         new Glyph(metric, data.PointSize),
                         location,
+                        Vector2.Zero,
                         scaledMaxAscender,
                         scaledMaxDescender,
                         scaledMaxLineGap,
@@ -438,9 +439,6 @@ namespace SixLabors.Fonts
             float offsetX = 0;
 
             // Set the Y-Origin for the line.
-            float scaledMaxLineGap = textBox.ScaledMaxLineGap(textLine.MaxPointSize);
-            float scaledMaxAscender = textBox.ScaledMaxAscender(textLine.MaxPointSize);
-            float scaledMaxDescender = textBox.ScaledMaxDescender(textLine.MaxPointSize);
             float scaledMaxLineHeight = textBox.ScaledMaxLineHeight(textLine.MaxPointSize);
 
             switch (options.VerticalAlignment)
@@ -546,14 +544,15 @@ namespace SixLabors.Fonts
                         advanceY = (metric.TopSideBearing + metric.Height + metric.BottomSideBearing) * scale.Y;
                     }
 
-                    // Center the glyph horizontally.
-                    // The last glyph of the text line needs to trim the line height.
+                    // Align the glyph horizontally and vertically.
+                    Vector2 offset = new((xWidth - (metric.AdvanceWidth * scale.X)) * .5F, (metric.Bounds.Max.Y + metric.TopSideBearing) * scale.Y);
                     glyphs.Add(new GlyphLayout(
                         new Glyph(metric, data.PointSize),
-                        location + new Vector2((xWidth - (metric.AdvanceWidth * scale.X)) * .5F, data.ScaledAscender),
-                        scaledMaxAscender,
-                        scaledMaxDescender,
-                        scaledMaxLineGap,
+                        location,
+                        offset,
+                        data.ScaledAscender,
+                        data.ScaledDescender,
+                        data.ScaledLineGap,
                         scaledMaxLineHeight,
                         advanceX,
                         advanceY,
@@ -561,7 +560,7 @@ namespace SixLabors.Fonts
                         i == 0));
                 }
 
-                location.Y += data.ScaledAdvance - offsetY;
+                location.Y += data.ScaledAdvance;
             }
 
             location.Y = originY;
@@ -587,9 +586,6 @@ namespace SixLabors.Fonts
             float offsetX = 0;
 
             // Set the Y-Origin for the line.
-            float scaledMaxLineGap = textBox.ScaledMaxLineGap(textLine.MaxPointSize);
-            float scaledMaxAscender = textBox.ScaledMaxAscender(textLine.MaxPointSize);
-            float scaledMaxDescender = textBox.ScaledMaxDescender(textLine.MaxPointSize);
             float scaledMaxLineHeight = textBox.ScaledMaxLineHeight(textLine.MaxPointSize);
 
             switch (options.VerticalAlignment)
@@ -698,12 +694,14 @@ namespace SixLabors.Fonts
                         }
 
                         // Shift the rotated text horizontally to counter rotation
+                        Vector2 offset = new(data.ScaledDescender, 0);
                         glyphs.Add(new GlyphLayout(
                             new Glyph(metric, data.PointSize),
-                            location + new Vector2(data.ScaledDescender, 0),
+                            location,
+                            offset,
                             metric.LeftSideBearing * scale.X, // TODO: Check this calculation.
                             metric.RightSideBearing * scale.X,
-                            scaledMaxLineGap,
+                            data.ScaledLineGap,
                             data.ScaledAdvance,
                             advanceX,
                             advanceY,
@@ -730,14 +728,15 @@ namespace SixLabors.Fonts
                             advanceY = (metric.TopSideBearing + metric.Height + metric.BottomSideBearing) * scale.Y;
                         }
 
-                        // Center the glyph horizontally.
-                        // The last glyph of the text line needs to trim the line height.
+                        // Align the glyph horizontally and vertically.
+                        Vector2 offset = new((xWidth - (metric.AdvanceWidth * scale.X)) * .5F, (metric.Bounds.Max.Y + metric.TopSideBearing) * scale.Y);
                         glyphs.Add(new GlyphLayout(
                             new Glyph(metric, data.PointSize),
-                            location + new Vector2((xWidth - (metric.AdvanceWidth * scale.X)) * .5F, data.ScaledAscender),
-                            scaledMaxAscender,
-                            scaledMaxDescender,
-                            scaledMaxLineGap,
+                            location,
+                            offset,
+                            data.ScaledAscender,
+                            data.ScaledDescender,
+                            data.ScaledLineGap,
                             data.ScaledLineHeight,
                             advanceX,
                             advanceY,
@@ -1127,6 +1126,7 @@ namespace SixLabors.Fonts
                     float ascender = metricsHeader.Ascender * scaleY;
 
                     // Adjust ascender for glyphs with a negative tsb. e.g. emoji to prevent cutoff.
+                    // TODO: Remove this hack.
                     if (!CodePoint.IsWhiteSpace(codePoint))
                     {
                         short tsbOffset = 0;

--- a/src/SixLabors.Fonts/TextRenderer.cs
+++ b/src/SixLabors.Fonts/TextRenderer.cs
@@ -59,7 +59,7 @@ namespace SixLabors.Fonts
 
             foreach (GlyphLayout g in glyphsToRender)
             {
-                g.Glyph.RenderTo(this.renderer, g.Location, options);
+                g.Glyph.RenderTo(this.renderer, g.Location, g.Offset, options);
             }
 
             this.renderer.EndText();

--- a/tests/SixLabors.Fonts.Tests/FakeFont.cs
+++ b/tests/SixLabors.Fonts.Tests/FakeFont.cs
@@ -20,11 +20,11 @@ namespace SixLabors.Fonts.Tests
             Assert.Equal(12, metrics.HorizontalMetrics.LineGap);
             Assert.Equal(35 - 8 + 12, metrics.HorizontalMetrics.LineHeight);
 
-            // Vertical metrics should be the same as the horizontal.
-            Assert.Equal(35, metrics.VerticalMetrics.Ascender);
-            Assert.Equal(8, metrics.VerticalMetrics.Descender);
-            Assert.Equal(12, metrics.VerticalMetrics.LineGap);
-            Assert.Equal(35 - 8 + 12, metrics.VerticalMetrics.LineHeight);
+            // Vertical metrics are all ones. Descender is always negative due to the grid orientation.
+            Assert.Equal(1, metrics.VerticalMetrics.Ascender);
+            Assert.Equal(-1, metrics.VerticalMetrics.Descender);
+            Assert.Equal(1, metrics.VerticalMetrics.LineGap);
+            Assert.Equal(1 - (-1) + 1, metrics.VerticalMetrics.LineHeight);
         }
 
         public static Font CreateFont(string text, string name = "name")

--- a/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
+++ b/tests/SixLabors.Fonts.Tests/Fakes/FakeFontInstance.cs
@@ -102,8 +102,8 @@ namespace SixLabors.Fonts.Tests.Fakes
             => new(
                 new[]
                 {
-                    new Fonts.Tables.General.Name.NameRecord(WellKnownIds.PlatformIDs.Windows, 0, WellKnownIds.KnownNameIds.FullFontName, name),
-                    new Fonts.Tables.General.Name.NameRecord(WellKnownIds.PlatformIDs.Windows, 0, WellKnownIds.KnownNameIds.FontFamilyName, name)
+                    new NameRecord(WellKnownIds.PlatformIDs.Windows, 0, WellKnownIds.KnownNameIds.FullFontName, name),
+                    new NameRecord(WellKnownIds.PlatformIDs.Windows, 0, WellKnownIds.KnownNameIds.FontFamilyName, name)
                 },
                 Array.Empty<string>());
 

--- a/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
@@ -52,7 +52,7 @@ namespace SixLabors.Fonts.Tests
 
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
 
             Assert.Equal(37, r.ControlPoints.Count);
             Assert.Single(r.GlyphKeys);
@@ -67,7 +67,7 @@ namespace SixLabors.Fonts.Tests
             Assert.True(font.TryGetGlyphs(new CodePoint('A'), ColorFontSupport.None, out IReadOnlyList<Glyph> glyphs));
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
 
             Assert.Equal(37, r.ControlPoints.Count);
             Assert.Single(r.GlyphKeys);
@@ -101,7 +101,7 @@ namespace SixLabors.Fonts.Tests
             Assert.True(font.TryGetGlyphs(new CodePoint('A'), ColorFontSupport.None, out IReadOnlyList<Glyph> glyphs));
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
 
             Assert.Equal(37, r.ControlPoints.Count);
             Assert.Single(r.GlyphKeys);
@@ -120,7 +120,7 @@ namespace SixLabors.Fonts.Tests
             Assert.True(font.TryGetGlyphs(new CodePoint('a'), ColorFontSupport.None, out IReadOnlyList<Glyph> glyphs));
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
 
             // the test font only has characters .notdef, 'a' & 'b' defined
             Assert.Equal(6, r.ControlPoints.Distinct().Count());
@@ -137,7 +137,7 @@ namespace SixLabors.Fonts.Tests
             Assert.True(font.TryGetGlyphs(new CodePoint('a'), ColorFontSupport.None, out IReadOnlyList<Glyph> glyphs));
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
 
             // the test font only has characters .notdef, 'a' & 'b' defined
             Assert.Equal(6, r.ControlPoints.Distinct().Count());

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -50,7 +50,7 @@ namespace SixLabors.Fonts.Tests
             Glyph glyph = new(glyphMetrics.CloneForRendering(textRun), font.Size);
 
             Vector2 locationInFontSpace = new Vector2(99, 99) / 72; // glyph ends up 10px over due to offset in fake glyph
-            glyph.RenderTo(this.renderer, locationInFontSpace, new TextOptions(font));
+            glyph.RenderTo(this.renderer, locationInFontSpace, Vector2.Zero, new TextOptions(font));
 
             Assert.Equal(new FontRectangle(99, 89, 0, 0), this.renderer.GlyphRects.Single());
         }

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -246,9 +246,9 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Theory]
-        [InlineData("hello world", 310, 30)]
-        [InlineData("hello world hello world hello world", 310, 90)]
-        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 160)]
+        [InlineData("hello world", 310, 10)]
+        [InlineData("hello world hello world hello world", 310, 16)]
+        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 25)]
         public void MeasureTextWordWrappingVerticalLeftRight(string text, float height, float width)
         {
             Font font = CreateFont(text);
@@ -264,9 +264,9 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Theory]
-        [InlineData("hello world", 310, 30)]
-        [InlineData("hello world hello world hello world", 310, 90)]
-        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 160)]
+        [InlineData("hello world", 310, 10)]
+        [InlineData("hello world hello world hello world", 310, 16)]
+        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 25)]
         public void MeasureTextWordWrappingVerticalRightLeft(string text, float height, float width)
         {
             Font font = CreateFont(text);
@@ -284,7 +284,7 @@ namespace SixLabors.Fonts.Tests
         [Theory]
         [InlineData("hello world", 290, 10)] // 310 - 20 due to negative result of x-axis on rotation.
         [InlineData("hello world hello world hello world", 290, 70)] // 310 - 20 due to negative result of x-axis on rotation.
-        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 160)]
+        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 25)]
         public void MeasureTextWordWrappingVerticalMixedLeftRight(string text, float height, float width)
         {
             Font font = CreateFont(text);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

While working on the updates to Drawing to allow rendering of vertically rotated fonts I discovered that we were still not rendering vertical fonts correctly for all fonts nor correctly placing the decorations. 

This PR fixes both the metrics calculation and the layout. Prior iterations incorrectly negatively vertically offset the Hangul font NotoSansKR-Regular.otf.

![CanDrawTextVerticalMixed_Rgba32_Blank500x400](https://user-images.githubusercontent.com/385879/235356358-c9b0cac1-963d-4528-b69b-59166dd44d48.png)

![CanDrawTextVertical_Rgba32_Blank500x400](https://user-images.githubusercontent.com/385879/235356407-4beda866-1092-4ff3-93d3-60f236d76ce5.png)

<!-- Thanks for contributing to SixLabors.Fonts! -->
