### PR TITLE
Only apply swap for non-horizontal layout

### DIFF
--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -825,6 +825,11 @@ internal static class TextLayout
 
         // TODO: This only replaces certain glyphs. We should investigate the specification further.
         // https://www.unicode.org/reports/tr50/#vertical_alternates
+        if (collection.TextOptions.LayoutMode.IsHorizontal())
+        {
+            return;
+        }
+
         for (int i = 0; i < collection.Count; i++)
         {
             GlyphShapingData data = collection[i];


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #355 

<!-- Thanks for contributing to SixLabors.Fonts! -->
