### PR TITLE
Rewrite Text Layout Engine

### DIFF
--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -209,7 +209,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
 
         public static void RenderText(RichTextOptions options, string text)
         {
-            FontRectangle size = TextMeasurer.Measure(text, options);
+            FontRectangle size = TextMeasurer.MeasureSize(text, options);
             if (size == FontRectangle.Empty)
             {
                 return;
@@ -250,7 +250,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                 textOptions.FallbackFontFamilies = fallbackFonts.ToArray();
             }
 
-            FontRectangle textSize = TextMeasurer.Measure(text, textOptions);
+            FontRectangle textSize = TextMeasurer.MeasureSize(text, textOptions);
             textOptions.Origin = new PointF(5, 5);
 
             using var img = new Image<Rgba32>((int)Math.Ceiling(textSize.Width) + 20, (int)Math.Ceiling(textSize.Height) + 20);
@@ -284,7 +284,7 @@ namespace SixLabors.Fonts.DrawWithImageSharp
                         textOptions.FallbackFontFamilies = fallbackFonts.ToArray();
                     }
 
-                    FontRectangle textSize = TextMeasurer.Measure(text, textOptions);
+                    FontRectangle textSize = TextMeasurer.MeasureSize(text, textOptions);
                     using var img = new Image<Rgba32>(((int)textSize.Width * 2) + 20, ((int)textSize.Height * 2) + 20);
                     Size size = img.Size();
                     textOptions.Origin = new PointF(size.Width / 2F, size.Height / 2F);

--- a/src/SixLabors.Fonts/Bounds.cs
+++ b/src/SixLabors.Fonts/Bounds.cs
@@ -8,6 +8,8 @@ namespace SixLabors.Fonts
 {
     internal readonly struct Bounds : IEquatable<Bounds>
     {
+        public static Bounds Empty = default;
+
         public Bounds(Vector2 min, Vector2 max)
         {
             this.Min = Vector2.Min(min, max);

--- a/src/SixLabors.Fonts/FontFamily.cs
+++ b/src/SixLabors.Fonts/FontFamily.cs
@@ -155,7 +155,7 @@ namespace SixLabors.Fonts
         /// <see langword="true"/> if the <see cref="FontFamily"/> contains font metrics
         /// with the specified name; otherwise, <see langword="false"/>.
         /// </returns>
-        internal bool TryGetMetrics(FontStyle style, [NotNullWhen(true)] out FontMetrics? metrics)
+        public bool TryGetMetrics(FontStyle style, [NotNullWhen(true)] out FontMetrics? metrics)
         {
             if (this == default)
             {

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -26,11 +26,12 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Calculates the bounding box.
         /// </summary>
+        /// <param name="mode">The glyph layout mode to measure using.</param>
         /// <param name="location">The location to calculate from.</param>
-        /// <param name="dpi">The DPI (Dots Per Inch) to render/measure the glyph at.</param>
+        /// <param name="dpi">The DPI (Dots Per Inch) to measure the glyph at.</param>
         /// <returns>The bounding box</returns>
-        public FontRectangle BoundingBox(Vector2 location, float dpi)
-            => this.GlyphMetrics.GetBoundingBox(location, this.pointSize * dpi);
+        public FontRectangle BoundingBox(GlyphLayoutMode mode, Vector2 location, float dpi)
+            => this.GlyphMetrics.GetBoundingBox(mode, location, this.pointSize * dpi);
 
         /// <summary>
         /// Renders the glyph to the render surface relative to a top left origin.
@@ -38,8 +39,9 @@ namespace SixLabors.Fonts
         /// <param name="surface">The surface.</param>
         /// <param name="location">The location to render the glyph at.</param>
         /// <param name="offset">The offset of the glyph vector relative to the top-left position of the glyph advance.</param>
+        /// <param name="mode">The glyph layout mode to render using.</param>
         /// <param name="options">The options to render using.</param>
-        internal void RenderTo(IGlyphRenderer surface, Vector2 location, Vector2 offset, TextOptions options)
-            => this.GlyphMetrics.RenderTo(surface, location, offset, options);
+        internal void RenderTo(IGlyphRenderer surface, Vector2 location, Vector2 offset, GlyphLayoutMode mode, TextOptions options)
+            => this.GlyphMetrics.RenderTo(surface, location, offset, mode, options);
     }
 }

--- a/src/SixLabors.Fonts/GlyphLayout.cs
+++ b/src/SixLabors.Fonts/GlyphLayout.cs
@@ -13,7 +13,8 @@ namespace SixLabors.Fonts
     {
         internal GlyphLayout(
             Glyph glyph,
-            Vector2 location,
+            Vector2 boxLocation,
+            Vector2 penLocation,
             Vector2 offset,
             float advanceWidth,
             float advanceHeight,
@@ -22,7 +23,8 @@ namespace SixLabors.Fonts
         {
             this.Glyph = glyph;
             this.CodePoint = glyph.GlyphMetrics.CodePoint;
-            this.Location = location;
+            this.BoxLocation = boxLocation;
+            this.PenLocation = penLocation;
             this.Offset = offset;
             this.AdvanceX = advanceWidth;
             this.AdvanceY = advanceHeight;
@@ -41,9 +43,14 @@ namespace SixLabors.Fonts
         public CodePoint CodePoint { get; }
 
         /// <summary>
+        /// Gets the location of the glyph box.
+        /// </summary>
+        public Vector2 BoxLocation { get; }
+
+        /// <summary>
         /// Gets the location to render the glyph at.
         /// </summary>
-        public Vector2 Location { get; }
+        public Vector2 PenLocation { get; }
 
         /// <summary>
         /// Gets the offset of the glyph vector relative to the top-left position of the glyph advance.
@@ -79,7 +86,7 @@ namespace SixLabors.Fonts
 
         internal FontRectangle BoundingBox(float dpi)
         {
-            Vector2 origin = (this.Location + this.Offset) * dpi;
+            Vector2 origin = (this.PenLocation + this.Offset) * dpi;
             FontRectangle box = this.Glyph.BoundingBox(this.LayoutMode, Vector2.Zero, dpi);
 
             if (this.IsWhiteSpace())
@@ -123,7 +130,7 @@ namespace SixLabors.Fonts
         {
             string s = this.IsStartOfLine ? "@ " : string.Empty;
             string ws = this.IsWhiteSpace() ? "!" : string.Empty;
-            Vector2 l = this.Location;
+            Vector2 l = this.PenLocation;
             return $"{s}{ws}{this.CodePoint.ToDebuggerDisplay()} {l.X},{l.Y} {this.AdvanceX}x{this.AdvanceY}";
         }
     }

--- a/src/SixLabors.Fonts/GlyphLayout.cs
+++ b/src/SixLabors.Fonts/GlyphLayout.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
 using System.Numerics;
 using SixLabors.Fonts.Unicode;
 
@@ -16,12 +15,8 @@ namespace SixLabors.Fonts
             Glyph glyph,
             Vector2 location,
             Vector2 offset,
-            float ascender,
-            float descender,
-            float linegap,
-            float lineHeight,
-            float width,
-            float height,
+            float advanceWidth,
+            float advanceHeight,
             GlyphLayoutMode layoutMode,
             bool isStartOfLine)
         {
@@ -29,12 +24,8 @@ namespace SixLabors.Fonts
             this.CodePoint = glyph.GlyphMetrics.CodePoint;
             this.Location = location;
             this.Offset = offset;
-            this.Ascender = ascender;
-            this.Descender = descender;
-            this.LineGap = linegap;
-            this.LineHeight = lineHeight;
-            this.Width = width;
-            this.Height = height;
+            this.AdvanceX = advanceWidth;
+            this.AdvanceY = advanceHeight;
             this.LayoutMode = layoutMode;
             this.IsStartOfLine = isStartOfLine;
         }
@@ -61,35 +52,18 @@ namespace SixLabors.Fonts
         public Vector2 Offset { get; }
 
         /// <summary>
-        /// Gets the ascender
-        /// </summary>
-        public float Ascender { get; }
-
-        /// <summary>
-        /// Gets the ascender
-        /// </summary>
-        public float Descender { get; }
-
-        /// <summary>
-        /// Gets the lie gap
-        /// </summary>
-        public float LineGap { get; }
-
-        /// <summary>
-        /// Gets the line height of the glyph.
-        /// </summary>
-        public float LineHeight { get; }
-
-        /// <summary>
         /// Gets the width.
         /// </summary>
-        public float Width { get; }
+        public float AdvanceX { get; }
 
         /// <summary>
         /// Gets the height.
         /// </summary>
-        public float Height { get; }
+        public float AdvanceY { get; }
 
+        /// <summary>
+        /// Gets the glyph layout mode.
+        /// </summary>
         public GlyphLayoutMode LayoutMode { get; }
 
         /// <summary>
@@ -105,21 +79,43 @@ namespace SixLabors.Fonts
 
         internal FontRectangle BoundingBox(float dpi)
         {
-            Vector2 origin = this.Location * dpi;
-            FontRectangle box = this.Glyph.BoundingBox(Vector2.Zero, dpi);
+            Vector2 origin = (this.Location + this.Offset) * dpi;
+            FontRectangle box = this.Glyph.BoundingBox(this.LayoutMode, Vector2.Zero, dpi);
+
             if (this.IsWhiteSpace())
             {
-                box = new FontRectangle(box.X, box.Y, this.Width * dpi, box.Height);
+                // Take the layout advance width/height to account for advance multipliers that can cause
+                // the glyph to extend beyond the box. For example '\t'.
+                if (this.LayoutMode == GlyphLayoutMode.Vertical)
+                {
+                    return new FontRectangle(
+                        box.X + origin.X,
+                        box.Y + origin.Y,
+                        box.Width,
+                        this.AdvanceY * dpi);
+                }
+
+                if (this.LayoutMode == GlyphLayoutMode.VerticalRotated)
+                {
+                    return new FontRectangle(
+                        box.X + origin.X,
+                        box.Y + origin.Y,
+                        0,
+                        this.AdvanceY * dpi);
+                }
+
+                return new FontRectangle(
+                    box.X + origin.X,
+                    box.Y + origin.Y,
+                    this.AdvanceX * dpi,
+                    box.Height);
             }
 
-            // Rotate 90 degrees clockwise if required.
-            if (this.LayoutMode == GlyphLayoutMode.VerticalRotated)
-            {
-                box = FontRectangle.Transform(in box, Matrix3x2.CreateRotation(-MathF.PI / 2F));
-            }
-
-            box = new FontRectangle(box.X + origin.X, box.Y + origin.Y, box.Width, box.Height);
-            return box;
+            return new FontRectangle(
+                box.X + origin.X,
+                box.Y + origin.Y,
+                box.Width,
+                box.Height);
         }
 
         /// <inheritdoc/>
@@ -128,16 +124,7 @@ namespace SixLabors.Fonts
             string s = this.IsStartOfLine ? "@ " : string.Empty;
             string ws = this.IsWhiteSpace() ? "!" : string.Empty;
             Vector2 l = this.Location;
-            return $"{s}{ws}{this.CodePoint.ToDebuggerDisplay()} {l.X},{l.Y} {this.Width}x{this.Height}";
+            return $"{s}{ws}{this.CodePoint.ToDebuggerDisplay()} {l.X},{l.Y} {this.AdvanceX}x{this.AdvanceY}";
         }
-    }
-
-#pragma warning disable SA1201 // Elements should appear in the correct order
-    internal enum GlyphLayoutMode
-#pragma warning restore SA1201 // Elements should appear in the correct order
-    {
-        Horizontal,
-        Vertical,
-        VerticalRotated
     }
 }

--- a/src/SixLabors.Fonts/GlyphLayoutMode.cs
+++ b/src/SixLabors.Fonts/GlyphLayoutMode.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.Fonts
+{
+    /// <summary>
+    /// Provides enumeration for the various layout mode of an individual glyph within a body of text.
+    /// </summary>
+    public enum GlyphLayoutMode
+    {
+        /// <summary>
+        /// Horizontal.
+        /// </summary>
+        Horizontal,
+
+        /// <summary>
+        /// Vertical.
+        /// </summary>
+        Vertical,
+
+        /// <summary>
+        /// Rotated 90 degrees clockwise.
+        /// </summary>
+        VerticalRotated
+    }
+}

--- a/src/SixLabors.Fonts/GlyphRendererParameters.cs
+++ b/src/SixLabors.Fonts/GlyphRendererParameters.cs
@@ -19,7 +19,7 @@ namespace SixLabors.Fonts
             TextRun textRun,
             float pointSize,
             float dpi,
-            LayoutMode layoutMode)
+            GlyphLayoutMode layoutMode)
         {
             this.Font = metrics.FontMetrics.Description.FontNameInvariantCulture?.ToUpper() ?? string.Empty;
             this.FontStyle = metrics.FontMetrics.Description.Style;
@@ -76,7 +76,7 @@ namespace SixLabors.Fonts
         /// <summary>
         /// Gets the layout mode applied to the glyph.
         /// </summary>
-        public LayoutMode LayoutMode { get; }
+        public GlyphLayoutMode LayoutMode { get; }
 
         /// <summary>
         /// Gets the text run that this glyph belongs to.

--- a/src/SixLabors.Fonts/StreamFontMetrics.TrueType.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.TrueType.cs
@@ -136,6 +136,8 @@ namespace SixLabors.Fonts
             short lsb = htmx.GetLeftSideBearing(glyphId);
 
             IMetricsHeader metrics = isVerticalLayout ? this.VerticalMetrics : this.HorizontalMetrics;
+
+            metrics = this.VerticalMetrics;
             ushort advancedHeight = (ushort)(metrics.Ascender - metrics.Descender);
             short tsb = (short)(metrics.Ascender - bounds.Max.Y);
             if (vtmx != null)

--- a/src/SixLabors.Fonts/StreamFontMetrics.TrueType.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.TrueType.cs
@@ -136,8 +136,6 @@ namespace SixLabors.Fonts
             short lsb = htmx.GetLeftSideBearing(glyphId);
 
             IMetricsHeader metrics = isVerticalLayout ? this.VerticalMetrics : this.HorizontalMetrics;
-
-            metrics = this.VerticalMetrics;
             ushort advancedHeight = (ushort)(metrics.Ascender - metrics.Descender);
             short tsb = (short)(metrics.Ascender - bounds.Max.Y);
             if (vtmx != null)

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -467,7 +467,8 @@ namespace SixLabors.Fonts
                 LineGap = metrics.LineGap,
                 LineHeight = metrics.LineHeight,
                 AdvanceWidthMax = metrics.AdvanceWidthMax,
-                AdvanceHeightMax = metrics.AdvanceHeightMax
+                AdvanceHeightMax = metrics.AdvanceHeightMax,
+                Synthesized = true
             };
 
             if (vhea is null)
@@ -486,6 +487,7 @@ namespace SixLabors.Fonts
             verticalMetrics.Descender = descender;
             verticalMetrics.LineGap = lineGap;
             verticalMetrics.LineHeight = lineHeight;
+            verticalMetrics.Synthesized = false;
 
             return verticalMetrics;
         }

--- a/src/SixLabors.Fonts/Tables/TrueType/Glyphs/GlyphTable.cs
+++ b/src/SixLabors.Fonts/Tables/TrueType/Glyphs/GlyphTable.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.IO;
-using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.Tables.Woff;
 
 namespace SixLabors.Fonts.Tables.TrueType.Glyphs
@@ -24,7 +23,10 @@ namespace SixLabors.Fonts.Tables.TrueType.Glyphs
         public static GlyphTable Load(FontReader reader)
         {
             uint[] locations = reader.GetTable<IndexLocationTable>().GlyphOffsets;
-            Bounds fallbackEmptyBounds = reader.GetTable<HeadTable>().Bounds;
+
+            // Use an empty bounds instance as the fallback.
+            // We will substitute this with the advance width/height to determine bounds instead when rendering/measuring.
+            Bounds fallbackEmptyBounds = Bounds.Empty;
 
             using BigEndianBinaryReader binaryReader = reader.GetReaderAtTablePosition(TableName);
             return Load(binaryReader, reader.TableFormat, locations, in fallbackEmptyBounds);

--- a/src/SixLabors.Fonts/Tables/TrueType/Glyphs/GlyphTableEntry.cs
+++ b/src/SixLabors.Fonts/Tables/TrueType/Glyphs/GlyphTableEntry.cs
@@ -31,7 +31,7 @@ namespace SixLabors.Fonts.Tables.TrueType.Glyphs
             this.OnCurves = onCurves;
             this.EndPoints = endPoints;
 
-            if (bounds != default)
+            if (bounds != default || this.ControlPoints.Length == 0)
             {
                 this.Bounds = bounds;
             }

--- a/src/SixLabors.Fonts/Tables/TrueType/TrueTypeGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/Tables/TrueType/TrueTypeGlyphMetrics.cs
@@ -105,7 +105,7 @@ namespace SixLabors.Fonts.Tables.TrueType
         public GlyphOutline GetOutline() => this.vector.GetOutline();
 
         /// <inheritdoc/>
-        internal override void RenderTo(IGlyphRenderer renderer, Vector2 location, Vector2 offset, TextOptions options)
+        internal override void RenderTo(IGlyphRenderer renderer, Vector2 location, Vector2 offset, GlyphLayoutMode mode, TextOptions options)
         {
             // https://www.unicode.org/faq/unsup_char.html
             if (ShouldSkipGlyphRendering(this.CodePoint))
@@ -122,15 +122,11 @@ namespace SixLabors.Fonts.Tables.TrueType
             location *= dpi;
             offset *= dpi;
             Vector2 renderLocation = location + offset;
-
             float scaledPPEM = this.GetScaledSize(pointSize, dpi);
 
-            bool rotated = this.TryGetRotationMatrix(options.LayoutMode, out Matrix3x2 rotation);
-            FontRectangle box = this.GetBoundingBox(Vector2.Zero, scaledPPEM);
-            box = FontRectangle.Transform(in box, rotation);
-            box = new FontRectangle(box.X + renderLocation.X, box.Y + renderLocation.Y, box.Width, box.Height);
-
-            GlyphRendererParameters parameters = new(this, this.TextRun, pointSize, dpi, options.LayoutMode);
+            Matrix3x2 rotation = GetRotationMatrix(mode);
+            FontRectangle box = this.GetBoundingBox(mode, renderLocation, scaledPPEM);
+            GlyphRendererParameters parameters = new(this, this.TextRun, pointSize, dpi, mode);
 
             if (renderer.BeginGlyph(in box, in parameters))
             {
@@ -234,7 +230,7 @@ namespace SixLabors.Fonts.Tables.TrueType
                     }
                 }
 
-                this.RenderDecorationsTo(renderer, location, options.LayoutMode, rotated, rotation, scaledPPEM);
+                this.RenderDecorationsTo(renderer, location, mode, rotation, scaledPPEM);
             }
 
             renderer.EndGlyph();

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -205,14 +205,28 @@ namespace SixLabors.Fonts
             LayoutMode layoutMode = options.LayoutMode;
             List<GlyphLayout> glyphs = new();
             Vector2 location = options.Origin / options.Dpi;
