### PR TITLE
Platform-independent way to build path for fonts into the sample. Now…

### DIFF
--- a/samples/DrawWithImageSharp/Program.cs
+++ b/samples/DrawWithImageSharp/Program.cs
@@ -21,18 +21,18 @@ public static class Program
     {
         var fonts = new FontCollection();
         var woffFonts = new FontCollection();
-        FontFamily font = fonts.Add(@"Fonts\SixLaborsSampleAB.ttf");
-        FontFamily fontWoff = woffFonts.Add(@"Fonts\SixLaborsSampleAB.woff");
-        FontFamily fontWoff2 = woffFonts.Add(@"Fonts\OpenSans-Regular.woff2");
-        FontFamily carter = fonts.Add(@"Fonts\CarterOne.ttf");
-        FontFamily wendyOne = fonts.Add(@"Fonts\WendyOne-Regular.ttf");
-        FontFamily whitneyBook = fonts.Add(@"Fonts\whitney-book.ttf");
-        FontFamily colorEmoji = fonts.Add(@"Fonts\Twemoji Mozilla.ttf");
-        FontFamily font2 = fonts.Add(@"Fonts\OpenSans-Regular.ttf");
-        FontFamily sunflower = fonts.Add(@"Fonts\Sunflower-Medium.ttf");
-        FontFamily bugzilla = fonts.Add(@"Fonts\me_quran_volt_newmet.ttf");
+        FontFamily font = fonts.Add(IOPath.Combine("Fonts", "SixLaborsSampleAB.ttf"));
+        FontFamily fontWoff = woffFonts.Add(IOPath.Combine("Fonts", "SixLaborsSampleAB.woff"));
+        FontFamily fontWoff2 = woffFonts.Add(IOPath.Combine("Fonts", "OpenSans-Regular.woff2"));
+        FontFamily carter = fonts.Add(IOPath.Combine("Fonts", "CarterOne.ttf"));
+        FontFamily wendyOne = fonts.Add(IOPath.Combine("Fonts", "WendyOne-Regular.ttf"));
+        FontFamily whitneyBook = fonts.Add(IOPath.Combine("Fonts", "whitney-book.ttf"));
+        FontFamily colorEmoji = fonts.Add(IOPath.Combine("Fonts", "Twemoji Mozilla.ttf"));
+        FontFamily font2 = fonts.Add(IOPath.Combine("Fonts", "OpenSans-Regular.ttf"));
+        FontFamily sunflower = fonts.Add(IOPath.Combine("Fonts", "Sunflower-Medium.ttf"));
+        FontFamily bugzilla = fonts.Add(IOPath.Combine("Fonts", "me_quran_volt_newmet.ttf"));
 
-        FontFamily notoKR = fonts.Add(@"Fonts\NotoSansKR-Regular.otf");
+        FontFamily notoKR = fonts.Add(IOPath.Combine("Fonts", "NotoSansKR-Regular.otf"));
 
         RenderText(notoKR, "\uD734", pointSize: 72);
         RenderText(notoKR, "Sphinx of black quartz, judge my vow!", pointSize: 72);


### PR DESCRIPTION
… should work on non-Windows systems.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
The `DrawWithImageSharp` were crashing on macos/net6 with the `System.IO.FileNotFoundException` while adding a fonts from files with the paths like the `/Users/user/work/Fonts/artifacts/bin/samples/DrawWithImageSharp/Debug/net6.0/Fonts\\SixLaborsSampleAB.ttf` (note the `\\` delimiter before the file name). This pull request uses the `Path.Combine` to build the paths, so the correct platform-specific path delimiters are used. 
<!-- Thanks for contributing to SixLabors.Fonts! -->
