### PR TITLE
Fix character bounds returned by TryMeasureCharacterBounds

### DIFF
--- a/src/SixLabors.Fonts/GlyphLayout.cs
+++ b/src/SixLabors.Fonts/GlyphLayout.cs
@@ -100,8 +100,15 @@ internal readonly struct GlyphLayout
 
     internal FontRectangle BoundingBox(float dpi)
     {
-        Vector2 origin = (this.PenLocation + this.Offset) * dpi;
-        FontRectangle box = this.Glyph.BoundingBox(this.LayoutMode, this.BoxLocation, dpi);
+        // Same logic as in TrueTypeGlyphMetrics.RenderTo
+        Vector2 location = this.PenLocation;
+        Vector2 offset = this.Offset;
+
+        location *= dpi;
+        offset *= dpi;
+        Vector2 renderLocation = location + offset;
+
+        FontRectangle box = this.Glyph.BoundingBox(this.LayoutMode, renderLocation, dpi);
 
         if (this.IsWhiteSpace())
         {
@@ -110,8 +117,8 @@ internal readonly struct GlyphLayout
             if (this.LayoutMode == GlyphLayoutMode.Vertical)
             {
                 return new FontRectangle(
-                    box.X + origin.X,
-                    box.Y + origin.Y,
+                    box.X,
+                    box.Y,
                     box.Width,
                     this.AdvanceY * dpi);
             }
@@ -119,24 +126,20 @@ internal readonly struct GlyphLayout
             if (this.LayoutMode == GlyphLayoutMode.VerticalRotated)
             {
                 return new FontRectangle(
-                    box.X + origin.X,
-                    box.Y + origin.Y,
+                    box.X,
+                    box.Y,
                     0,
                     this.AdvanceY * dpi);
             }
 
             return new FontRectangle(
-                box.X + origin.X,
-                box.Y + origin.Y,
+                box.X,
+                box.Y,
                 this.AdvanceX * dpi,
                 box.Height);
         }
 
-        return new FontRectangle(
-            box.X + origin.X,
-            box.Y + origin.Y,
-            box.Width,
-            box.Height);
+        return box;
     }
 
     /// <inheritdoc/>

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -164,7 +164,7 @@ public class GlyphTests
         FontRectangle size = TextMeasurer.MeasureSize(text, new TextOptions(font));
         FontRectangle size2 = TextMeasurer.MeasureSize(text2, new TextOptions(font));
 
-        Assert.Equal(52f, size.Width);
+        Assert.Equal(51f, size.Width);
         Assert.Equal(51f, size2.Width);
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
refer https://github.com/SixLabors/Fonts/discussions/397

There was a new test failure in GlyphTests - EmojiWidthIsComputedCorrectlyWithSubstitutionOnZwj
which I fixed by adjusting the test, seems more correct now since it is now the same width with the the substitution.