+
+            // If a wrapping length is specified that should be used to determine the box size to orient against.
             float maxScaledAdvance = textBox.ScaledMaxAdvance();
+            if (options.WrappingLength > 0)
+            {
+                maxScaledAdvance = Math.Max(options.WrappingLength / options.Dpi, maxScaledAdvance);
+            }
+
             TextDirection direction = textBox.TextDirection();
 
             if (layoutMode == LayoutMode.HorizontalTopBottom)
             {
                 for (int i = 0; i < textBox.TextLines.Count; i++)
                 {
-                    glyphs.AddRange(LayoutLineHorizontal(textBox, textBox.TextLines[i], direction, maxScaledAdvance, options, i, ref location));
+                    glyphs.AddRange(LayoutLineHorizontal(
+                        textBox,
+                        textBox.TextLines[i],
+                        direction,
+                        maxScaledAdvance,
+                        options,
+                        i,
+                        ref location));
                 }
             }
             else if (layoutMode == LayoutMode.HorizontalBottomTop)
@@ -220,14 +234,28 @@ namespace SixLabors.Fonts
                 int index = 0;
                 for (int i = textBox.TextLines.Count - 1; i >= 0; i--)
                 {
-                    glyphs.AddRange(LayoutLineHorizontal(textBox, textBox.TextLines[i], direction, maxScaledAdvance, options, index++, ref location));
+                    glyphs.AddRange(LayoutLineHorizontal(
+                        textBox,
+                        textBox.TextLines[i],
+                        direction,
+                        maxScaledAdvance,
+                        options,
+                        index++,
+                        ref location));
                 }
             }
             else if (layoutMode is LayoutMode.VerticalLeftRight)
             {
                 for (int i = 0; i < textBox.TextLines.Count; i++)
                 {
-                    glyphs.AddRange(LayoutLineVertical(textBox, textBox.TextLines[i], direction, maxScaledAdvance, options, i, ref location));
+                    glyphs.AddRange(LayoutLineVertical(
+                        textBox,
+                        textBox.TextLines[i],
+                        direction,
+                        maxScaledAdvance,
+                        options,
+                        i,
+                        ref location));
                 }
             }
             else if (layoutMode is LayoutMode.VerticalRightLeft)
@@ -235,14 +263,28 @@ namespace SixLabors.Fonts
                 int index = 0;
                 for (int i = textBox.TextLines.Count - 1; i >= 0; i--)
                 {
-                    glyphs.AddRange(LayoutLineVertical(textBox, textBox.TextLines[i], direction, maxScaledAdvance, options, index++, ref location));
+                    glyphs.AddRange(LayoutLineVertical(
+                        textBox,
+                        textBox.TextLines[i],
+                        direction,
+                        maxScaledAdvance,
+                        options,
+                        index++,
+                        ref location));
                 }
             }
             else if (layoutMode is LayoutMode.VerticalMixedLeftRight)
             {
                 for (int i = 0; i < textBox.TextLines.Count; i++)
                 {
-                    glyphs.AddRange(LayoutLineVerticalMixed(textBox, textBox.TextLines[i], direction, maxScaledAdvance, options, i, ref location));
+                    glyphs.AddRange(LayoutLineVerticalMixed(
+                        textBox,
+                        textBox.TextLines[i],
+                        direction,
+                        maxScaledAdvance,
+                        options,
+                        i,
+                        ref location));
                 }
             }
             else
@@ -250,7 +292,14 @@ namespace SixLabors.Fonts
                 int index = 0;
                 for (int i = textBox.TextLines.Count - 1; i >= 0; i--)
                 {
-                    glyphs.AddRange(LayoutLineVerticalMixed(textBox, textBox.TextLines[i], direction, maxScaledAdvance, options, index++, ref location));
+                    glyphs.AddRange(LayoutLineVerticalMixed(
+                        textBox,
+                        textBox.TextLines[i],
+                        direction,
+                        maxScaledAdvance,
+                        options,
+                        index++,
+                        ref location));
                 }
             }
 
@@ -455,6 +504,12 @@ namespace SixLabors.Fonts
             }
 
             // Set the alignment of lines within the text.
+            // Use the wrapping length to determine the bounds to align to.
+            if (options.WrappingLength > 0)
+            {
+                maxScaledAdvance = Math.Max(options.WrappingLength / options.Dpi, maxScaledAdvance);
+            }
+
             if (direction == TextDirection.LeftToRight)
             {
                 switch (options.TextAlignment)
@@ -602,6 +657,12 @@ namespace SixLabors.Fonts
             }
 
             // Set the alignment of lines within the text.
