### PR TITLE
trim whitespace from EOLs when line split is found

### DIFF
--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -1358,7 +1358,14 @@ internal static class TextLayout
             this.data.RemoveRange(index, this.data.Count - index);
 
             // Now trim trailing whitespace from this line.
-            index = this.data.Count;
+            this.TrimTrailingWhitespaceAndRecalculateMetrics();
+
+            return result;
+        }
+
+        private void TrimTrailingWhitespaceAndRecalculateMetrics()
+        {
+            int index = this.data.Count;
             while (index > 0)
             {
                 if (!CodePoint.IsWhiteSpace(this.data[index - 1].CodePoint))
@@ -1375,10 +1382,10 @@ internal static class TextLayout
             }
 
             // Lastly recalculate this line metrics.
-            advance = 0;
-            ascender = 0;
-            descender = 0;
-            lineHeight = 0;
+            float advance = 0;
+            float ascender = 0;
+            float descender = 0;
+            float lineHeight = 0;
             for (int i = 0; i < this.data.Count; i++)
             {
                 GlyphLayoutData glyph = this.data[i];
@@ -1392,8 +1399,6 @@ internal static class TextLayout
             this.ScaledMaxAscender = ascender;
             this.ScaledMaxDescender = descender;
             this.ScaledMaxLineHeight = lineHeight;
-
-            return result;
         }
 
         public TextLine Finalize() => this.BidiReOrder();

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_367.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_367.cs
@@ -23,7 +23,7 @@ public class Issues_367
         Assert.Equal(3, lineCount);
 
         FontRectangle advance = TextMeasurer.MeasureAdvance(text, options);
-        Assert.Equal(365, advance.Width);
+        Assert.Equal(355, advance.Width);
         Assert.Equal(48, advance.Height);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
In `SplitAt`, when a `TextLine` is split at exact length match - the loop will no longer grab and trim the whitespace on the next iteration because it exits early (Issue 367 fix).  Instead, added a whitespace trim in `SplitAt` when the exact length match is being examined.

See [Issue 393](https://github.com/SixLabors/Fonts/issues/393) for a visual representation.  More detail can be provided upon request.

<!-- Thanks for contributing to SixLabors.Fonts! -->
