### PR TITLE
Add StringIndex and GraphemeIndex to GlyphBounds

### DIFF
--- a/src/SixLabors.Fonts/GlyphBounds.cs
+++ b/src/SixLabors.Fonts/GlyphBounds.cs
@@ -15,10 +15,14 @@ public readonly struct GlyphBounds
     /// </summary>
     /// <param name="codePoint">The Unicode codepoint for the glyph.</param>
     /// <param name="bounds">The glyph bounds.</param>
-    public GlyphBounds(CodePoint codePoint, in FontRectangle bounds)
+    /// <param name="graphemeIndex">The index of the grapheme in original text.</param>
+    /// <param name="stringIndex">The index of the codepoint in original text..</param>
+    public GlyphBounds(CodePoint codePoint, in FontRectangle bounds, int graphemeIndex, int stringIndex)
     {
         this.Codepoint = codePoint;
         this.Bounds = bounds;
+        this.GraphemeIndex = graphemeIndex;
+        this.StringIndex = stringIndex;
     }
 
     /// <summary>
@@ -30,6 +34,16 @@ public readonly struct GlyphBounds
     /// Gets the glyph bounds.
     /// </summary>
     public FontRectangle Bounds { get; }
+
+    /// <summary>
+    /// Gets grapheme index of glyph in original text.
+    /// </summary>
+    public int GraphemeIndex { get; }
+
+    /// <summary>
+    /// Gets string index of glyph in original text.
+    /// </summary>
+    public int StringIndex { get; }
 
     /// <inheritdoc/>
     public override string ToString()

--- a/src/SixLabors.Fonts/GlyphLayout.cs
+++ b/src/SixLabors.Fonts/GlyphLayout.cs
@@ -19,7 +19,9 @@ internal readonly struct GlyphLayout
         float advanceWidth,
         float advanceHeight,
         GlyphLayoutMode layoutMode,
-        bool isStartOfLine)
+        bool isStartOfLine,
+        int graphemeIndex,
+        int stringIndex)
     {
         this.Glyph = glyph;
         this.CodePoint = glyph.GlyphMetrics.CodePoint;
@@ -30,6 +32,8 @@ internal readonly struct GlyphLayout
         this.AdvanceY = advanceHeight;
         this.LayoutMode = layoutMode;
         this.IsStartOfLine = isStartOfLine;
+        this.GraphemeIndex = graphemeIndex;
+        this.StringIndex = stringIndex;
     }
 
     /// <summary>
@@ -77,6 +81,16 @@ internal readonly struct GlyphLayout
     /// Gets a value indicating whether this glyph is the first glyph on a new line.
     /// </summary>
     public bool IsStartOfLine { get; }
+
+    /// <summary>
+    /// Gets grapheme index of glyph in original text.
+    /// </summary>
+    public int GraphemeIndex { get; }
+
+    /// <summary>
+    /// Gets string index of glyph in original text.
+    /// </summary>
+    public int StringIndex { get; }
 
     /// <summary>
     /// Gets a value indicating whether the glyph represents a whitespace character.

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -420,7 +420,9 @@ internal static class TextLayout
                     data.ScaledAdvance,
                     advanceY,
                     GlyphLayoutMode.Horizontal,
-                    i == 0 && j == 0));
+                    i == 0 && j == 0,
+                    data.GraphemeIndex,
+                    data.StringIndex));
 
                 j++;
             }
@@ -556,7 +558,9 @@ internal static class TextLayout
                     advanceX,
                     data.ScaledAdvance,
                     GlyphLayoutMode.Vertical,
-                    i == 0 && j == 0));
+                    i == 0 && j == 0,
+                    data.GraphemeIndex,
+                    data.StringIndex));
 
                 j++;
             }
@@ -689,7 +693,9 @@ internal static class TextLayout
                         advanceX,
                         data.ScaledAdvance,
                         GlyphLayoutMode.VerticalRotated,
-                        i == 0 && j == 0));
+                        i == 0 && j == 0,
+                        data.GraphemeIndex,
+                        data.StringIndex));
 
                     j++;
                 }
@@ -712,7 +718,9 @@ internal static class TextLayout
                         advanceX,
                         data.ScaledAdvance,
                         GlyphLayoutMode.Vertical,