+            // Use the wrapping length to determine the bounds to align to.
+            if (options.WrappingLength > 0)
+            {
+                maxScaledAdvance = Math.Max(options.WrappingLength / options.Dpi, maxScaledAdvance);
+            }
+
             if (direction == TextDirection.LeftToRight)
             {
                 switch (options.TextAlignment)
@@ -1075,8 +1136,8 @@ namespace SixLabors.Fonts
                             else if (lastLineBreak.PositionWrap < codePointIndex && !CodePoint.IsWhiteSpace(codePoint))
                             {
                                 // Split the current textline into two at the last wrapping point if the current glyph
-                                // does not represent whitespace. Whitespace characters will be correctly trimmed at the next
-                                // iteration.
+                                // does not represent whitespace. Whitespace characters will be correctly trimmed at the
+                                // next iteration.
                                 TextLine split = textLine.SplitAt(lastLineBreak, keepAll);
                                 if (split != textLine)
                                 {

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -206,9 +206,10 @@ namespace SixLabors.Fonts
             List<GlyphLayout> glyphs = new();
             Vector2 location = options.Origin / options.Dpi;
 
-            // If a wrapping length is specified that should be used to determine the box size to orient against.
+            // If a wrapping length is specified that should be used to determine the
+            // box size to align text within.
             float maxScaledAdvance = textBox.ScaledMaxAdvance();
-            if (options.WrappingLength > 0)
+            if (options.TextAlignment != TextAlignment.Start && options.WrappingLength > 0)
             {
                 maxScaledAdvance = Math.Max(options.WrappingLength / options.Dpi, maxScaledAdvance);
             }
@@ -315,27 +316,14 @@ namespace SixLabors.Fonts
             int index,
             ref Vector2 location)
         {
-            float scaledMaxLineGap = textBox.ScaledMaxLineGap(textLine.MaxPointSize);
-            float scaledMaxAscender = textBox.ScaledMaxAscender(textLine.MaxPointSize);
-            float scaledMaxDescender = textBox.ScaledMaxDescender(textLine.MaxPointSize);
-            float scaledMaxLineHeight = textBox.ScaledMaxLineHeight(textLine.MaxPointSize);
-
+            // Offset the location to center the line vertically.
             bool isFirstLine = index == 0;
-            bool isLastLine = index == textBox.TextLines.Count - 1;
-            float scaledLineAdvance = scaledMaxLineHeight * options.LineSpacing;
-
-            // Recalculate the advance based upon the next line.
-            // If larger, we want to scale it up to ensure it it pushed down far enough.
-            // We split the different at 2/3 (heuristically determined value based upon extensive visual testing).
-            if (!isFirstLine && !isLastLine)
-            {
-                TextLine next = textBox.TextLines[index + 1];
-                float nextLineAdvance = textBox.ScaledMaxLineHeight(next.MaxPointSize) * options.LineSpacing;
-                scaledLineAdvance += (nextLineAdvance - scaledLineAdvance) * .667F;
-            }
+            float lineHeight = textLine.ScaledMaxLineHeight;
+            float advanceY = lineHeight * options.LineSpacing;
+            float offsetY = (advanceY - lineHeight) * .5F;
+            float yLineAdvance = advanceY - offsetY;
 
             float originX = location.X;
-            float offsetY = 0;
             float offsetX = 0;
 
             // Set the Y-Origin for the line.
@@ -343,45 +331,24 @@ namespace SixLabors.Fonts
             {
                 switch (options.VerticalAlignment)
                 {
-                    case VerticalAlignment.Top:
-                        offsetY = scaledMaxAscender;
-                        break;
                     case VerticalAlignment.Center:
-                        offsetY = (scaledMaxAscender - (scaledMaxDescender + scaledMaxLineGap)) * .5F;
-                        for (int i = index; i < textBox.TextLines.Count - 1; i++)
+                        for (int i = 0; i < textBox.TextLines.Count; i++)
                         {
-                            float advance = textBox.ScaledMaxLineHeight(textBox.TextLines[i].MaxPointSize);
-                            if (i != 0)
-                            {
-                                TextLine next = textBox.TextLines[index + 1];
-                                float nextLineAdvance = textBox.ScaledMaxLineHeight(next.MaxPointSize);
-                                advance += (nextLineAdvance - advance) * .667F;
-                            }
-
-                            offsetY -= advance * options.LineSpacing * .5F;
+                            offsetY -= textBox.TextLines[i].ScaledMaxLineHeight * options.LineSpacing * .5F;
                         }
 
                         break;
                     case VerticalAlignment.Bottom:
-                        offsetY = -(scaledMaxDescender + scaledMaxLineGap);
-                        for (int i = index; i < textBox.TextLines.Count - 1; i++)
+                        for (int i = 0; i < textBox.TextLines.Count; i++)
                         {
-                            float advance = textBox.ScaledMaxLineHeight(textBox.TextLines[i].MaxPointSize);
-                            if (i != 0)
-                            {
-                                TextLine next = textBox.TextLines[index + 1];
-                                float nextLineAdvance = textBox.ScaledMaxLineHeight(next.MaxPointSize);
-                                advance += (nextLineAdvance - advance) * .667F;
-                            }
-
-                            offsetY -= advance * options.LineSpacing;
+                            offsetY -= textBox.TextLines[i].ScaledMaxLineHeight * options.LineSpacing;
                         }
 
                         break;
                 }
-
-                location.Y += offsetY;
             }
+
+            location.Y += offsetY;
 
             // Set the X-Origin for horizontal alignment.
             switch (options.HorizontalAlignment)
@@ -428,35 +395,17 @@ namespace SixLabors.Fonts
                 TextLine.GlyphLayoutData data = textLine[i];
                 if (data.IsNewLine)
                 {
-                    location.Y += scaledLineAdvance;
+                    location.Y += yLineAdvance;
                     continue;
                 }
 
                 foreach (GlyphMetrics metric in data.Metrics)
                 {
-                    // Advance Width & Height can be 0 which is fine for layout but not for measuring.
-                    Vector2 scale = new Vector2(data.PointSize) / metric.ScaleFactor;
-                    float advanceX = data.ScaledAdvance;
-                    float advanceY = metric.AdvanceHeight * scale.Y;
-                    if (advanceX == 0)
-                    {
-                        advanceX = (metric.LeftSideBearing + metric.Width + metric.RightSideBearing) * scale.X;
-                    }
-
-                    if (advanceY == 0)
-                    {
-                        advanceY = (metric.TopSideBearing + metric.Height + metric.BottomSideBearing) * scale.Y;
-                    }
-
                     glyphs.Add(new GlyphLayout(
                         new Glyph(metric, data.PointSize),
-                        location,
+                        location + new Vector2(0, textLine.ScaledMaxAscender),
                         Vector2.Zero,
-                        scaledMaxAscender,
-                        scaledMaxDescender,
-                        scaledMaxLineGap,
-                        scaledLineAdvance,
-                        advanceX,
+                        data.ScaledAdvance,
                         advanceY,
                         GlyphLayoutMode.Horizontal,
                         i == 0));
@@ -468,7 +417,7 @@ namespace SixLabors.Fonts
             location.X = originX;
             if (glyphs.Count > 0)
             {
-                location.Y += scaledLineAdvance;
+                location.Y += yLineAdvance;
             }
 
             return glyphs;
@@ -485,11 +434,14 @@ namespace SixLabors.Fonts
         {
             float originY = location.Y;
             float offsetY = 0;
-            float offsetX = 0;
+
+            // Offset the location to center the line horizontally.
+            float scaledMaxLineHeight = textLine.ScaledMaxLineHeight;
+            float advanceX = scaledMaxLineHeight * options.LineSpacing;
+            float offsetX = (advanceX - scaledMaxLineHeight) * .5F;
+            float xLineAdvance = advanceX - offsetX;
 
             // Set the Y-Origin for the line.
-            float scaledMaxLineHeight = textBox.ScaledMaxLineHeight(textLine.MaxPointSize);
-
             switch (options.VerticalAlignment)
             {
                 case VerticalAlignment.Top:
@@ -538,17 +490,16 @@ namespace SixLabors.Fonts
                 switch (options.HorizontalAlignment)
                 {
                     case HorizontalAlignment.Right:
-                        // The textline methods are memoized so we're safe to call them multiple times.
                         for (int i = 0; i < textBox.TextLines.Count; i++)
                         {
-                            offsetX -= textBox.ScaledMaxLineHeight(textBox.TextLines[i].MaxPointSize) * options.LineSpacing;
+                            offsetX -= textBox.TextLines[i].ScaledMaxLineHeight * options.LineSpacing;
                         }
 
                         break;
                     case HorizontalAlignment.Center:
                         for (int i = 0; i < textBox.TextLines.Count; i++)
                         {
-                            offsetX -= textBox.ScaledMaxLineHeight(textBox.TextLines[i].MaxPointSize) * options.LineSpacing * .5F;
+                            offsetX -= textBox.TextLines[i].ScaledMaxLineHeight * options.LineSpacing * .5F;
                         }
 
                         break;
@@ -558,14 +509,6 @@ namespace SixLabors.Fonts
             location.X += offsetX;
 
             List<GlyphLayout> glyphs = new();
-            float xWidth = scaledMaxLineHeight * (isFirstLine ? 1F : options.LineSpacing);
-            float xLineAdvance = scaledMaxLineHeight * options.LineSpacing;
-
-            if (isFirstLine)
-            {
-                xLineAdvance -= (xLineAdvance - scaledMaxLineHeight) * .5F;
-            }
-
             for (int i = 0; i < textLine.Count; i++)
             {
                 TextLine.GlyphLayoutData data = textLine[i];
@@ -578,33 +521,17 @@ namespace SixLabors.Fonts
 
                 foreach (GlyphMetrics metric in data.Metrics)
                 {
+                    // Align the glyph horizontally and vertically centering horizontally around the baseline.
                     Vector2 scale = new Vector2(data.PointSize) / metric.ScaleFactor;
-                    float advanceX = xLineAdvance;
-                    float advanceY = data.ScaledAdvance;
+                    float oX = (data.ScaledLineHeight - (metric.Bounds.Size().X * scale.X)) * .5F;
+                    Vector2 offset = new(oX, (metric.Bounds.Max.Y + metric.TopSideBearing) * scale.Y);
 
-                    // Advance Width & Height can be 0 which is fine for layout but not for measuring.
-                    if (advanceX == 0)
-                    {
-                        advanceX = (metric.LeftSideBearing + metric.Width + metric.RightSideBearing) * scale.X;
-                    }
-
-                    if (advanceY == 0)
-                    {
-                        advanceY = (metric.TopSideBearing + metric.Height + metric.BottomSideBearing) * scale.Y;
-                    }
-
-                    // Align the glyph horizontally and vertically.
-                    Vector2 offset = new((xWidth - (metric.AdvanceWidth * scale.X)) * .5F, (metric.Bounds.Max.Y + metric.TopSideBearing) * scale.Y);
                     glyphs.Add(new GlyphLayout(
                         new Glyph(metric, data.PointSize),
-                        location,
+                        location + new Vector2((scaledMaxLineHeight - data.ScaledLineHeight) * .5F, 0),
                         offset,
-                        data.ScaledAscender,
-                        data.ScaledDescender,
-                        data.ScaledLineGap,
-                        scaledMaxLineHeight,
                         advanceX,
-                        advanceY,
+                        data.ScaledAdvance,
                         GlyphLayoutMode.Vertical,
                         i == 0));
                 }
@@ -632,11 +559,14 @@ namespace SixLabors.Fonts
         {
             float originY = location.Y;
             float offsetY = 0;
-            float offsetX = 0;
+
+            // Offset the location to center the line horizontally.
+            float scaledMaxLineHeight = textLine.ScaledMaxLineHeight;
+            float advanceX = scaledMaxLineHeight * options.LineSpacing;
+            float offsetX = (advanceX - scaledMaxLineHeight) * .5F;
+            float xLineAdvance = advanceX - offsetX;
 
             // Set the Y-Origin for the line.
-            float scaledMaxLineHeight = textBox.ScaledMaxLineHeight(textLine.MaxPointSize);
-
             switch (options.VerticalAlignment)
             {
                 case VerticalAlignment.Top:
@@ -685,17 +615,16 @@ namespace SixLabors.Fonts
                 switch (options.HorizontalAlignment)
                 {
                     case HorizontalAlignment.Right:
-                        // The textline methods are memoized so we're safe to call them multiple times.
                         for (int i = 0; i < textBox.TextLines.Count; i++)
                         {
-                            offsetX -= textBox.ScaledMaxLineHeight(textBox.TextLines[i].MaxPointSize) * options.LineSpacing;
+                            offsetX -= textBox.TextLines[i].ScaledMaxLineHeight * options.LineSpacing;
                         }
 
                         break;
                     case HorizontalAlignment.Center:
                         for (int i = 0; i < textBox.TextLines.Count; i++)
                         {
-                            offsetX -= textBox.ScaledMaxLineHeight(textBox.TextLines[i].MaxPointSize) * options.LineSpacing * .5F;
+                            offsetX -= textBox.TextLines[i].ScaledMaxLineHeight * options.LineSpacing * .5F;
                         }
 
                         break;
@@ -705,14 +634,6 @@ namespace SixLabors.Fonts
             location.X += offsetX;
 
             List<GlyphLayout> glyphs = new();
-            float xWidth = scaledMaxLineHeight * (isFirstLine ? 1F : options.LineSpacing);
-            float xLineAdvance = scaledMaxLineHeight * options.LineSpacing;
-
-            if (isFirstLine)
-            {
-                xLineAdvance -= (xLineAdvance - scaledMaxLineHeight) * .5F;
-            }
-
             for (int i = 0; i < textLine.Count; i++)
             {
                 TextLine.GlyphLayoutData data = textLine[i];
@@ -723,37 +644,17 @@ namespace SixLabors.Fonts
                     continue;
                 }
 
-                if (data.IsVerticalRotated)
+                if (data.IsRotated)
                 {
                     foreach (GlyphMetrics metric in data.Metrics)
                     {
                         Vector2 scale = new Vector2(data.PointSize) / metric.ScaleFactor;
-                        float advanceX = xLineAdvance;
-                        float advanceY = data.ScaledAdvance;
-
-                        // Advance Width & Height can be 0 which is fine for layout but not for measuring.
-                        if (advanceX == 0)
-                        {
-                            advanceX = (metric.TopSideBearing + metric.Height + metric.BottomSideBearing) * scale.Y * options.LineSpacing;
-                        }
-
-                        if (advanceY == 0)
-                        {
-                            advanceY = (metric.LeftSideBearing + metric.Width + metric.RightSideBearing) * scale.X;
-                        }
-
-                        // Shift the rotated text horizontally to counter rotation
-                        Vector2 offset = new(data.ScaledDescender, 0);
                         glyphs.Add(new GlyphLayout(
                             new Glyph(metric, data.PointSize),
-                            location,
-                            offset,
-                            metric.LeftSideBearing * scale.X, // TODO: Check this calculation.
-                            metric.RightSideBearing * scale.X,
-                            data.ScaledLineGap,
-                            data.ScaledAdvance,
+                            location + new Vector2(((scaledMaxLineHeight - data.ScaledLineHeight) * .5F) + data.ScaledDescender, 0),
+                            Vector2.Zero,
                             advanceX,
-                            advanceY,
+                            data.ScaledAdvance,
                             GlyphLayoutMode.VerticalRotated,
                             i == 0));
                     }
@@ -762,33 +663,17 @@ namespace SixLabors.Fonts
                 {
                     foreach (GlyphMetrics metric in data.Metrics)
                     {
+                        // Align the glyph horizontally and vertically centering horizontally around the baseline.
                         Vector2 scale = new Vector2(data.PointSize) / metric.ScaleFactor;
-                        float advanceX = xLineAdvance;
-                        float advanceY = data.ScaledAdvance;
+                        float oX = (data.ScaledLineHeight - (metric.Bounds.Size().X * scale.X)) * .5F;
+                        Vector2 offset = new(oX, (metric.Bounds.Max.Y + metric.TopSideBearing) * scale.Y);
 
-                        // Advance Width & Height can be 0 which is fine for layout but not for measuring.
-                        if (advanceX == 0)
-                        {
-                            advanceX = (metric.LeftSideBearing + metric.Width + metric.RightSideBearing) * scale.X;
-                        }
-
-                        if (advanceY == 0)
-                        {
-                            advanceY = (metric.TopSideBearing + metric.Height + metric.BottomSideBearing) * scale.Y;
-                        }
-
-                        // Align the glyph horizontally and vertically.
-                        Vector2 offset = new((xWidth - (metric.AdvanceWidth * scale.X)) * .5F, (metric.Bounds.Max.Y + metric.TopSideBearing) * scale.Y);
                         glyphs.Add(new GlyphLayout(
                             new Glyph(metric, data.PointSize),
-                            location,
+                            location + new Vector2((scaledMaxLineHeight - data.ScaledLineHeight) * .5F, 0),
                             offset,
-                            data.ScaledAscender,
-                            data.ScaledDescender,
-                            data.ScaledLineGap,
-                            data.ScaledLineHeight,
                             advanceX,
-                            advanceY,
+                            data.ScaledAdvance,
                             GlyphLayoutMode.Vertical,
                             i == 0));
                     }
@@ -945,7 +830,7 @@ namespace SixLabors.Fonts
             bool keepAll = options.WordBreaking == WordBreaking.KeepAll;
             bool isHorizontalLayout = layoutMode.IsHorizontal();
             bool isVerticalMixedLayout = layoutMode.IsVerticalMixed();
-            bool isVerticalLayout = isVerticalMixedLayout || layoutMode.IsVertical();
+            bool isVerticalLayout = layoutMode.IsVertical();
 
             // Calculate the position of potential line breaks.
             var lineBreakEnumerator = new LineBreakEnumerator(text);
@@ -982,11 +867,11 @@ namespace SixLabors.Fonts
                         continue;
                     }
 
+                    // Determine whether the glyph advance should be calculated using vertical or horizontal metrics
+                    // For vertical mixed layout we will be rotating glyphs with the vertical orientation type R or TR.
                     CodePoint codePoint = codePointEnumerator.Current;
-
-                    // For mixed layout we will be rotating glyphs with the vertical orientation type R or TR.
                     VerticalOrientationType verticalOrientationType = CodePoint.GetVerticalOrientationType(codePoint);
-                    bool isVerticalRotated = isVerticalMixedLayout && verticalOrientationType is VerticalOrientationType.Rotate or VerticalOrientationType.TransformRotate;
+                    bool isRotated = isVerticalMixedLayout && verticalOrientationType is VerticalOrientationType.Rotate or VerticalOrientationType.TransformRotate;
 
                     if (CodePoint.IsVariationSelector(codePoint))
                     {
@@ -999,7 +884,7 @@ namespace SixLabors.Fonts
                     GlyphMetrics glyph = metrics[0];
 
                     float glyphAdvance;
-                    if (isHorizontalLayout || isVerticalRotated)
+                    if (isHorizontalLayout || isRotated)
                     {
                         glyphAdvance = glyph.AdvanceWidth;
                     }
@@ -1010,7 +895,33 @@ namespace SixLabors.Fonts
 
                     if (CodePoint.IsTabulation(codePoint))
                     {
-                        glyphAdvance *= options.TabWidth;
+                        if (options.TabWidth > -1F)
+                        {
+                            // Do not use the default font tab width. Instead find the advance for the space glyph
+                            // and multiply that by the options value.
+                            CodePoint space = new(0x0020);
+                            if (glyph.FontMetrics.TryGetGlyphId(space, out ushort spaceGlyphId))
+                            {
+                                GlyphMetrics spaceMetrics = glyph.FontMetrics.GetGlyphMetrics(
+                                      space,
+                                      spaceGlyphId,
+                                      glyph.TextAttributes,
+                                      glyph.TextDecorations,
+                                      layoutMode,
+                                      options.ColorFontSupport)[0];
+
+                                if (isHorizontalLayout || isRotated)
+                                {
+                                    glyphAdvance = spaceMetrics.AdvanceWidth * options.TabWidth;
+                                    glyph.SetAdvanceWidth((ushort)glyphAdvance);
+                                }
+                                else
+                                {
+                                    glyphAdvance = spaceMetrics.AdvanceHeight * options.TabWidth;
+                                    glyph.SetAdvanceHeight((ushort)glyphAdvance);
+                                }
+                            }
+                        }
                     }
                     else if (metrics.Count == 1 && (CodePoint.IsZeroWidthJoiner(codePoint) || CodePoint.IsZeroWidthNonJoiner(codePoint)))
                     {
@@ -1024,7 +935,7 @@ namespace SixLabors.Fonts
                     {
                         // Standard text.
                         // If decomposed we need to add the advance; otherwise, use the largest advance for the metrics.
-                        if (isHorizontalLayout || isVerticalRotated)
+                        if (isHorizontalLayout || isRotated)
                         {
                             for (int i = 1; i < metrics.Count; i++)
                             {
@@ -1057,7 +968,7 @@ namespace SixLabors.Fonts
                     }
 
                     // Now scale the advance.
-                    if (isHorizontalLayout || isVerticalRotated)
+                    if (isHorizontalLayout || isRotated)
                     {
                         glyphAdvance *= pointSize / glyph.ScaleFactor.X;
                     }
@@ -1123,7 +1034,7 @@ namespace SixLabors.Fonts
                             }
                             else if (lastLineBreak.PositionWrap < codePointIndex && !CodePoint.IsWhiteSpace(codePoint))
                             {
-                                // Split the current textline into two at the last wrapping point if the current glyph
+                                // Split the current text line into two at the last wrapping point if the current glyph
                                 // does not represent whitespace. Whitespace characters will be correctly trimmed at the
                                 // next iteration.
                                 TextLine split = textLine.SplitAt(lastLineBreak, keepAll);
@@ -1167,15 +1078,15 @@ namespace SixLabors.Fonts
                         continue;
                     }
 
+                    // Work out the scaled metrics for the glyph.
                     GlyphMetrics metric = metrics[0];
                     float scaleY = pointSize / metric.ScaleFactor.Y;
-
-                    bool useVerticalMetrics = isVerticalLayout && !isVerticalRotated;
-                    IMetricsHeader metricsHeader = useVerticalMetrics ? metric.FontMetrics.VerticalMetrics : metric.FontMetrics.HorizontalMetrics;
+                    IMetricsHeader metricsHeader = isHorizontalLayout || isRotated
+                        ? metric.FontMetrics.HorizontalMetrics
+                        : metric.FontMetrics.VerticalMetrics;
                     float ascender = metricsHeader.Ascender * scaleY;
 
                     // Adjust ascender for glyphs with a negative tsb. e.g. emoji to prevent cutoff.
-                    // TODO: Remove this hack.
                     if (!CodePoint.IsWhiteSpace(codePoint))
                     {
                         short tsbOffset = 0;
@@ -1190,10 +1101,13 @@ namespace SixLabors.Fonts
                         }
                     }
 
+                    // Match how line height is calculated for browsers.
+                    // https://www.w3.org/TR/CSS2/visudet.html#propdef-line-height
                     float descender = Math.Abs(metricsHeader.Descender * scaleY);
-                    float lineHeight = metricsHeader.LineHeight * scaleY;
-                    float lineGap = lineHeight - (ascender + descender);
-                    float leftSideBearing = metrics.Max(x => x.LeftSideBearing * pointSize / metric.ScaleFactor.X);
+                    float lineHeight = metric.UnitsPerEm * scaleY;
+                    float delta = ((metricsHeader.LineHeight * scaleY) - lineHeight) * .5F;
+                    ascender -= delta;
+                    descender -= delta;
 
                     // Add our metrics to the line.
                     lineAdvance += glyphAdvance;
@@ -1204,12 +1118,10 @@ namespace SixLabors.Fonts
                         lineHeight,
                         ascender,
                         descender,
-                        lineGap,
-                        leftSideBearing,
                         bidiRuns[bidiMap[codePointIndex]],
                         graphemeIndex,
                         codePointIndex,
-                        isVerticalRotated);
+                        isRotated);
 
                     codePointIndex++;
                     graphemeCodePointIndex++;
@@ -1238,24 +1150,8 @@ namespace SixLabors.Fonts
 
             public IReadOnlyList<TextLine> TextLines { get; }
 
-            // TODO: It would be very good to cache these.
             public float ScaledMaxAdvance()
                 => this.TextLines.Max(x => x.ScaledLineAdvance);
-
-            public float ScaledMaxLineHeight(float pointSize)
-                => this.TextLines.Where(x => x.MaxPointSize == pointSize).Max(x => x.ScaledMaxLineHeight);
-
-            public float ScaledMaxAscender(float pointSize)
-                => this.TextLines.Where(x => x.MaxPointSize == pointSize).Max(x => x.ScaledMaxAscender);
-
-            public float ScaledMaxDescender(float pointSize)
-                => this.TextLines.Where(x => x.MaxPointSize == pointSize).Max(x => x.ScaledMaxDescender);
-
-            public float ScaledMaxLineGap(float pointSize)
-                => this.TextLines.Where(x => x.MaxPointSize == pointSize).Max(x => x.ScaledMaxLineGap);
-
-            public float ScaledMaxLeftSideBearing(float pointSize)
-                => this.TextLines.Where(x => x.MaxPointSize == pointSize).Max(x => x.ScaledLeftSideBearing);
 
             public TextDirection TextDirection() => this.TextLines[0][0].TextDirection;
         }
@@ -1266,8 +1162,6 @@ namespace SixLabors.Fonts
 
             public int Count => this.data.Count;
 
-            public float MaxPointSize { get; private set; } = -1;
-
             public float ScaledLineAdvance { get; private set; } = 0;
 
             public float ScaledMaxLineHeight { get; private set; } = -1;
@@ -1275,10 +1169,6 @@ namespace SixLabors.Fonts
             public float ScaledMaxAscender { get; private set; } = -1;
 
             public float ScaledMaxDescender { get; private set; } = -1;
-
-            public float ScaledMaxLineGap { get; private set; } = -1;
-
-            public float ScaledLeftSideBearing { get; private set; } = -1;
 
             public GlyphLayoutData this[int index] => this.data[index];
 
@@ -1289,24 +1179,17 @@ namespace SixLabors.Fonts
                 float scaledLineHeight,
                 float scaledAscender,
                 float scaledDescender,
-                float scaledLineGap,
-                float scaledLeftSideBearing,
                 BidiRun bidiRun,
                 int graphemeIndex,
                 int offset,
-                bool verticalRotated)
+                bool isRotated)
             {
                 // Reset metrics.
                 // We track the maximum metrics for each line to ensure glyphs can be aligned.
-                // These will be grouped by the point size for each run within the text to ensure
-                // multi-line text maintains an even layout for equal point sizes.
-                this.MaxPointSize = MathF.Max(this.MaxPointSize, pointSize);
                 this.ScaledLineAdvance += scaledAdvance;
                 this.ScaledMaxLineHeight = MathF.Max(this.ScaledMaxLineHeight, scaledLineHeight);
                 this.ScaledMaxAscender = MathF.Max(this.ScaledMaxAscender, scaledAscender);
                 this.ScaledMaxDescender = MathF.Max(this.ScaledMaxDescender, scaledDescender);
-                this.ScaledMaxLineGap = MathF.Max(this.ScaledMaxLineGap, scaledLineGap);
-                this.ScaledLeftSideBearing = MathF.Max(this.ScaledLeftSideBearing, scaledLeftSideBearing);
 
                 this.data.Add(new(
                     metrics,
@@ -1315,12 +1198,10 @@ namespace SixLabors.Fonts
                     scaledLineHeight,
                     scaledAscender,
                     scaledDescender,
-                    scaledLineGap,
-                    scaledLeftSideBearing,
                     bidiRun,
                     graphemeIndex,
                     offset,
-                    verticalRotated));
+                    isRotated));
             }
 
             public TextLine SplitAt(LineBreak lineBreak, bool keepAll)
@@ -1364,16 +1245,13 @@ namespace SixLabors.Fonts
                     }
                 }
 
-                // Create a new line ensuring we capture the intitial metrics.
+                // Create a new line ensuring we capture the initial metrics.
                 TextLine result = new();
                 result.data.AddRange(this.data.GetRange(index, this.data.Count - index));
                 result.ScaledLineAdvance = result.data.Sum(x => x.ScaledAdvance);
-                result.MaxPointSize = result.data.Max(x => x.PointSize);
                 result.ScaledMaxAscender = result.data.Max(x => x.ScaledAscender);
                 result.ScaledMaxDescender = result.data.Max(x => x.ScaledDescender);
                 result.ScaledMaxLineHeight = result.data.Max(x => x.ScaledLineHeight);
-                result.ScaledMaxLineGap = result.data.Max(x => x.ScaledLineGap);
-                result.ScaledLeftSideBearing = result.data.Max(x => x.ScaledLeftSideBearing);
 
                 // Remove those items from this line.
                 this.data.RemoveRange(index, this.data.Count - index);
@@ -1397,11 +1275,9 @@ namespace SixLabors.Fonts
 
                 // Lastly recalculate this line metrics.
                 this.ScaledLineAdvance = this.data.Sum(x => x.ScaledAdvance);
-                this.MaxPointSize = this.data.Max(x => x.PointSize);
                 this.ScaledMaxAscender = this.data.Max(x => x.ScaledAscender);
                 this.ScaledMaxDescender = this.data.Max(x => x.ScaledDescender);
                 this.ScaledMaxLineHeight = this.data.Max(x => x.ScaledLineHeight);
-                this.ScaledMaxLineGap = this.data.Max(x => x.ScaledLineGap);
 
                 return result;
             }
@@ -1633,12 +1509,10 @@ namespace SixLabors.Fonts
                     float scaledLineHeight,
                     float scaledAscender,
                     float scaledDescender,
-                    float scaledLineGap,
-                    float scaledLeftSideBearing,
                     BidiRun bidiRun,
                     int graphemeIndex,
                     int offset,
-                    bool verticalRotated)
+                    bool isRotated)
                 {
                     this.Metrics = metrics;
                     this.PointSize = pointSize;
@@ -1646,12 +1520,10 @@ namespace SixLabors.Fonts
                     this.ScaledLineHeight = scaledLineHeight;
                     this.ScaledAscender = scaledAscender;
                     this.ScaledDescender = scaledDescender;
-                    this.ScaledLineGap = scaledLineGap;
-                    this.ScaledLeftSideBearing = scaledLeftSideBearing;
                     this.BidiRun = bidiRun;
                     this.GraphemeIndex = graphemeIndex;
                     this.Offset = offset;
-                    this.IsVerticalRotated = verticalRotated;
+                    this.IsRotated = isRotated;
                 }
 
                 public CodePoint CodePoint => this.Metrics[0].CodePoint;
@@ -1668,10 +1540,6 @@ namespace SixLabors.Fonts
 
                 public float ScaledDescender { get; }
 
-                public float ScaledLineGap { get; }
-
-                public float ScaledLeftSideBearing { get; }
-
                 public BidiRun BidiRun { get; }
 
                 public TextDirection TextDirection => (TextDirection)this.BidiRun.Direction;
@@ -1680,7 +1548,7 @@ namespace SixLabors.Fonts
 
                 public int Offset { get; }
 
-                public bool IsVerticalRotated { get; }
+                public bool IsRotated { get; }
 
                 public bool IsNewLine => CodePoint.IsNewLine(this.CodePoint);
 

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -504,12 +504,6 @@ namespace SixLabors.Fonts
             }
 
             // Set the alignment of lines within the text.
-            // Use the wrapping length to determine the bounds to align to.
-            if (options.WrappingLength > 0)
-            {
-                maxScaledAdvance = Math.Max(options.WrappingLength / options.Dpi, maxScaledAdvance);
-            }
-
             if (direction == TextDirection.LeftToRight)
             {
                 switch (options.TextAlignment)
@@ -657,12 +651,6 @@ namespace SixLabors.Fonts
             }
 
             // Set the alignment of lines within the text.
-            // Use the wrapping length to determine the bounds to align to.
-            if (options.WrappingLength > 0)
-            {
-                maxScaledAdvance = Math.Max(options.WrappingLength / options.Dpi, maxScaledAdvance);
-            }
-
             if (direction == TextDirection.LeftToRight)
             {
                 switch (options.TextAlignment)

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -14,80 +14,118 @@ namespace SixLabors.Fonts
     public static class TextMeasurer
     {
         /// <summary>
-        /// Measures the size of the text in pixel units.
+        /// Measures the advance (line-height and horizontal/vertical advance) of the text in pixel units.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The text shaping options.</param>
-        /// <returns>The size of the text if it was to be rendered.</returns>
-        public static FontRectangle Measure(string text, TextOptions options)
-            => Measure(text.AsSpan(), options);
+        /// <returns>The advance of the text if it was to be rendered.</returns>
+        public static FontRectangle MeasureAdvance(string text, TextOptions options)
+            => MeasureAdvance(text.AsSpan(), options);
 
         /// <summary>
-        /// Measures the size of the text in pixel units.
+        /// Measures the advance (line-height and horizontal/vertical advance) of the text in pixel units.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="options">The text shaping options.</param>
+        /// <returns>The advance of the text if it was to be rendered.</returns>
+        public static FontRectangle MeasureAdvance(ReadOnlySpan<char> text, TextOptions options)
+            => GetAdvance(TextLayout.GenerateLayout(text, options), options.Dpi);
+
+        /// <summary>
+        /// Measures the minimum size required, in pixel units, to render the text.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The text shaping options.</param>
         /// <returns>The size of the text if it was to be rendered.</returns>
-        public static FontRectangle Measure(ReadOnlySpan<char> text, TextOptions options)
+        public static FontRectangle MeasureSize(string text, TextOptions options)
+            => MeasureSize(text.AsSpan(), options);
+
+        /// <summary>
+        /// Measures the minimum size required, in pixel units, to render the text.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="options">The text shaping options.</param>
+        /// <returns>The size of the text if it was to be rendered.</returns>
+        public static FontRectangle MeasureSize(ReadOnlySpan<char> text, TextOptions options)
             => GetSize(TextLayout.GenerateLayout(text, options), options.Dpi);
 
         /// <summary>
-        /// Measures the text bounds in pixel units.
+        /// Measures the text bounds in sub-pixel units.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The text shaping options.</param>
-        /// <returns>The size of the text if it was to be rendered.</returns>
+        /// <returns>The bounds of the text if it was to be rendered.</returns>
         public static FontRectangle MeasureBounds(string text, TextOptions options)
             => MeasureBounds(text.AsSpan(), options);
 
         /// <summary>
-        /// Measures the text bounds in pixel units.
+        /// Measures the text bounds in sub-pixel units.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The text shaping options.</param>
-        /// <returns>The size of the text if it was to be rendered.</returns>
+        /// <returns>The bounds of the text if it was to be rendered.</returns>
         public static FontRectangle MeasureBounds(ReadOnlySpan<char> text, TextOptions options)
             => GetBounds(TextLayout.GenerateLayout(text, options), options.Dpi);
 
         /// <summary>
-        /// Measures the size of each character of the text in pixel units.
+        /// Measures the advance (line-height and horizontal/vertical advance) of each character of the text in pixel units.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The text shaping options.</param>
-        /// <param name="characterBounds">The list of character dimensions of the text if it was to be rendered.</param>
+        /// <param name="advances">The list of character advances of the text if it was to be rendered.</param>
+        /// <returns>Whether any of the characters had non-empty advances.</returns>
+        public static bool TryMeasureCharacterAdvances(string text, TextOptions options, out GlyphBounds[] advances)
+            => TryMeasureCharacterAdvances(text.AsSpan(), options, out advances);
+
+        /// <summary>
+        /// Measures the advance (line-height and horizontal/vertical advance) of each character of the text in pixel units.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="options">The text shaping options.</param>
+        /// <param name="advances">The list of character advances of the text if it was to be rendered.</param>
+        /// <returns>Whether any of the characters had non-empty advances.</returns>
+        public static bool TryMeasureCharacterAdvances(ReadOnlySpan<char> text, TextOptions options, out GlyphBounds[] advances)
+            => TryGetCharacterAdvances(TextLayout.GenerateLayout(text, options), options.Dpi, out advances);
+
+        /// <summary>
+        /// Measures the minimum size required, in pixel units, to render each character in the text.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="options">The text shaping options.</param>
+        /// <param name="sizes">The list of character dimensions of the text if it was to be rendered.</param>
         /// <returns>Whether any of the characters had non-empty dimensions.</returns>
-        public static bool TryMeasureCharacterDimensions(string text, TextOptions options, out GlyphBounds[] characterBounds)
-            => TryMeasureCharacterDimensions(text.AsSpan(), options, out characterBounds);
+        public static bool TryMeasureCharacterSizes(string text, TextOptions options, out GlyphBounds[] sizes)
+            => TryMeasureCharacterSizes(text.AsSpan(), options, out sizes);
 
         /// <summary>
-        /// Measures the size of each character of the text in pixel units.
+        /// Measures the minimum size required, in pixel units, to render each character in the text.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The text shaping options.</param>
-        /// <param name="characterBounds">The list of character dimensions of the text if it was to be rendered.</param>
+        /// <param name="sizes">The list of character dimensions of the text if it was to be rendered.</param>
         /// <returns>Whether any of the characters had non-empty dimensions.</returns>
-        public static bool TryMeasureCharacterDimensions(ReadOnlySpan<char> text, TextOptions options, out GlyphBounds[] characterBounds)
-            => TryGetCharacterDimensions(TextLayout.GenerateLayout(text, options), options.Dpi, out characterBounds);
+        public static bool TryMeasureCharacterSizes(ReadOnlySpan<char> text, TextOptions options, out GlyphBounds[] sizes)
+            => TryGetCharacterSizes(TextLayout.GenerateLayout(text, options), options.Dpi, out sizes);
 
         /// <summary>
-        /// Measures the character bounds of the text in pixel units.
+        /// Measures the character bounds of the text in sub-pixel units.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The text shaping options.</param>
-        /// <param name="characterBounds">The list of character bounds of the text if it was to be rendered.</param>
+        /// <param name="bounds">The list of character bounds of the text if it was to be rendered.</param>
         /// <returns>Whether any of the characters had non-empty bounds.</returns>
-        public static bool TryMeasureCharacterBounds(string text, TextOptions options, out GlyphBounds[] characterBounds)
-            => TryMeasureCharacterBounds(text.AsSpan(), options, out characterBounds);
+        public static bool TryMeasureCharacterBounds(string text, TextOptions options, out GlyphBounds[] bounds)
+            => TryMeasureCharacterBounds(text.AsSpan(), options, out bounds);
 
         /// <summary>
-        /// Measures the character bounds of the text in pixel units.
+        /// Measures the character bounds of the text in sub-pixel units.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="options">The text shaping options.</param>
-        /// <param name="characterBounds">The list of character bounds of the text if it was to be rendered.</param>
+        /// <param name="bounds">The list of character bounds of the text if it was to be rendered.</param>
         /// <returns>Whether any of the characters had non-empty bounds.</returns>
-        public static bool TryMeasureCharacterBounds(ReadOnlySpan<char> text, TextOptions options, out GlyphBounds[] characterBounds)
-            => TryGetCharacterBounds(TextLayout.GenerateLayout(text, options), options.Dpi, out characterBounds);
+        public static bool TryMeasureCharacterBounds(ReadOnlySpan<char> text, TextOptions options, out GlyphBounds[] bounds)
+            => TryGetCharacterBounds(TextLayout.GenerateLayout(text, options), options.Dpi, out bounds);
 
         /// <summary>
         /// Gets the number of lines contained within the text.
@@ -107,30 +145,42 @@ namespace SixLabors.Fonts
         public static int CountLines(ReadOnlySpan<char> text, TextOptions options)
             => TextLayout.GenerateLayout(text, options).Count(x => x.IsStartOfLine);
 
-        internal static FontRectangle GetSize(IReadOnlyList<GlyphLayout> glyphLayouts, float dpi)
+        internal static FontRectangle GetAdvance(IReadOnlyList<GlyphLayout> glyphLayouts, float dpi)
         {
             if (glyphLayouts.Count == 0)
             {
                 return FontRectangle.Empty;
             }
 
-            float left = int.MaxValue;
-            float top = int.MaxValue;
-            float bottom = int.MinValue;
-            float right = int.MinValue;
+            float left = float.MaxValue;
+            float top = float.MaxValue;
+            float bottom = float.MinValue;
+            float right = float.MinValue;
 
             for (int i = 0; i < glyphLayouts.Count; i++)
             {
                 GlyphLayout glyph = glyphLayouts[i];
                 Vector2 location = glyph.Location;
                 float x = location.X;
-                float y = location.Y - glyph.Ascender;
-                float lineHeight = glyph.LineHeight;
+                float y = location.Y;
 
-                // Avoid trimming zero-width/height marks that extend past the bounds of their base.
-                FontRectangle box = glyph.BoundingBox(1F);
-                float advanceX = Math.Max(x + glyph.Width, box.Right);
-                float advanceY = Math.Max(y + lineHeight, box.Top + box.Height);
+                if (glyph.IsStartOfLine)
+                {
+                    // When the text contains a mix of glyphs of different sizes there can be line position overlap.
+                    // To accurately measure we offset to ensure that we always start where the last line ended.
+                    // Glyphs are always laid out from top-left to bottom-right so we can simply use the max.
+                    if (glyph.LayoutMode == GlyphLayoutMode.Horizontal)
+                    {
+                        y = MathF.Max(y, bottom);
+                    }
+                    else
+                    {
+                        x = MathF.Max(x, right);
+                    }
+                }
+
+                float advanceX = x + glyph.AdvanceX;
+                float advanceY = y + glyph.AdvanceY;
 
                 if (left > x)
                 {
@@ -153,11 +203,21 @@ namespace SixLabors.Fonts
                 }
             }
 
-            Vector2 topLeft = new Vector2(left, top) * dpi;
-            Vector2 bottomRight = new Vector2(right, bottom) * dpi;
-            Vector2 size = bottomRight - topLeft;
-
+            Vector2 topLeft = new(left, top);
+            Vector2 bottomRight = new(right, bottom);
+            Vector2 size = (bottomRight - topLeft) * dpi;
             return new FontRectangle(0, 0, MathF.Ceiling(size.X), MathF.Ceiling(size.Y));
+        }
+
+        internal static FontRectangle GetSize(IReadOnlyList<GlyphLayout> glyphLayouts, float dpi)
+        {
+            if (glyphLayouts.Count == 0)
+            {
+                return FontRectangle.Empty;
+            }
+
+            FontRectangle bounds = GetBounds(glyphLayouts, dpi);
+            return new FontRectangle(0, 0, MathF.Ceiling(bounds.Right), MathF.Ceiling(bounds.Bottom));
         }
 
         internal static FontRectangle GetBounds(IReadOnlyList<GlyphLayout> glyphLayouts, float dpi)
@@ -167,10 +227,10 @@ namespace SixLabors.Fonts
                 return FontRectangle.Empty;
             }
 
-            float left = int.MaxValue;
-            float top = int.MaxValue;
-            float bottom = int.MinValue;
-            float right = int.MinValue;
+            float left = float.MaxValue;
+            float top = float.MaxValue;
+            float bottom = float.MinValue;
+            float right = float.MinValue;
             for (int i = 0; i < glyphLayouts.Count; i++)
             {
                 FontRectangle box = glyphLayouts[i].BoundingBox(dpi);
@@ -198,7 +258,7 @@ namespace SixLabors.Fonts
             return FontRectangle.FromLTRB(left, top, right, bottom);
         }
 
-        internal static bool TryGetCharacterDimensions(IReadOnlyList<GlyphLayout> glyphLayouts, float dpi, out GlyphBounds[] characterBounds)
+        internal static bool TryGetCharacterAdvances(IReadOnlyList<GlyphLayout> glyphLayouts, float dpi, out GlyphBounds[] characterBounds)
         {
             bool hasSize = false;
             if (glyphLayouts.Count == 0)
@@ -211,9 +271,82 @@ namespace SixLabors.Fonts
             for (int i = 0; i < glyphLayouts.Count; i++)
             {
                 GlyphLayout glyph = glyphLayouts[i];
-                FontRectangle bounds = new(0, 0, glyph.Width * dpi, glyph.Height * dpi);
+                FontRectangle bounds = new(0, 0, glyph.AdvanceX * dpi, glyph.AdvanceY * dpi);
                 hasSize |= bounds.Width > 0 || bounds.Height > 0;
                 characterBoundsList[i] = new GlyphBounds(glyph.Glyph.GlyphMetrics.CodePoint, in bounds);
+            }
+
+            characterBounds = characterBoundsList;
+            return hasSize;
+        }
+
+        internal static bool TryGetCharacterSizes(IReadOnlyList<GlyphLayout> glyphLayouts, float dpi, out GlyphBounds[] characterBounds)
+        {
+            bool hasSize = false;
+            if (glyphLayouts.Count == 0)
+            {
+                characterBounds = Array.Empty<GlyphBounds>();
+                return hasSize;
+            }
+
+            var characterBoundsList = new GlyphBounds[glyphLayouts.Count];
+
+            float left = float.MinValue;
+            float top = float.MinValue;
+            float bottom = float.MinValue;
+            float right = float.MinValue;
+            for (int i = 0; i < glyphLayouts.Count; i++)
+            {
+                GlyphLayout g = glyphLayouts[i];
+                FontRectangle bounds = g.BoundingBox(dpi);
+
+                // We need to track the position of the glyph relative to the top left to include leading advances.
+                Vector2 location = g.Location;
+                float x = location.X;
+                float y = location.Y;
+
+                if (g.IsStartOfLine)
+                {
+                    // When the text contains a mix of glyphs of different sizes there can be line position overlap.
+                    // To accurately measure we offset to ensure that we always start where the last line ended.
+                    // Glyphs are always laid out from top-left to bottom-right so we can simply use the max.
+                    if (g.LayoutMode == GlyphLayoutMode.Horizontal)
+                    {
+                        y = MathF.Max(y, bottom);
+                    }
+                    else
+                    {
+                        x = MathF.Max(x, right);
+                    }
+                }
+
+                float advanceX = x + g.AdvanceX;
+                float advanceY = y + g.AdvanceY;
+
+                if (left < x)
+                {
+                    left = x;
+                }
+
+                if (top < y)
+                {
+                    top = y;
+                }
+
+                if (right < advanceX)
+                {
+                    right = advanceX;
+                }
+
+                if (bottom < advanceY)
+                {
+                    bottom = advanceY;
+                }
+
+                bounds = new(0, 0, bounds.Right - (left * dpi), bounds.Bottom - (top * dpi));
+
+                hasSize |= bounds.Width > 0 || bounds.Height > 0;
+                characterBoundsList[i] = new GlyphBounds(g.Glyph.GlyphMetrics.CodePoint, in bounds);
             }
 
             characterBounds = characterBoundsList;

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -216,8 +216,9 @@ namespace SixLabors.Fonts
                 return FontRectangle.Empty;
             }
 
+            Vector2 topLeft = glyphLayouts[0].BoxLocation * dpi;
             FontRectangle bounds = GetBounds(glyphLayouts, dpi);
-            return new FontRectangle(0, 0, MathF.Ceiling(bounds.Right), MathF.Ceiling(bounds.Bottom));
+            return new FontRectangle(0, 0, MathF.Ceiling(bounds.Right - topLeft.X), MathF.Ceiling(bounds.Bottom - topLeft.Y));
         }
 
         internal static FontRectangle GetBounds(IReadOnlyList<GlyphLayout> glyphLayouts, float dpi)

--- a/src/SixLabors.Fonts/TextOptions.cs
+++ b/src/SixLabors.Fonts/TextOptions.cs
@@ -131,7 +131,9 @@ namespace SixLabors.Fonts
         public Vector2 Origin { get; set; } = Vector2.Zero;
 
         /// <summary>
-        /// Gets or sets the length relative to the current DPI at which text will automatically wrap onto a newline.
+        /// Gets or sets the length in pixel units (px) at which text will automatically wrap onto a new line.
+        /// This property also affects the width or height (depending on the <see cref="LayoutMode"/>) of the text box
+        /// for alignment of text.
         /// </summary>
         /// <remarks>
         /// If value is -1 then wrapping is disabled.

--- a/src/SixLabors.Fonts/TextOptions.cs
+++ b/src/SixLabors.Fonts/TextOptions.cs
@@ -13,7 +13,6 @@ namespace SixLabors.Fonts
     /// </summary>
     public class TextOptions
     {
-        private float tabWidth = 4F;
         private float dpi = 72F;
         private float lineSpacing = 1F;
         private Font? font;
@@ -88,20 +87,12 @@ namespace SixLabors.Fonts
         }
 
         /// <summary>
-        /// Gets or sets the width of the tab. Measured as the distance in spaces.
-        /// <para/>
-        /// Defaults to 4.
+        /// Gets or sets the width of the tab. Measured as the distance in spaces (U+0020).
         /// </summary>
-        public float TabWidth
-        {
-            get => this.tabWidth;
-
-            set
-            {
-                Guard.MustBeGreaterThanOrEqualTo(value, 0, nameof(this.TabWidth));
-                this.tabWidth = value;
-            }
-        }
+        /// <remarks>
+        /// If value is -1 then the font default tab width is used.
+        /// </remarks>
+        public float TabWidth { get; set; } = -1F;
 
         /// <summary>
         /// Gets or sets a value indicating whether to apply hinting - The use of mathematical instructions

--- a/src/SixLabors.Fonts/TextRenderer.cs
+++ b/src/SixLabors.Fonts/TextRenderer.cs
@@ -59,7 +59,7 @@ namespace SixLabors.Fonts
 
             foreach (GlyphLayout g in glyphsToRender)
             {
-                g.Glyph.RenderTo(this.renderer, g.Location, g.Offset, options);
+                g.Glyph.RenderTo(this.renderer, g.Location, g.Offset, g.LayoutMode, options);
             }
 
             this.renderer.EndText();

--- a/src/SixLabors.Fonts/TextRenderer.cs
+++ b/src/SixLabors.Fonts/TextRenderer.cs
@@ -59,7 +59,7 @@ namespace SixLabors.Fonts
 
             foreach (GlyphLayout g in glyphsToRender)
             {
-                g.Glyph.RenderTo(this.renderer, g.Location, g.Offset, g.LayoutMode, options);
+                g.Glyph.RenderTo(this.renderer, g.PenLocation, g.Offset, g.LayoutMode, options);
             }
 
             this.renderer.EndText();

--- a/src/SixLabors.Fonts/VerticalMetrics.cs
+++ b/src/SixLabors.Fonts/VerticalMetrics.cs
@@ -25,5 +25,10 @@ namespace SixLabors.Fonts
 
         /// <inheritdoc/>
         public short AdvanceHeightMax { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the metrics have been synthesized.
+        /// </summary>
+        internal bool Synthesized { get; set; }
     }
 }

