### PR TITLE
Fix 355

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches:
       - main
-
+      - release/*
 jobs:
   Build:
     strategy:

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -828,6 +828,11 @@ namespace SixLabors.Fonts
 
             // TODO: This only replaces certain glyphs. We should investigate the specification further.
             // https://www.unicode.org/reports/tr50/#vertical_alternates
+            if (collection.TextOptions.LayoutMode.IsHorizontal())
+            {
+                return;
+            }
+
             for (int i = 0; i < collection.Count; i++)
             {
                 GlyphShapingData data = collection[i];


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #355 

TR50 vertical codepoint substitution should only take place when the layout is not horizontal.

<!-- Thanks for contributing to SixLabors.Fonts! -->