-                        i == 0 && j == 0));
+                        i == 0 && j == 0,
+                        data.GraphemeIndex,
+                        data.StringIndex));
 
                     j++;
                 }
@@ -895,6 +903,7 @@ internal static class TextLayout
         List<TextLine> textLines = new();
         TextLine textLine = new();
         int glyphCount = 0;
+        int stringIndex = 0;
 
         // No glyph should contain more than 64 metrics.
         // We do a sanity check below just in case.
@@ -1205,12 +1214,15 @@ internal static class TextLayout
                         graphemeIndex,
                         codePointIndex,
                         isRotated,
-                        isDecomposed);
+                        isDecomposed,
+                        stringIndex);
                 }
 
                 codePointIndex++;
                 graphemeCodePointIndex++;
             }
+
+            stringIndex += graphemeEnumerator.Current.Length;
         }
 
         // Add the final line.
@@ -1268,7 +1280,8 @@ internal static class TextLayout
             int graphemeIndex,
             int offset,
             bool isRotated,
-            bool isDecomposed)
+            bool isDecomposed,
+            int stringIndex)
         {
             // Reset metrics.
             // We track the maximum metrics for each line to ensure glyphs can be aligned.
@@ -1288,7 +1301,8 @@ internal static class TextLayout
                 graphemeIndex,
                 offset,
                 isRotated,
-                isDecomposed));
+                isDecomposed,
+                stringIndex));
         }
 
         public TextLine SplitAt(LineBreak lineBreak, bool keepAll)
@@ -1627,7 +1641,8 @@ internal static class TextLayout
                 int graphemeIndex,
                 int offset,
                 bool isRotated,
-                bool isDecomposed)
+                bool isDecomposed,
+                int stringIndex)
             {
                 this.Metrics = metrics;
                 this.PointSize = pointSize;
@@ -1640,6 +1655,7 @@ internal static class TextLayout
                 this.Offset = offset;
                 this.IsRotated = isRotated;
                 this.IsDecomposed = isDecomposed;
+                this.StringIndex = stringIndex;
             }
 
             public readonly CodePoint CodePoint => this.Metrics[0].CodePoint;
@@ -1667,6 +1683,8 @@ internal static class TextLayout
             public bool IsRotated { get; }
 
             public bool IsDecomposed { get; }
+
+            public int StringIndex { get; }
 
             public readonly bool IsNewLine => CodePoint.IsNewLine(this.CodePoint);
 

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -265,7 +265,7 @@ public static class TextMeasurer
             GlyphLayout glyph = glyphLayouts[i];
             FontRectangle bounds = new(0, 0, glyph.AdvanceX * dpi, glyph.AdvanceY * dpi);
             hasSize |= bounds.Width > 0 || bounds.Height > 0;
-            characterBoundsList[i] = new GlyphBounds(glyph.Glyph.GlyphMetrics.CodePoint, in bounds);
+            characterBoundsList[i] = new GlyphBounds(glyph.Glyph.GlyphMetrics.CodePoint, in bounds, glyph.GraphemeIndex, glyph.StringIndex);
         }
 
         characterBounds = characterBoundsList;
@@ -290,7 +290,7 @@ public static class TextMeasurer
             bounds = new(0, 0, bounds.Width, bounds.Height);
 
             hasSize |= bounds.Width > 0 || bounds.Height > 0;
-            characterBoundsList[i] = new GlyphBounds(g.Glyph.GlyphMetrics.CodePoint, in bounds);
+            characterBoundsList[i] = new GlyphBounds(g.Glyph.GlyphMetrics.CodePoint, in bounds, g.GraphemeIndex, g.StringIndex);
         }
 
         characterBounds = characterBoundsList;
@@ -312,7 +312,7 @@ public static class TextMeasurer
             GlyphLayout g = glyphLayouts[i];
             FontRectangle bounds = g.BoundingBox(dpi);
             hasSize |= bounds.Width > 0 || bounds.Height > 0;
-            characterBoundsList[i] = new GlyphBounds(g.Glyph.GlyphMetrics.CodePoint, in bounds);
+            characterBoundsList[i] = new GlyphBounds(g.Glyph.GlyphMetrics.CodePoint, in bounds, g.GraphemeIndex, g.StringIndex);
         }
 
         characterBounds = characterBoundsList;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Add StringIndex and GraphemeIndex to GlyphBounds to enable hit testing glyphs and get the string index.