--- a/tests/SixLabors.Fonts.Benchmarks/SixLabors.Fonts.Benchmarks/MeasureTextBenchmark.cs
+++ b/tests/SixLabors.Fonts.Benchmarks/SixLabors.Fonts.Benchmarks/MeasureTextBenchmark.cs
@@ -46,7 +46,7 @@ namespace SixLabors.Fonts.Benchmarks
         public string Text { get; set; } = string.Empty;
 
         [Benchmark]
-        public void SixLaborsFonts() => TextMeasurer.Measure(this.Text, this.textOptions);
+        public void SixLaborsFonts() => TextMeasurer.MeasureSize(this.Text, this.textOptions);
 
         [Benchmark]
         public void SkiaSharp() => this.paint.MeasureText(this.Text);

--- a/tests/SixLabors.Fonts.Tests/Accents.cs
+++ b/tests/SixLabors.Fonts.Tests/Accents.cs
@@ -21,7 +21,7 @@ namespace SixLabors.Fonts.Tests
             FontFamily sans = new FontCollection().Add(TestFonts.OpenSansFile);
             var font = new Font(sans, 1f, FontStyle.Regular);
 
-            FontRectangle size = TextMeasurer.Measure(c.ToString(), new TextOptions(font));
+            FontRectangle size = TextMeasurer.MeasureSize(c.ToString(), new TextOptions(font));
         }
 
         [Theory]
