### PR TITLE
Also search "~/.local/share/fonts/" on Linux

### DIFF
--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -40,6 +40,7 @@ namespace SixLabors.Fonts
                 StandardFontLocations = new[]
                 {
                     "%HOME%/.fonts/",
+                    "%HOME%/.local/share/fonts/",
                     "/usr/local/share/fonts/",
                     "/usr/share/fonts/",
                 };


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
`.local/share/fonts/` is another common  location for user provided font files on "modern" Linux platforms, see https://wiki.archlinux.org/title/Fonts#Manual_installation
