### PR TITLE
Use overloads while passing culture

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ SixLabors.Fonts
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/SixLabors/Fonts/build-and-test.yml?branch=main)](https://github.com/SixLabors/Fonts/actions)
 [![codecov](https://codecov.io/gh/SixLabors/Fonts/branch/main/graph/badge.svg)](https://codecov.io/gh/SixLabors/Fonts)
-[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
+[![License: Six Labors Split](https://img.shields.io/badge/license-Six%20Labors%20Split-%23e30183)](https://github.com/SixLabors/Fonts/blob/main/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/SixLabors/Fonts.svg)](https://github.com/SixLabors/Fonts/issues)
 [![GitHub stars](https://img.shields.io/github/stars/SixLabors/Fonts.svg)](https://github.com/SixLabors/Fonts/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/SixLabors/Fonts.svg)](https://github.com/SixLabors/Fonts/network)
@@ -92,7 +91,7 @@ git submodule update --init --recursive
 - Loading [WOFF fonts](https://www.w3.org/Submission/WOFF/).
 - Loading [WOFF2 fonts](https://www.w3.org/TR/WOFF2).
 - Load all compatible fonts from local machine store.
-- Suppord for line breaking based on [UAX 14](https://www.unicode.org/reports/tr14/)
+- Support for line breaking based on [UAX 14](https://www.unicode.org/reports/tr14/)
 - Support for rendering left to right, right to left and bidirectional text.
 - Support for ligatures.
 - Support for advanced OpenType features glyph substitution ([GSUB](https://docs.microsoft.com/en-us/typography/opentype/spec/gsub)) and glyph positioning ([GPOS](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos))

--- a/src/SixLabors.Fonts/FontCollection.cs
+++ b/src/SixLabors.Fonts/FontCollection.cs
@@ -78,11 +78,11 @@ public sealed class FontCollection : IFontCollection, IFontMetricsCollection
 
     /// <inheritdoc/>
     public FontFamily Get(string name)
-        => this.GetImpl(name, CultureInfo.InvariantCulture);
+        => this.Get(name, CultureInfo.InvariantCulture);
 
     /// <inheritdoc/>
     public bool TryGet(string name, out FontFamily family)
-        => this.TryGetImpl(name, CultureInfo.InvariantCulture, out family);
+        => this.TryGet(name, CultureInfo.InvariantCulture, out family);
 
     /// <inheritdoc/>
     public FontFamily Add(string path, CultureInfo culture)
@@ -195,14 +195,14 @@ public sealed class FontCollection : IFontCollection, IFontMetricsCollection
 
     private FontFamily AddImpl(string path, CultureInfo culture, out FontDescription description)
     {
-        var instance = new FileFontMetrics(path);
+        FileFontMetrics instance = new(path);
         description = instance.Description;
         return ((IFontMetricsCollection)this).AddMetrics(instance, culture);
     }
 
     private FontFamily AddImpl(Stream stream, CultureInfo culture, out FontDescription description)
     {
-        var metrics = StreamFontMetrics.LoadFont(stream);
+        StreamFontMetrics metrics = StreamFontMetrics.LoadFont(stream);
         description = metrics.Description;
 
         return ((IFontMetricsCollection)this).AddMetrics(metrics, culture);
@@ -215,8 +215,8 @@ public sealed class FontCollection : IFontCollection, IFontMetricsCollection
     {
         FileFontMetrics[] fonts = FileFontMetrics.LoadFontCollection(path);
 
-        var description = new FontDescription[fonts.Length];
-        var families = new HashSet<FontFamily>();
+        FontDescription[] description = new FontDescription[fonts.Length];
+        HashSet<FontFamily> families = new();
         for (int i = 0; i < fonts.Length; i++)
         {
             description[i] = fonts[i].Description;
@@ -234,14 +234,14 @@ public sealed class FontCollection : IFontCollection, IFontMetricsCollection
         out IEnumerable<FontDescription> descriptions)
     {
         long startPos = stream.Position;
-        var reader = new BigEndianBinaryReader(stream, true);
-        var ttcHeader = TtcHeader.Read(reader);
-        var result = new List<FontDescription>((int)ttcHeader.NumFonts);
-        var installedFamilies = new HashSet<FontFamily>();
+        BigEndianBinaryReader reader = new(stream, true);
+        TtcHeader ttcHeader = TtcHeader.Read(reader);
+        List<FontDescription> result = new((int)ttcHeader.NumFonts);
+        HashSet<FontFamily> installedFamilies = new();
         for (int i = 0; i < ttcHeader.NumFonts; ++i)
         {
             stream.Position = startPos + ttcHeader.OffsetTable[i];
-            var instance = StreamFontMetrics.LoadFont(stream);
+            StreamFontMetrics instance = StreamFontMetrics.LoadFont(stream);
             installedFamilies.Add(((IFontMetricsCollection)this).AddMetrics(instance, culture));
             FontDescription fontDescription = instance.Description;
             result.Add(fontDescription);

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -12,7 +12,7 @@
     <PackageTags>font;truetype;opentype;woff;woff2</PackageTags>
     <Description>A cross-platform library for loading and laying out fonts for processing and measuring; written in C#</Description>
     <!--Prevent version conflicts in DrawWithImageSharp-->
-    <AssemblyVersion Condition="'$(IsContinuousIntegration)'==''">2.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(IsContinuousIntegration)'==''">3.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <!--This enables the nullable analysis and treats all nullable warnings as error-->

--- a/src/SixLabors.Fonts/SystemFontCollection.cs
+++ b/src/SixLabors.Fonts/SystemFontCollection.cs
@@ -108,7 +108,7 @@ internal sealed class SystemFontCollection : IReadOnlySystemFontCollection, IRea
     public IEnumerable<string> SearchDirectories => this.searchDirectories;
 
     /// <inheritdoc/>
-    public FontFamily Get(string name) => this.collection.Get(name);
+    public FontFamily Get(string name) => this.Get(name, CultureInfo.InvariantCulture);
 
     /// <inheritdoc/>
     public bool TryGet(string name, out FontFamily family)

--- a/src/SixLabors.Fonts/SystemFonts.cs
+++ b/src/SixLabors.Fonts/SystemFonts.cs
@@ -23,7 +23,7 @@ public static class SystemFonts
     public static IEnumerable<FontFamily> Families => Collection.Families;
 
     /// <inheritdoc cref="IReadOnlyFontCollection.Get(string)"/>
-    public static FontFamily Get(string name) => LazySystemFonts.Value.Get(name);
+    public static FontFamily Get(string name) => Get(name, CultureInfo.InvariantCulture);
 
     /// <inheritdoc cref="IReadOnlyFontCollection.TryGet(string, out FontFamily)" />
     public static bool TryGet(string fontFamily, out FontFamily family)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Roslyn is incorrectly flagging [CA1304](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1304) against the codebase following the move to .NET 6. I can't stop it doing that but I did find areas where we were not using the overloads correctly in our `FontCollection` based types.
354
<!-- Thanks for contributing to SixLabors.Fonts! -->