@@ -38,7 +38,7 @@ namespace SixLabors.Fonts.Tests
             FontFamily sans = new FontCollection().Add(TestFonts.OpenSansFile);
             var font = new Font(sans, 1f, FontStyle.Regular);
 
-            FontRectangle size = TextMeasurer.Measure($"abc{c}def", new TextOptions(font));
+            FontRectangle size = TextMeasurer.MeasureSize($"abc{c}def", new TextOptions(font));
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
@@ -52,7 +52,7 @@ namespace SixLabors.Fonts.Tests
 
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
 
             Assert.Equal(37, r.ControlPoints.Count);
             Assert.Single(r.GlyphKeys);
@@ -67,7 +67,7 @@ namespace SixLabors.Fonts.Tests
             Assert.True(font.TryGetGlyphs(new CodePoint('A'), ColorFontSupport.None, out IReadOnlyList<Glyph> glyphs));
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
 
             Assert.Equal(37, r.ControlPoints.Count);
             Assert.Single(r.GlyphKeys);
@@ -101,7 +101,7 @@ namespace SixLabors.Fonts.Tests
             Assert.True(font.TryGetGlyphs(new CodePoint('A'), ColorFontSupport.None, out IReadOnlyList<Glyph> glyphs));
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
 
             Assert.Equal(37, r.ControlPoints.Count);
             Assert.Single(r.GlyphKeys);
@@ -120,7 +120,7 @@ namespace SixLabors.Fonts.Tests
             Assert.True(font.TryGetGlyphs(new CodePoint('a'), ColorFontSupport.None, out IReadOnlyList<Glyph> glyphs));
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
 
             // the test font only has characters .notdef, 'a' & 'b' defined
             Assert.Equal(6, r.ControlPoints.Distinct().Count());
@@ -137,7 +137,7 @@ namespace SixLabors.Fonts.Tests
             Assert.True(font.TryGetGlyphs(new CodePoint('a'), ColorFontSupport.None, out IReadOnlyList<Glyph> glyphs));
             Glyph glyph = glyphs[0];
             GlyphRenderer r = new();
-            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(r, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
 
             // the test font only has characters .notdef, 'a' & 'b' defined
             Assert.Equal(6, r.ControlPoints.Distinct().Count());

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -50,7 +50,7 @@ namespace SixLabors.Fonts.Tests
             Glyph glyph = new(glyphMetrics.CloneForRendering(textRun), font.Size);
 
             Vector2 locationInFontSpace = new Vector2(99, 99) / 72; // glyph ends up 10px over due to offset in fake glyph
-            glyph.RenderTo(this.renderer, locationInFontSpace, Vector2.Zero, new TextOptions(font));
+            glyph.RenderTo(this.renderer, locationInFontSpace, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
 
             Assert.Equal(new FontRectangle(99, 89, 0, 0), this.renderer.GlyphRects.Single());
         }
@@ -167,11 +167,11 @@ namespace SixLabors.Fonts.Tests
             string text = "\U0001F469\U0001F3FB\u200D\U0001F91D\u200D\U0001F469\U0001F3FC"; // women holding hands: light skin tone, medium-light skin tone
             string text2 = "\U0001F46D\U0001F3FB"; // women holding hands: light skin tone
 
-            FontRectangle size = TextMeasurer.Measure(text, new TextOptions(font));
-            FontRectangle size2 = TextMeasurer.Measure(text2, new TextOptions(font));
+            FontRectangle size = TextMeasurer.MeasureSize(text, new TextOptions(font));
+            FontRectangle size2 = TextMeasurer.MeasureSize(text2, new TextOptions(font));
 
-            Assert.True(size.Width > 103);
-            Assert.True(size2.Width > 98);
+            Assert.Equal(75F, size.Width);
+            Assert.Equal(75F, size2.Width);
         }
 
         [Theory]

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_180.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_180.cs
@@ -13,10 +13,10 @@ namespace SixLabors.Fonts.Tests.Issues
             // Whitney-book has invalid hhea values.
             Font font = new FontCollection().Add(TestFonts.WhitneyBookFile).CreateFont(25);
 
-            FontRectangle size = TextMeasurer.Measure("H", new TextOptions(font));
+            FontRectangle size = TextMeasurer.MeasureSize("H", new TextOptions(font));
 
-            Assert.Equal(18, size.Width, 1);
-            Assert.Equal(31, size.Height, 1);
+            Assert.Equal(16, size.Width, 1);
+            Assert.Equal(21, size.Height, 1);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_269.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_269.cs
@@ -4,7 +4,6 @@
 #if NET472
 using System;
 #endif
-
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_269.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_269.cs
@@ -13,10 +13,10 @@ namespace SixLabors.Fonts.Tests.Issues
             // AliceFrancesHMK has invalid subtables.
             Font font = new FontCollection().Add(TestFonts.AliceFrancesHMKRegularFile).CreateFont(25);
 
-            FontRectangle size = TextMeasurer.Measure("H", new TextOptions(font));
+            FontRectangle size = TextMeasurer.MeasureSize("H", new TextOptions(font));
 
             Assert.Equal(32, size.Width, 1);
-            Assert.Equal(31, size.Height, 1);
+            Assert.Equal(27, size.Height, 1);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_269.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_269.cs
@@ -17,21 +17,7 @@ namespace SixLabors.Fonts.Tests.Issues
             Font font = new FontCollection().Add(TestFonts.AliceFrancesHMKRegularFile).CreateFont(25);
 
             FontRectangle size = TextMeasurer.MeasureSize("H", new TextOptions(font));
-
-            // TODO: We should probably drop the 32bit test runner.
-#if NET472
-            if (Environment.Is64BitProcess)
-            {
-                Assert.Equal(32, size.Width, 1);
-            }
-            else
-            {
-                Assert.Equal(33, size.Width, 1);
-            }
-#else
             Assert.Equal(32, size.Width, 1);
-#endif
-
             Assert.Equal(27, size.Height, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_269.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_269.cs
@@ -1,6 +1,10 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+#if NET472
+using System;
+#endif
+
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues
@@ -15,7 +19,20 @@ namespace SixLabors.Fonts.Tests.Issues
 
             FontRectangle size = TextMeasurer.MeasureSize("H", new TextOptions(font));
 
+            // TODO: We should probably drop the 32bit test runner.
+#if NET472
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(32, size.Width, 1);
+            }
+            else
+            {
+                Assert.Equal(33, size.Width, 1);
+            }
+#else
             Assert.Equal(32, size.Width, 1);
+#endif
+
             Assert.Equal(27, size.Height, 1);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_27.cs
@@ -15,7 +15,7 @@ namespace SixLabors.Fonts.Tests.Issues
             FontRectangle size = TextMeasurer.MeasureBounds("          ", new TextOptions(new Font(font, 30)));
 
             Assert.Equal(60, size.Width, 1);
-            Assert.Equal(31.6, size.Height, 1);
+            Assert.Equal(0, size.Height, 1);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_298.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_298.cs
@@ -28,7 +28,7 @@ namespace SixLabors.Fonts.Tests.Issues
                 KerningMode = KerningMode.Auto
             };
 
-            FontRectangle bounds = TextMeasurer.Measure(content.AsSpan(), renderOptions);
+            FontRectangle bounds = TextMeasurer.MeasureSize(content.AsSpan(), renderOptions);
             Assert.NotEqual(default, bounds);
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_302.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_302.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using Xunit;
 
 namespace SixLabors.Fonts.Tests.Issues
@@ -16,7 +17,7 @@ namespace SixLabors.Fonts.Tests.Issues
             Font font = fontFamily.CreateFont(16, FontStyle.Regular);
             TextOptions renderOptions = new(font);
 
-            Assert.True(TextMeasurer.TryMeasureCharacterBounds(content, renderOptions, out GlyphBounds[] _));
+            Assert.True(TextMeasurer.TryMeasureCharacterBounds(content, renderOptions, out ReadOnlySpan<GlyphBounds> _));
         }
 #endif
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_32.cs
@@ -14,7 +14,7 @@ namespace SixLabors.Fonts.Tests.Issues
         {
             string text = "Hello\tworld";
             Font font = CreateFont(text);
-            FontRectangle size = TextMeasurer.MeasureBounds(text, new TextOptions(font)
+            FontRectangle size = TextMeasurer.MeasureSize(text, new TextOptions(font)
             {
                 Dpi = font.FontMetrics.ScaleFactor,
                 TabWidth = 0
@@ -22,7 +22,7 @@ namespace SixLabors.Fonts.Tests.Issues
 
             // tab width of 0 should make tabs not render at all
             Assert.Equal(10, size.Height, 4);
-            Assert.Equal(280, size.Width, 4);
+            Assert.Equal(320, size.Width, 4);
         }
 
         public static Font CreateFont(string text)

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
@@ -10,11 +10,11 @@ namespace SixLabors.Fonts.Tests.Issues
     public class Issues_33
     {
         [Theory]
-        [InlineData("\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs", 760, 70)] // newlines aren't directly measured but it is used for offsetting
-        [InlineData("\n\tHelloworld", 400, 10)]
-        [InlineData("\tHelloworld", 400, 10)]
+        [InlineData("\naaaabbbbccccddddeeee\n\t\t\t3 tabs\n\t\t\t\t\t5 tabs", 580, 70)] // newlines aren't directly measured but it is used for offsetting
+        [InlineData("\n\tHelloworld", 310, 10)]
+        [InlineData("\tHelloworld", 310, 10)]
         [InlineData("  Helloworld", 340, 10)]
-        [InlineData("Hell owor ld\t", 480, 10)]
+        [InlineData("Hell owor ld\t", 390, 10)]
         [InlineData("Helloworld  ", 360, 10)]
         public void WhiteSpaceAtStartOfLineNotMeasured(string text, float width, float height)
         {

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_335.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_335.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using Xunit;
+
+namespace SixLabors.Fonts.Tests.Issues
+{
+    public class Issues_335
+    {
+        [Theory]
+        [InlineData(TextAlignment.Start)]
+        [InlineData(TextAlignment.Center)]
+        [InlineData(TextAlignment.End)]
+        public void HorizontalAlignmentWorksForSingleLineText(TextAlignment alignment)
+        {
+            FontFamily family = new FontCollection().Add(TestFonts.OpenSansFile);
+            family.TryGetMetrics(FontStyle.Regular, out FontMetrics metrics);
+
+            TextOptions options = new(family.CreateFont(metrics.UnitsPerEm))
+            {
+                LineSpacing = 1.5F,
+                WrappingLength = 10000,
+                TextAlignment = alignment,
+            };
+
+            string text = "abc123";
+
+            FontRectangle singleBounds = TextMeasurer.MeasureBounds(text, options);
+
+            text = "abc123\nabc123";
+
+            FontRectangle multipleBounds = TextMeasurer.MeasureBounds(text, options);
+
+            Assert.Equal(multipleBounds.Location, singleBounds.Location);
+        }
+
+        [Theory]
+        [InlineData(TextAlignment.Start)]
+        [InlineData(TextAlignment.Center)]
+        [InlineData(TextAlignment.End)]
+        public void VerticalAlignmentWorksForSingleLineText(TextAlignment alignment)
+        {
+            FontFamily family = new FontCollection().Add(TestFonts.OpenSansFile);
+            family.TryGetMetrics(FontStyle.Regular, out FontMetrics metrics);
+
+            TextOptions options = new(family.CreateFont(metrics.UnitsPerEm))
+            {
+                LineSpacing = 1.5F,
+                WrappingLength = 10000,
+                TextAlignment = alignment,
+                LayoutMode = LayoutMode.VerticalLeftRight
+            };
+
+            string text = "abc123";
+
+            FontRectangle singleBounds = TextMeasurer.MeasureBounds(text, options);
+
+            text = "abc123\nabc123";
+
+            FontRectangle multipleBounds = TextMeasurer.MeasureBounds(text, options);
+
+            Assert.Equal(multipleBounds.Location, singleBounds.Location);
+        }
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_47.cs
@@ -25,13 +25,13 @@ namespace SixLabors.Fonts.Tests.Issues
                 HorizontalAlignment = HorizontalAlignment.Left
             });
 
-            float lineYPos = layout[0].Location.Y;
+            float lineYPos = layout[0].PenLocation.Y;
             foreach (GlyphLayout glyph in layout)
             {
-                if (lineYPos != glyph.Location.Y)
+                if (lineYPos != glyph.PenLocation.Y)
                 {
                     Assert.False(glyph.IsWhiteSpace());
-                    lineYPos = glyph.Location.Y;
+                    lineYPos = glyph.PenLocation.Y;
                 }
             }
         }
@@ -53,15 +53,15 @@ namespace SixLabors.Fonts.Tests.Issues
                 HorizontalAlignment = horizontalAlignment
             });
 
-            float lineYPos = layout[0].Location.Y;
+            float lineYPos = layout[0].PenLocation.Y;
             for (int i = 0; i < layout.Count; i++)
             {
                 GlyphLayout glyph = layout[i];
-                if (lineYPos != glyph.Location.Y)
+                if (lineYPos != glyph.PenLocation.Y)
                 {
                     Assert.False(glyph.IsWhiteSpace());
                     Assert.False(layout[i - 1].IsWhiteSpace());
-                    lineYPos = glyph.Location.Y;
+                    lineYPos = glyph.PenLocation.Y;
                 }
             }
         }

--- a/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/GPos/GPosTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/GPos/GPosTableTests.cs
@@ -21,8 +21,8 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 20, 22 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(275, 1811, 825, 719),
-                new(1622, 1810, 978, 704),
+                new(275, 1085.9999F, 825, 719),
+                new(1622, 1084.9999F, 978, 704),
             };
 
             // act
