### PR TITLE
Simplify dependencies

### DIFF
--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -27,14 +27,12 @@
     <None Include="..\..\shared-infrastructure\branding\icons\fonts\sixlabors.fonts.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -27,7 +27,7 @@
     <None Include="..\..\shared-infrastructure\branding\icons\fonts\sixlabors.fonts.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
[System.Memory](https://www.nuget.org/packages/System.Memory/) depends on the 3 other packages :

![image](https://github.com/SixLabors/Fonts/assets/15875066/1c86d31c-f912-4002-9fd0-66680e5ba677)

So they don't need to be explicitely referenced.