@@ -56,8 +56,8 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 23, 22 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(322, 1811, 978, 708),
-                new(1522, 1810, 978, 704),
+                new(322, 1085.9999F, 978, 708),
+                new(1522, 1084.9999F, 978, 704),
             };
 
             // act
@@ -91,9 +91,9 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 25, 20, 22 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(322, 1830, 978, 671),
-                new(1675, 1811, 825, 719),
-                new(3322, 2210, 978, 704),
+                new(322, 1104.9999F, 978, 671),
+                new(1675, 1085.9999F, 825, 719),
+                new(3322, 1484.9999F, 978, 704),
             };
 
             // act
@@ -127,8 +127,8 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 20, 20 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(475, 1911, 825, 719),
-                new(575, 1811, 825, 719),
+                new(475, 1185.9999F, 825, 719),
+                new(575, 1085.9999F, 825, 719),
             };
 
             // act
@@ -162,8 +162,8 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 20, 21 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(475, 1811, 825, 719),
-                new(375, 1890, 825, 709),
+                new(475, 1085.9999F, 825, 719),
+                new(375, 1164.9999F, 825, 709),
             };
 
             // act
@@ -197,8 +197,8 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 20, 21 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(475, 1811, 825, 719),
-                new(375, 1890, 825, 709),
+                new(475, 1085.9999F, 825, 719),
+                new(375, 1164.9999F, 825, 709),
             };
 
             // act
@@ -232,8 +232,8 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 20, 21 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(475, 1811, 825, 719),
-                new(375, 1890, 825, 709),
+                new(475, 1085.9999F, 825, 719),
+                new(375, 1164.9999F, 825, 709),
             };
 
             // act
@@ -267,9 +267,9 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 22, 23, 24 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(342, 1810, 978, 704),
-                new(1842, 1811, 978, 708),
-                new(3342, 1834, 978, 667),
+                new(342, 1084.9999F, 978, 704),
+                new(1842, 1085.9999F, 978, 708),
+                new(3342, 1108.9999F, 978, 667),
             };
 
             // act
@@ -303,9 +303,9 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 22, 23, 24 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(342, 1810, 978, 704),
-                new(1842, 1811, 978, 708),
-                new(3342, 1834, 978, 667),
+                new(342, 1084.9999F, 978, 704),
+                new(1842, 1085.9999F, 978, 708),
+                new(3342, 1108.9999F, 978, 667),
             };
 
             // act
@@ -340,9 +340,9 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
 
             FontRectangle[] expectedFontRectangles =
             {
-                new(342, 1810, 978, 704),
-                new(1842, 1811, 978, 708),
-                new(3342, 1834, 978, 667),
+                new(342, 1084.9999F, 978, 704),
+                new(1842, 1085.9999F, 978, 708),
+                new(3342, 1108.9999F, 978, 667),
             };
 
             // act
@@ -378,10 +378,10 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 22, 23, 24, 25 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(322, 1810, 978, 704),
-                new(2022, 1811, 978, 708),
-                new(3522, 1834, 978, 667),
-                new(4822, 1830, 978, 671),
+                new(322, 1084.9999F, 978, 704),
+                new(2022, 1085.9999F, 978, 708),
+                new(3522, 1108.9999F, 978, 667),
+                new(4822, 1104.9999F, 978, 671),
             };
 
             // act
@@ -417,10 +417,10 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 22, 23, 24, 25 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(322, 1810, 978, 704),
-                new(2022, 1811, 978, 708),
-                new(3522, 1834, 978, 667),
-                new(4822, 1830, 978, 671),
+                new(322, 1084.9999F, 978, 704),
+                new(2022, 1085.9999F, 978, 708),
+                new(3522, 1108.9999F, 978, 667),
+                new(4822, 1104.9999F, 978, 671),
             };
 
             // act
@@ -456,10 +456,10 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 22, 23, 24, 25 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(322, 1810, 978, 704),
-                new(2022, 1811, 978, 708),
-                new(3522, 1834, 978, 667),
-                new(4822, 1830, 978, 671),
+                new(322, 1084.9999F, 978, 704),
+                new(2022, 1085.9999F, 978, 708),
+                new(3522, 1108.9999F, 978, 667),
+                new(4822, 1104.9999F, 978, 671),
             };
 
             // act
@@ -492,8 +492,8 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 759, 989 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(246, 177, 363, 322),
-                new(71, 238, 966, 1573),
+                new(246, 23.5F, 363, 322),
+                new(71, 84.5F, 966, 1573),
             };
 
             // act
@@ -527,9 +527,9 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GPos
             int[] expectedGlyphIndices = { 47, 50, 23 };
             FontRectangle[] expectedFontRectangles =
             {
-                new(345, 1398, 561, 461),
-                new(420, 1837, 447, 414),
-                new(40, 2514, 1002, 986),
+                new(345, 182, 561, 461),
+                new(420, 621, 447, 414),
+                new(40, 1298, 1002, 986),
             };
 
             // act

--- a/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
@@ -376,7 +376,7 @@ namespace SixLabors.Fonts.Tests.Tables.AdvancedTypographic.GSub
             Font font = new FontCollection().Add(TestFonts.GSubLookupType2BillionLaughs).CreateFont(12);
 
             // Act
-            TextMeasurer.Measure("lol", new TextOptions(font));
+            TextMeasurer.MeasureSize("lol", new TextOptions(font));
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/TestFonts.cs
+++ b/tests/SixLabors.Fonts.Tests/TestFonts.cs
@@ -280,7 +280,7 @@ namespace SixLabors.Fonts.Tests
             };
 
             IEnumerable<string> fullPaths = paths.Select(x => Path.GetFullPath(Path.Combine(root, x)));
-            string rootPath = fullPaths.FirstOrDefault(x => Directory.Exists(x));
+            string rootPath = fullPaths.FirstOrDefault(Directory.Exists);
 
             Assert.True(rootPath != null, $"could not find the font folder in any of these location, \n{string.Join("\n", fullPaths)}");
 

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -100,7 +100,7 @@ namespace SixLabors.Fonts.Tests
             HorizontalAlignment.Center,
             -30,
             -155)]
-        public void VerticalAlignmentTests(
+        public void CanAlignText(
             VerticalAlignment vertical,
             HorizontalAlignment horizontal,
             float top,
@@ -109,15 +109,90 @@ namespace SixLabors.Fonts.Tests
             const string text = "hello world\nhello";
             Font font = CreateFont(text);
 
-            var span = new TextOptions(font)
+            TextOptions options = new(font)
             {
                 Dpi = font.FontMetrics.ScaleFactor,
                 HorizontalAlignment = horizontal,
                 VerticalAlignment = vertical
             };
 
-            IReadOnlyList<GlyphLayout> glyphsToRender = TextLayout.GenerateLayout(text.AsSpan(), span);
-            FontRectangle bound = TextMeasurer.GetBounds(glyphsToRender, span.Dpi);
+            IReadOnlyList<GlyphLayout> glyphsToRender = TextLayout.GenerateLayout(text.AsSpan(), options);
+            FontRectangle bound = TextMeasurer.GetBounds(glyphsToRender, options.Dpi);
+
+            Assert.Equal(310, bound.Width, 3);
+            Assert.Equal(40, bound.Height, 3);
+            Assert.Equal(left, bound.Left, 3);
+            Assert.Equal(top, bound.Top, 3);
+        }
+
+        [Theory]
+        [InlineData(
+            VerticalAlignment.Top,
+            HorizontalAlignment.Left,
+            0,
+            180)]
+        [InlineData(
+            VerticalAlignment.Top,
+            HorizontalAlignment.Right,
+            0,
+            -320)]
+        [InlineData(
+            VerticalAlignment.Top,
+            HorizontalAlignment.Center,
+            0,
+            -70)]
+        [InlineData(
+            VerticalAlignment.Bottom,
+            HorizontalAlignment.Left,
+            -60,
+            180)]
+        [InlineData(
+            VerticalAlignment.Bottom,
+            HorizontalAlignment.Right,
+            -60,
+            -320)]
+        [InlineData(
+            VerticalAlignment.Bottom,
+            HorizontalAlignment.Center,
+            -60,
+            -70)]
+        [InlineData(
+            VerticalAlignment.Center,
+            HorizontalAlignment.Left,
+            -30,
+            180)]
+        [InlineData(
+            VerticalAlignment.Center,
+            HorizontalAlignment.Right,
+            -30,
+            -320)]
+        [InlineData(
+            VerticalAlignment.Center,
+            HorizontalAlignment.Center,
+            -30,
+            -70)]
+        public void CanAlignWithWrapping(
+            VerticalAlignment vertical,
+            HorizontalAlignment horizontal,
+            float top,
+            float left)
+        {
+            // Using a string with a forced line break shorter than the wrapping
+            // width covers cases where the offset should be expanded for both single and multiple lines.
+            const string text = "hello world\nhello";
+            Font font = CreateFont(text);
+
+            TextOptions options = new(font)
+            {
+                Dpi = font.FontMetrics.ScaleFactor,
+                HorizontalAlignment = horizontal,
+                VerticalAlignment = vertical,
+                WrappingLength = 500,
+                TextAlignment = TextAlignment.End
+            };
+
+            IReadOnlyList<GlyphLayout> glyphsToRender = TextLayout.GenerateLayout(text.AsSpan(), options);
+            FontRectangle bound = TextMeasurer.GetBounds(glyphsToRender, options.Dpi);
 
             Assert.Equal(310, bound.Width, 3);
             Assert.Equal(40, bound.Height, 3);
@@ -247,8 +322,8 @@ namespace SixLabors.Fonts.Tests
 
         [Theory]
         [InlineData("hello world", 310, 10)]
-        [InlineData("hello world hello world hello world", 310, 16)]
-        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 25)]
+        [InlineData("hello world hello world hello world", 310, 70)]
+        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 160)]
         public void MeasureTextWordWrappingVerticalLeftRight(string text, float height, float width)
         {
             Font font = CreateFont(text);
@@ -265,8 +340,8 @@ namespace SixLabors.Fonts.Tests
 
         [Theory]
         [InlineData("hello world", 310, 10)]
-        [InlineData("hello world hello world hello world", 310, 16)]
-        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 25)]
+        [InlineData("hello world hello world hello world", 310, 70)]
+        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 160)]
         public void MeasureTextWordWrappingVerticalRightLeft(string text, float height, float width)
         {
             Font font = CreateFont(text);
@@ -282,9 +357,9 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Theory]
-        [InlineData("hello world", 290, 10)] // 310 - 20 due to negative result of x-axis on rotation.
-        [InlineData("hello world hello world hello world", 290, 70)] // 310 - 20 due to negative result of x-axis on rotation.
-        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 25)]
+        [InlineData("hello world", 310, 10)]
+        [InlineData("hello world hello world hello world", 310, 70)]
+        [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 160)]
         public void MeasureTextWordWrappingVerticalMixedLeftRight(string text, float height, float width)
         {
             Font font = CreateFont(text);
@@ -301,12 +376,12 @@ namespace SixLabors.Fonts.Tests
 
 #if OS_WINDOWS
         [Theory]
-        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.Standard, 134, 871)]
-        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakAll, 160, 400)]
-        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.KeepAll, 80, 700)]
-        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.Standard, 134, 871)]
-        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakAll, 160, 400)]
-        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.KeepAll, 80, 700)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.Standard, 100, 870)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakAll, 120, 399)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.KeepAll, 60, 699)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.Standard, 101, 870)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakAll, 121, 399)]
+        [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.KeepAll, 61, 699)]
         public void MeasureTextWordBreak(string text, LayoutMode layoutMode, WordBreaking wordBreaking, float height, float width)
         {
             // Testing using Windows only to ensure that actual glyphs are rendered
@@ -315,7 +390,7 @@ namespace SixLabors.Fonts.Tests
             FontFamily jhengHei = SystemFonts.Get("Microsoft JhengHei");
 
             Font font = arial.CreateFont(20);
-            FontRectangle size = TextMeasurer.Measure(
+            FontRectangle size = TextMeasurer.MeasureSize(
                 text,
                 new TextOptions(font)
                 {
@@ -352,7 +427,7 @@ namespace SixLabors.Fonts.Tests
         }
 
         [Theory]
-        [InlineData("a", 100, 100, 125, 452)]
+        [InlineData("a", 100, 100, 125, 396)]
         public void LayoutWithLocation(string text, float x, float y, float expectedX, float expectedY)
         {
             var c = new FontCollection();
@@ -379,7 +454,7 @@ namespace SixLabors.Fonts.Tests
             FontCollection c = new();
             Font font = c.Add(TestFonts.SimpleFontFileData()).CreateFont(12);
             TextOptions textOptions = new(font);
-            FontRectangle measurement = TextMeasurer.Measure("/ This will fail", textOptions);
+            FontRectangle measurement = TextMeasurer.MeasureSize("/ This will fail", textOptions);
 
             Assert.NotEqual(FontRectangle.Empty, measurement);
         }
@@ -545,7 +620,7 @@ namespace SixLabors.Fonts.Tests
             // Collect the first line so we can compare it to the target wrapping length.
             IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
-            TextMeasurer.TryGetCharacterDimensions(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
+            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
 
             Assert.Equal(wrappingLength, justifiedCharacterBounds.Sum(x => x.Bounds.Width), 4);
 
@@ -553,7 +628,7 @@ namespace SixLabors.Fonts.Tests
             options.TextJustification = TextJustification.None;
             IReadOnlyList<GlyphLayout> glyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> line = CollectFirstLine(glyphs);
-            TextMeasurer.TryGetCharacterDimensions(line, options.Dpi, out GlyphBounds[] characterBounds);
+            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out GlyphBounds[] characterBounds);
 
             // All but the last justified character advance should be greater than the
             // corresponding character advance.
@@ -589,7 +664,7 @@ namespace SixLabors.Fonts.Tests
             // Collect the first line so we can compare it to the target wrapping length.
             IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
-            TextMeasurer.TryGetCharacterDimensions(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
+            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
 
             Assert.Equal(wrappingLength, justifiedCharacterBounds.Sum(x => x.Bounds.Width), 4);
 
@@ -597,7 +672,7 @@ namespace SixLabors.Fonts.Tests
             options.TextJustification = TextJustification.None;
             IReadOnlyList<GlyphLayout> glyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> line = CollectFirstLine(glyphs);
-            TextMeasurer.TryGetCharacterDimensions(line, options.Dpi, out GlyphBounds[] characterBounds);
+            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out GlyphBounds[] characterBounds);
 
             // All but the last justified whitespace character advance should be greater than the
             // corresponding character advance.
@@ -634,7 +709,7 @@ namespace SixLabors.Fonts.Tests
             // Collect the first line so we can compare it to the target wrapping length.
             IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
-            TextMeasurer.TryGetCharacterDimensions(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
+            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
 
             Assert.Equal(wrappingLength, justifiedCharacterBounds.Sum(x => x.Bounds.Height), 4);
 
@@ -642,7 +717,7 @@ namespace SixLabors.Fonts.Tests
             options.TextJustification = TextJustification.None;
             IReadOnlyList<GlyphLayout> glyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> line = CollectFirstLine(glyphs);
-            TextMeasurer.TryGetCharacterDimensions(line, options.Dpi, out GlyphBounds[] characterBounds);
+            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out GlyphBounds[] characterBounds);
 
             // All but the last justified character advance should be greater than the
             // corresponding character advance.
@@ -679,7 +754,7 @@ namespace SixLabors.Fonts.Tests
             // Collect the first line so we can compare it to the target wrapping length.
             IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
-            TextMeasurer.TryGetCharacterDimensions(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
+            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
 
             Assert.Equal(wrappingLength, justifiedCharacterBounds.Sum(x => x.Bounds.Height), 4);
 
@@ -687,7 +762,7 @@ namespace SixLabors.Fonts.Tests
             options.TextJustification = TextJustification.None;
             IReadOnlyList<GlyphLayout> glyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> line = CollectFirstLine(glyphs);
-            TextMeasurer.TryGetCharacterDimensions(line, options.Dpi, out GlyphBounds[] characterBounds);
+            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out GlyphBounds[] characterBounds);
 
             // All but the last justified whitespace character advance should be greater than the
             // corresponding character advance.
@@ -707,100 +782,100 @@ namespace SixLabors.Fonts.Tests
         public static TheoryData<char, FontRectangle> OpenSans_Data
             = new()
             {
-                { '!', new(0, 0, 3, 14) },
-                { '"', new(0, 0, 4, 14) },
-                { '#', new(0, 0, 7, 14) },
-                { '$', new(0, 0, 6, 14) },
-                { '%', new(0, 0, 9, 14) },
-                { '&', new(0, 0, 8, 14) },
-                { '\'', new(0, 0, 3, 14) },
-                { '(', new(0, 0, 3, 14) },
-                { ')', new(0, 0, 3, 14) },
-                { '*', new(0, 0, 6, 14) },
-                { '+', new(0, 0, 6, 14) },
-                { ',', new(0, 0, 3, 14) },
-                { '-', new(0, 0, 4, 14) },
-                { '.', new(0, 0, 3, 14) },
-                { '/', new(0, 0, 4, 14) },
-                { '0', new(0, 0, 6, 14) },
-                { '1', new(0, 0, 6, 14) },
-                { '2', new(0, 0, 6, 14) },
-                { '3', new(0, 0, 6, 14) },
-                { '4', new(0, 0, 6, 14) },
-                { '5', new(0, 0, 6, 14) },
-                { '6', new(0, 0, 6, 14) },
-                { '7', new(0, 0, 6, 14) },
-                { '8', new(0, 0, 6, 14) },
-                { '9', new(0, 0, 6, 14) },
-                { ':', new(0, 0, 3, 14) },
-                { ';', new(0, 0, 3, 14) },
-                { '<', new(0, 0, 6, 14) },
-                { '=', new(0, 0, 6, 14) },
-                { '>', new(0, 0, 6, 14) },
-                { '?', new(0, 0, 5, 14) },
-                { '@', new(0, 0, 9, 14) },
-                { 'A', new(0, 0, 7, 14) },
-                { 'B', new(0, 0, 7, 14) },
-                { 'C', new(0, 0, 7, 14) },
-                { 'D', new(0, 0, 8, 14) },
-                { 'E', new(0, 0, 6, 14) },
-                { 'F', new(0, 0, 6, 14) },
-                { 'G', new(0, 0, 8, 14) },
-                { 'H', new(0, 0, 8, 14) },
-                { 'I', new(0, 0, 3, 14) },
-                { 'J', new(0, 0, 3, 14) },
-                { 'K', new(0, 0, 7, 14) },
-                { 'L', new(0, 0, 6, 14) },
-                { 'M', new(0, 0, 9, 14) },
-                { 'N', new(0, 0, 8, 14) },
-                { 'O', new(0, 0, 8, 14) },
-                { 'P', new(0, 0, 7, 14) },
-                { 'Q', new(0, 0, 8, 14) },
-                { 'R', new(0, 0, 7, 14) },
-                { 'S', new(0, 0, 6, 14) },
-                { 'T', new(0, 0, 6, 14) },
-                { 'U', new(0, 0, 8, 14) },
-                { 'V', new(0, 0, 6, 14) },
-                { 'W', new(0, 0, 10, 14) },
-                { 'X', new(0, 0, 6, 14) },
-                { 'Y', new(0, 0, 6, 14) },
-                { 'Z', new(0, 0, 6, 14) },
-                { '[', new(0, 0, 4, 14) },
-                { '\\', new(0, 0, 4, 14) },
-                { ']', new(0, 0, 4, 14) },
-                { '^', new(0, 0, 6, 14) },
-                { '_', new(0, 0, 5, 14) },
-                { '`', new(0, 0, 3, 14) },
-                { 'a', new(0, 0, 6, 14) },
-                { 'b', new(0, 0, 7, 14) },
-                { 'c', new(0, 0, 5, 14) },
-                { 'd', new(0, 0, 7, 14) },
-                { 'e', new(0, 0, 6, 14) },
-                { 'f', new(0, 0, 4, 14) },
-                { 'g', new(0, 0, 6, 14) },
-                { 'h', new(0, 0, 7, 14) },
-                { 'i', new(0, 0, 3, 14) },
-                { 'j', new(0, 0, 3, 14) },
-                { 'k', new(0, 0, 6, 14) },
-                { 'l', new(0, 0, 3, 14) },
-                { 'm', new(0, 0, 10, 14) },
-                { 'n', new(0, 0, 7, 14) },
-                { 'o', new(0, 0, 7, 14) },
-                { 'p', new(0, 0, 7, 14) },
-                { 'q', new(0, 0, 7, 14) },
-                { 'r', new(0, 0, 5, 14) },
-                { 's', new(0, 0, 5, 14) },
-                { 't', new(0, 0, 4, 14) },
-                { 'u', new(0, 0, 7, 14) },
-                { 'v', new(0, 0, 5, 14) },
-                { 'w', new(0, 0, 8, 14) },
-                { 'x', new(0, 0, 6, 14) },
-                { 'y', new(0, 0, 6, 14) },
-                { 'z', new(0, 0, 5, 14) },
-                { '{', new(0, 0, 4, 14) },
-                { '|', new(0, 0, 6, 14) },
-                { '}', new(0, 0, 4, 14) },
-                { '~', new(0, 0, 6, 14) },
+                { '!', new(0, 0, 2, 10) },
+                { '"', new(0, 0, 4, 5) },
+                { '#', new(0, 0, 7, 9) },
+                { '$', new(0, 0, 6, 10) },
+                { '%', new(0, 0, 8, 9) },
+                { '&', new(0, 0, 8, 9) },
+                { '\'', new(0, 0, 2, 5) },
+                { '(', new(0, 0, 3, 11) },
+                { ')', new(0, 0, 3, 11) },
+                { '*', new(0, 0, 6, 6) },
+                { '+', new(0, 0, 6, 8) },
+                { ',', new(0, 0, 2, 11) },
+                { '-', new(0, 0, 3, 7) },
+                { '.', new(0, 0, 2, 10) },
+                { '/', new(0, 0, 4, 9) },
+                { '0', new(0, 0, 6, 9) },
+                { '1', new(0, 0, 4, 9) },
+                { '2', new(0, 0, 6, 9) },
+                { '3', new(0, 0, 6, 9) },
+                { '4', new(0, 0, 6, 9) },
+                { '5', new(0, 0, 6, 9) },
+                { '6', new(0, 0, 6, 9) },
+                { '7', new(0, 0, 6, 9) },
+                { '8', new(0, 0, 6, 9) },
+                { '9', new(0, 0, 6, 9) },
+                { ':', new(0, 0, 2, 10) },
+                { ';', new(0, 0, 2, 11) },
+                { '<', new(0, 0, 6, 8) },
+                { '=', new(0, 0, 6, 7) },
+                { '>', new(0, 0, 6, 8) },
+                { '?', new(0, 0, 5, 10) },
+                { '@', new(0, 0, 9, 10) },
+                { 'A', new(0, 0, 7, 9) },
+                { 'B', new(0, 0, 6, 9) },
+                { 'C', new(0, 0, 6, 9) },
+                { 'D', new(0, 0, 7, 9) },
+                { 'E', new(0, 0, 5, 9) },
+                { 'F', new(0, 0, 5, 9) },
+                { 'G', new(0, 0, 7, 9) },
+                { 'H', new(0, 0, 7, 9) },
+                { 'I', new(0, 0, 2, 9) },
+                { 'J', new(0, 0, 2, 11) },
+                { 'K', new(0, 0, 7, 9) },
+                { 'L', new(0, 0, 5, 9) },
+                { 'M', new(0, 0, 9, 9) },
+                { 'N', new(0, 0, 7, 9) },
+                { 'O', new(0, 0, 8, 9) },
+                { 'P', new(0, 0, 6, 9) },
+                { 'Q', new(0, 0, 8, 11) },
+                { 'R', new(0, 0, 7, 9) },
+                { 'S', new(0, 0, 6, 9) },
+                { 'T', new(0, 0, 6, 9) },
+                { 'U', new(0, 0, 7, 9) },
+                { 'V', new(0, 0, 6, 9) },
+                { 'W', new(0, 0, 10, 9) },
+                { 'X', new(0, 0, 6, 9) },
+                { 'Y', new(0, 0, 6, 9) },
+                { 'Z', new(0, 0, 6, 9) },
+                { '[', new(0, 0, 4, 11) },
+                { '\\', new(0, 0, 4, 9) },
+                { ']', new(0, 0, 3, 11) },
+                { '^', new(0, 0, 6, 7) },
+                { '_', new(0, 0, 5, 11) },
+                { '`', new(0, 0, 3, 3) },
+                { 'a', new(0, 0, 5, 9) },
+                { 'b', new(0, 0, 6, 9) },
+                { 'c', new(0, 0, 5, 9) },
+                { 'd', new(0, 0, 6, 9) },
+                { 'e', new(0, 0, 6, 9) },
+                { 'f', new(0, 0, 4, 9) },
+                { 'g', new(0, 0, 6, 12) },
+                { 'h', new(0, 0, 6, 9) },
+                { 'i', new(0, 0, 2, 9) },
+                { 'j', new(0, 0, 2, 12) },
+                { 'k', new(0, 0, 6, 9) },
+                { 'l', new(0, 0, 2, 9) },
+                { 'm', new(0, 0, 9, 9) },
+                { 'n', new(0, 0, 6, 9) },
+                { 'o', new(0, 0, 6, 9) },
+                { 'p', new(0, 0, 6, 12) },
+                { 'q', new(0, 0, 6, 12) },
+                { 'r', new(0, 0, 4, 9) },
+                { 's', new(0, 0, 5, 9) },
+                { 't', new(0, 0, 4, 9) },
+                { 'u', new(0, 0, 6, 9) },
+                { 'v', new(0, 0, 5, 9) },
+                { 'w', new(0, 0, 8, 9) },
+                { 'x', new(0, 0, 6, 9) },
+                { 'y', new(0, 0, 6, 12) },
+                { 'z', new(0, 0, 5, 9) },
+                { '{', new(0, 0, 4, 11) },
+                { '|', new(0, 0, 4, 12) },
+                { '}', new(0, 0, 4, 11) },
+                { '~', new(0, 0, 6, 6) },
             };
 
         [Theory]
@@ -813,7 +888,7 @@ namespace SixLabors.Fonts.Tests
                 HintingMode = HintingMode.Standard
             };
 
-            FontRectangle actual = TextMeasurer.Measure(c.ToString(), options);
+            FontRectangle actual = TextMeasurer.MeasureSize(c.ToString(), options);
             Assert.Equal(expected, actual);
 
             options = new(OpenSansWoff)
@@ -822,7 +897,7 @@ namespace SixLabors.Fonts.Tests
                 HintingMode = HintingMode.Standard
             };
 
-            actual = TextMeasurer.Measure(c.ToString(), options);
+            actual = TextMeasurer.MeasureSize(c.ToString(), options);
             Assert.Equal(expected, actual);
         }
 
@@ -833,100 +908,100 @@ namespace SixLabors.Fonts.Tests
         public static TheoryData<char, FontRectangle> SegoeUi_Data
             = new()
             {
-                { '!', new(0, 0, 3, 14) },
-                { '"', new(0, 0, 4, 14) },
-                { '#', new(0, 0, 6, 14) },
-                { '$', new(0, 0, 6, 14) },
-                { '%', new(0, 0, 9, 14) },
-                { '&', new(0, 0, 9, 14) },
-                { '\'', new(0, 0, 3, 14) },
-                { '(', new(0, 0, 4, 14) },
-                { ')', new(0, 0, 4, 14) },
-                { '*', new(0, 0, 5, 14) },
-                { '+', new(0, 0, 7, 14) },
-                { ',', new(0, 0, 3, 14) },
-                { '-', new(0, 0, 4, 14) },
-                { '.', new(0, 0, 3, 14) },
-                { '/', new(0, 0, 4, 14) },
-                { '0', new(0, 0, 6, 14) },
-                { '1', new(0, 0, 6, 14) },
-                { '2', new(0, 0, 6, 14) },
-                { '3', new(0, 0, 6, 14) },
-                { '4', new(0, 0, 6, 14) },
-                { '5', new(0, 0, 6, 14) },
-                { '6', new(0, 0, 6, 14) },
-                { '7', new(0, 0, 6, 14) },
-                { '8', new(0, 0, 6, 14) },
-                { '9', new(0, 0, 6, 14) },
-                { ':', new(0, 0, 3, 14) },
-                { ';', new(0, 0, 3, 14) },
-                { '<', new(0, 0, 7, 14) },
-                { '=', new(0, 0, 7, 14) },
-                { '>', new(0, 0, 7, 14) },
-                { '?', new(0, 0, 5, 14) },
-                { '@', new(0, 0, 10, 14) },
-                { 'A', new(0, 0, 7, 14) },
-                { 'B', new(0, 0, 6, 14) },
-                { 'C', new(0, 0, 7, 14) },
-                { 'D', new(0, 0, 8, 14) },
-                { 'E', new(0, 0, 6, 14) },
-                { 'F', new(0, 0, 5, 14) },
-                { 'G', new(0, 0, 7, 14) },
-                { 'H', new(0, 0, 8, 14) },
-                { 'I', new(0, 0, 3, 14) },
-                { 'J', new(0, 0, 4, 14) },
-                { 'K', new(0, 0, 6, 14) },
-                { 'L', new(0, 0, 5, 14) },
-                { 'M', new(0, 0, 9, 14) },
-                { 'N', new(0, 0, 8, 14) },
-                { 'O', new(0, 0, 8, 14) },
-                { 'P', new(0, 0, 6, 14) },
-                { 'Q', new(0, 0, 8, 14) },
-                { 'R', new(0, 0, 6, 14) },
-                { 'S', new(0, 0, 6, 14) },
-                { 'T', new(0, 0, 6, 14) },
-                { 'U', new(0, 0, 7, 14) },
-                { 'V', new(0, 0, 7, 14) },
-                { 'W', new(0, 0, 10, 14) },
-                { 'X', new(0, 0, 6, 14) },
-                { 'Y', new(0, 0, 6, 14) },
-                { 'Z', new(0, 0, 6, 14) },
-                { '[', new(0, 0, 4, 14) },
-                { '\\', new(0, 0, 4, 14) },
-                { ']', new(0, 0, 4, 14) },
-                { '^', new(0, 0, 7, 14) },
-                { '_', new(0, 0, 5, 14) },
-                { '`', new(0, 0, 3, 14) },
-                { 'a', new(0, 0, 6, 14) },
-                { 'b', new(0, 0, 6, 14) },
-                { 'c', new(0, 0, 5, 14) },
-                { 'd', new(0, 0, 6, 14) },
-                { 'e', new(0, 0, 6, 14) },
-                { 'f', new(0, 0, 4, 14) },
-                { 'g', new(0, 0, 6, 14) },
-                { 'h', new(0, 0, 6, 14) },
-                { 'i', new(0, 0, 3, 14) },
-                { 'j', new(0, 0, 3, 14) },
-                { 'k', new(0, 0, 5, 14) },
-                { 'l', new(0, 0, 3, 14) },
-                { 'm', new(0, 0, 9, 14) },
-                { 'n', new(0, 0, 6, 14) },
-                { 'o', new(0, 0, 6, 14) },
-                { 'p', new(0, 0, 6, 14) },
-                { 'q', new(0, 0, 6, 14) },
-                { 'r', new(0, 0, 4, 14) },
-                { 's', new(0, 0, 5, 14) },
-                { 't', new(0, 0, 4, 14) },
-                { 'u', new(0, 0, 6, 14) },
-                { 'v', new(0, 0, 5, 14) },
-                { 'w', new(0, 0, 8, 14) },
-                { 'x', new(0, 0, 5, 14) },
-                { 'y', new(0, 0, 5, 14) },
-                { 'z', new(0, 0, 5, 14) },
-                { '{', new(0, 0, 4, 14) },
-                { '|', new(0, 0, 3, 14) },
-                { '}', new(0, 0, 4, 14) },
-                { '~', new(0, 0, 7, 14) }
+                { '!', new(0, 0, 2, 10) },
+                { '"', new(0, 0, 4, 5) },
+                { '#', new(0, 0, 6, 9) },
+                { '$', new(0, 0, 5, 11) },
+                { '%', new(0, 0, 8, 10) },
+                { '&', new(0, 0, 8, 10) },
+                { '\'', new(0, 0, 2, 5) },
+                { '(', new(0, 0, 3, 11) },
+                { ')', new(0, 0, 3, 11) },
+                { '*', new(0, 0, 4, 6) },
+                { '+', new(0, 0, 6, 9) },
+                { ',', new(0, 0, 2, 11) },
+                { '-', new(0, 0, 4, 7) },
+                { '.', new(0, 0, 2, 10) },
+                { '/', new(0, 0, 4, 11) },
+                { '0', new(0, 0, 5, 10) },
+                { '1', new(0, 0, 4, 10) },
+                { '2', new(0, 0, 5, 10) },
+                { '3', new(0, 0, 5, 10) },
+                { '4', new(0, 0, 6, 10) },
+                { '5', new(0, 0, 5, 10) },
+                { '6', new(0, 0, 5, 10) },
+                { '7', new(0, 0, 5, 10) },
+                { '8', new(0, 0, 5, 10) },
+                { '9', new(0, 0, 5, 10) },
+                { ':', new(0, 0, 2, 10) },
+                { ';', new(0, 0, 2, 11) },
+                { '<', new(0, 0, 6, 9) },
+                { '=', new(0, 0, 6, 8) },
+                { '>', new(0, 0, 6, 9) },
+                { '?', new(0, 0, 4, 10) },
+                { '@', new(0, 0, 9, 11) },
+                { 'A', new(0, 0, 7, 10) },
+                { 'B', new(0, 0, 6, 10) },
+                { 'C', new(0, 0, 6, 10) },
+                { 'D', new(0, 0, 7, 10) },
+                { 'E', new(0, 0, 5, 10) },
+                { 'F', new(0, 0, 5, 10) },
+                { 'G', new(0, 0, 7, 10) },
+                { 'H', new(0, 0, 7, 10) },
+                { 'I', new(0, 0, 2, 10) },
+                { 'J', new(0, 0, 3, 10) },
+                { 'K', new(0, 0, 6, 10) },
+                { 'L', new(0, 0, 5, 10) },
+                { 'M', new(0, 0, 9, 10) },
+                { 'N', new(0, 0, 7, 10) },
+                { 'O', new(0, 0, 8, 10) },
+                { 'P', new(0, 0, 6, 10) },
+                { 'Q', new(0, 0, 8, 11) },
+                { 'R', new(0, 0, 6, 10) },
+                { 'S', new(0, 0, 5, 10) },
+                { 'T', new(0, 0, 6, 10) },
+                { 'U', new(0, 0, 7, 10) },
+                { 'V', new(0, 0, 7, 10) },
+                { 'W', new(0, 0, 10, 10) },
+                { 'X', new(0, 0, 6, 10) },
+                { 'Y', new(0, 0, 6, 10) },
+                { 'Z', new(0, 0, 6, 10) },
+                { '[', new(0, 0, 3, 11) },
+                { '\\', new(0, 0, 4, 11) },
+                { ']', new(0, 0, 3, 11) },
+                { '^', new(0, 0, 6, 7) },
+                { '_', new(0, 0, 5, 11) },
+                { '`', new(0, 0, 3, 4) },
+                { 'a', new(0, 0, 5, 10) },
+                { 'b', new(0, 0, 6, 10) },
+                { 'c', new(0, 0, 5, 10) },
+                { 'd', new(0, 0, 6, 10) },
+                { 'e', new(0, 0, 5, 10) },
+                { 'f', new(0, 0, 4, 10) },
+                { 'g', new(0, 0, 6, 12) },
+                { 'h', new(0, 0, 5, 10) },
+                { 'i', new(0, 0, 2, 10) },
+                { 'j', new(0, 0, 2, 12) },
+                { 'k', new(0, 0, 5, 10) },
+                { 'l', new(0, 0, 2, 10) },
+                { 'm', new(0, 0, 8, 10) },
+                { 'n', new(0, 0, 5, 10) },
+                { 'o', new(0, 0, 6, 10) },
+                { 'p', new(0, 0, 6, 12) },
+                { 'q', new(0, 0, 6, 12) },
+                { 'r', new(0, 0, 4, 10) },
+                { 's', new(0, 0, 4, 10) },
+                { 't', new(0, 0, 4, 10) },
+                { 'u', new(0, 0, 5, 10) },
+                { 'v', new(0, 0, 5, 10) },
+                { 'w', new(0, 0, 8, 10) },
+                { 'x', new(0, 0, 5, 10) },
+                { 'y', new(0, 0, 5, 12) },
+                { 'z', new(0, 0, 5, 10) },
+                { '{', new(0, 0, 3, 11) },
+                { '|', new(0, 0, 2, 12) },
+                { '}', new(0, 0, 3, 11) },
+                { '~', new(0, 0, 6, 7) }
             };
 
         [Theory]
@@ -939,7 +1014,7 @@ namespace SixLabors.Fonts.Tests
                 HintingMode = HintingMode.Standard
             };
 
-            FontRectangle actual = TextMeasurer.Measure(c.ToString(), options);
+            FontRectangle actual = TextMeasurer.MeasureSize(c.ToString(), options);
             Assert.Equal(expected, actual);
         }
 
@@ -971,7 +1046,7 @@ namespace SixLabors.Fonts.Tests
         public FontRectangle BenchmarkTest()
         {
             Font font = Arial;
-            return TextMeasurer.Measure("The quick brown fox jumped over the lazy dog", new TextOptions(font) { Dpi = font.FontMetrics.ScaleFactor });
+            return TextMeasurer.MeasureSize("The quick brown fox jumped over the lazy dog", new TextOptions(font) { Dpi = font.FontMetrics.ScaleFactor });
         }
 
         private static readonly Font Arial = SystemFonts.CreateFont("Arial", 12);

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -254,14 +254,14 @@ namespace SixLabors.Fonts.Tests
             Assert.True(TextMeasurer.TryMeasureCharacterBounds(
                 text.AsSpan(),
                 new TextOptions(font) { Dpi = font.FontMetrics.ScaleFactor },
-                out GlyphBounds[] glyphMetrics));
+                out ReadOnlySpan<GlyphBounds> bounds));
 
             // Newline should not be returned.
-            Assert.Equal(text.Length - 1, glyphMetrics.Length);
-            for (int i = 0; i < glyphMetrics.Length; i++)
+            Assert.Equal(text.Length - 1, bounds.Length);
+            for (int i = 0; i < bounds.Length; i++)
             {
                 GlyphBounds expected = expectedGlyphMetrics[i];
-                GlyphBounds actual = glyphMetrics[i];
+                GlyphBounds actual = bounds[i];
                 Assert.Equal(expected.Codepoint, actual.Codepoint);
 
                 // 4 dp as there is minor offset difference in the float values
@@ -620,15 +620,15 @@ namespace SixLabors.Fonts.Tests
             // Collect the first line so we can compare it to the target wrapping length.
             IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
-            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
+            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out ReadOnlySpan<GlyphBounds> justifiedCharacterBounds);
 
-            Assert.Equal(wrappingLength, justifiedCharacterBounds.Sum(x => x.Bounds.Width), 4);
+            Assert.Equal(wrappingLength, justifiedCharacterBounds.ToArray().Sum(x => x.Bounds.Width), 4);
 
             // Now compare character widths.
             options.TextJustification = TextJustification.None;
             IReadOnlyList<GlyphLayout> glyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> line = CollectFirstLine(glyphs);
-            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out GlyphBounds[] characterBounds);
+            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out ReadOnlySpan<GlyphBounds> characterBounds);
 
             // All but the last justified character advance should be greater than the
             // corresponding character advance.
@@ -664,15 +664,15 @@ namespace SixLabors.Fonts.Tests
             // Collect the first line so we can compare it to the target wrapping length.
             IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
-            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
+            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out ReadOnlySpan<GlyphBounds> justifiedCharacterBounds);
 
-            Assert.Equal(wrappingLength, justifiedCharacterBounds.Sum(x => x.Bounds.Width), 4);
+            Assert.Equal(wrappingLength, justifiedCharacterBounds.ToArray().Sum(x => x.Bounds.Width), 4);
 
             // Now compare character widths.
             options.TextJustification = TextJustification.None;
             IReadOnlyList<GlyphLayout> glyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> line = CollectFirstLine(glyphs);
-            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out GlyphBounds[] characterBounds);
+            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out ReadOnlySpan<GlyphBounds> characterBounds);
 
             // All but the last justified whitespace character advance should be greater than the
             // corresponding character advance.
@@ -709,15 +709,15 @@ namespace SixLabors.Fonts.Tests
             // Collect the first line so we can compare it to the target wrapping length.
             IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
-            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
+            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out ReadOnlySpan<GlyphBounds> justifiedCharacterBounds);
 
-            Assert.Equal(wrappingLength, justifiedCharacterBounds.Sum(x => x.Bounds.Height), 4);
+            Assert.Equal(wrappingLength, justifiedCharacterBounds.ToArray().Sum(x => x.Bounds.Height), 4);
 
             // Now compare character widths.
             options.TextJustification = TextJustification.None;
             IReadOnlyList<GlyphLayout> glyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> line = CollectFirstLine(glyphs);
-            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out GlyphBounds[] characterBounds);
+            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out ReadOnlySpan<GlyphBounds> characterBounds);
 
             // All but the last justified character advance should be greater than the
             // corresponding character advance.
@@ -754,15 +754,15 @@ namespace SixLabors.Fonts.Tests
             // Collect the first line so we can compare it to the target wrapping length.
             IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
-            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out GlyphBounds[] justifiedCharacterBounds);
+            TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out ReadOnlySpan<GlyphBounds> justifiedCharacterBounds);
 
-            Assert.Equal(wrappingLength, justifiedCharacterBounds.Sum(x => x.Bounds.Height), 4);
+            Assert.Equal(wrappingLength, justifiedCharacterBounds.ToArray().Sum(x => x.Bounds.Height), 4);
 
             // Now compare character widths.
             options.TextJustification = TextJustification.None;
             IReadOnlyList<GlyphLayout> glyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
             IReadOnlyList<GlyphLayout> line = CollectFirstLine(glyphs);
-            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out GlyphBounds[] characterBounds);
+            TextMeasurer.TryGetCharacterAdvances(line, options.Dpi, out ReadOnlySpan<GlyphBounds> characterBounds);
 
             // All but the last justified whitespace character advance should be greater than the
             // corresponding character advance.
@@ -899,6 +899,100 @@ namespace SixLabors.Fonts.Tests
 
             actual = TextMeasurer.MeasureSize(c.ToString(), options);
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanMeasureTextAdvance()
+        {
+            FontFamily family = new FontCollection().Add(TestFonts.OpenSansFile);
+            family.TryGetMetrics(FontStyle.Regular, out FontMetrics metrics);
+
+            TextOptions options = new(family.CreateFont(metrics.UnitsPerEm))
+            {
+                LineSpacing = 1F
+            };
+
+            const string text = "Hello World!";
+            FontRectangle first = TextMeasurer.MeasureAdvance(text, options);
+            Assert.Equal(new FontRectangle(0, 0, 11729, 2049), first);
+
+            options.LineSpacing = 2F;
+            FontRectangle second = TextMeasurer.MeasureAdvance(text, options);
+            Assert.Equal(new FontRectangle(0, 0, 11729, 4096), second);
+        }
+
+        [Fact]
+        public void CanMeasureCharacterLayouts()
+        {
+            FontFamily family = new FontCollection().Add(TestFonts.OpenSansFile);
+            family.TryGetMetrics(FontStyle.Regular, out FontMetrics metrics);
+
+            TextOptions options = new(family.CreateFont(metrics.UnitsPerEm))
+            {
+                LineSpacing = 1.5F
+            };
+
+            const string text = "Hello World!";
+
+            Assert.True(TextMeasurer.TryMeasureCharacterAdvances(text, options, out ReadOnlySpan<GlyphBounds> advances));
+            Assert.True(TextMeasurer.TryMeasureCharacterSizes(text, options, out ReadOnlySpan<GlyphBounds> sizes));
+            Assert.True(TextMeasurer.TryMeasureCharacterBounds(text, options, out ReadOnlySpan<GlyphBounds> bounds));
+
+            Assert.Equal(advances.Length, sizes.Length);
+            Assert.Equal(advances.Length, bounds.Length);
+
+            for (int i = 0; i < advances.Length; i++)
+            {
+                GlyphBounds advance = advances[i];
+                GlyphBounds size = sizes[i];
+                GlyphBounds bound = bounds[i];
+
+                Assert.Equal(advance.Codepoint, size.Codepoint);
+                Assert.Equal(advance.Codepoint, bound.Codepoint);
+
+                // Since this is a single line starting at 0,0 the following should be predictable.
+                Assert.Equal(advance.Bounds.X, size.Bounds.X);
+                Assert.Equal(size.Bounds.Bottom, bound.Bounds.Bottom);
+            }
+        }
+
+        [Fact]
+        public void CanMeasureMultilineCharacterLayouts()
+        {
+            FontFamily family = new FontCollection().Add(TestFonts.OpenSansFile);
+            family.TryGetMetrics(FontStyle.Regular, out FontMetrics metrics);
+
+            TextOptions options = new(family.CreateFont(metrics.UnitsPerEm))
+            {
+                LineSpacing = 1.5F
+            };
+
+            const string text = "A\nA\nA\nA";
+
+            Assert.True(TextMeasurer.TryMeasureCharacterAdvances(text, options, out ReadOnlySpan<GlyphBounds> advances));
+            Assert.True(TextMeasurer.TryMeasureCharacterSizes(text, options, out ReadOnlySpan<GlyphBounds> sizes));
+
+            Assert.Equal(advances.Length, sizes.Length);
+
+            GlyphBounds? lastAdvance = null;
+            GlyphBounds? lastSize = null;
+            for (int i = 0; i < advances.Length; i++)
+            {
+                GlyphBounds advance = advances[i];
+                GlyphBounds size = sizes[i];
+
+                Assert.Equal(advance.Codepoint, size.Codepoint);
+
+                if (lastAdvance.HasValue)
+                {
+                    Assert.Equal(lastAdvance.Value.Bounds, advance.Bounds);
+                    Assert.Equal(lastSize.Value.Bounds.Width, size.Bounds.Width, 2);
+                    Assert.Equal(lastSize.Value.Bounds.Height, size.Bounds.Height, 2);
+                }
+
+                lastAdvance = advance;
+                lastSize = size;
+            }
         }
 
         private static readonly Font OpenSansTTF = new FontCollection().Add(TestFonts.OpenSansFile).CreateFont(10);

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -914,7 +914,20 @@ namespace SixLabors.Fonts.Tests
 
             const string text = "Hello World!";
             FontRectangle first = TextMeasurer.MeasureAdvance(text, options);
+
+            // TODO: We should probably drop the 32bit test runner.
+#if NET472
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(new FontRectangle(0, 0, 11729, 2049), first);
+            }
+            else
+            {
+                Assert.Equal(new FontRectangle(0, 0, 11729, 2048), first);
+            }
+#else
             Assert.Equal(new FontRectangle(0, 0, 11729, 2049), first);
+#endif
 
             options.LineSpacing = 2F;
             FontRectangle second = TextMeasurer.MeasureAdvance(text, options);

--- a/tests/SixLabors.Fonts.Tests/TextOptionsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextOptionsTests.cs
@@ -272,7 +272,7 @@ namespace SixLabors.Fonts.Tests
         [Fact]
         public void DefaultTextOptionsTabWidth()
         {
-            const float expected = 4F;
+            const float expected = -1F;
             Assert.Equal(expected, this.newTextOptions.TabWidth);
             Assert.Equal(expected, this.clonedTextOptions.TabWidth);
         }
@@ -356,7 +356,7 @@ namespace SixLabors.Fonts.Tests
 
         private static void VerifyPropertyDefault(TextOptions options)
         {
-            Assert.Equal(4, options.TabWidth);
+            Assert.Equal(-1, options.TabWidth);
             Assert.Equal(KerningMode.Standard, options.KerningMode);
             Assert.Equal(-1, options.WrappingLength);
             Assert.Equal(HorizontalAlignment.Left, options.HorizontalAlignment);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
When rendering single line text both the orientation and layout of text within the box was incorrectly calculated for single line text, ignoring the set wrapping length. This PR fixes both algorithms to respect that value.

https://github.com/SixLabors/Fonts/issues/335

UPDATE. When writing tests I realized we had multiple issues with our layout engine so I rewrote it to match exactly the output produced by browsers.

I've also added the ability to measure 3 sets of bounds per textbox and for individual glyphs.

- Advance : The line-height and advanced width
- Size : The minimum size to render the box or glyphs. Leading advances are included but following are not.
- Bounds : The exact bounds of the box or glyphs.

In the following images below, you can see various boxes indicating the results of those measurements. These work for all layout options.

![issue_275_Top_Left_Start - Copy](https://github.com/SixLabors/Fonts/assets/385879/2acd64c4-c126-4753-875b-796432c2449c)
![issue_275_Top_Left_Start](https://github.com/SixLabors/Fonts/assets/385879/809886c5-6370-41cc-8ea1-d57a6601239a)
![issue_275_Top_Left_Start - Copy (2)](https://github.com/SixLabors/Fonts/assets/385879/168756fe-b226-4ca5-b5f0-9f8ba75dfe28)


<!-- Thanks for contributing to SixLabors.Fonts! -->
