### PR TITLE
Add DoShaping Option

### DIFF
--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/NoShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/NoShaper.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.Fonts;
+using SixLabors.Fonts.Tables.AdvancedTypographic.Shapers;
+
+internal class NoShaper : BaseShaper
+{
+    private readonly HashSet<ShapingStage> shapingStages = new();
+
+    internal NoShaper()
+    {
+    }
+
+    protected override void PlanFeatures(IGlyphShapingCollection collection, int index, int count)
+    {
+    }
+
+    protected override void PlanPreprocessingFeatures(IGlyphShapingCollection collection, int index, int count)
+    {
+    }
+
+    protected override void PlanPostprocessingFeatures(IGlyphShapingCollection collection, int index, int count)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void AssignFeatures(IGlyphShapingCollection collection, int index, int count)
+    {
+    }
+
+    public override IEnumerable<ShapingStage> GetShapingStages() => this.shapingStages;
+}

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ShaperFactory.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ShaperFactory.cs
@@ -83,6 +83,6 @@ internal static class ShaperFactory
             or ScriptClass.Tifinagh
             or ScriptClass.Tirhuta
             => new UniversalShaper(script, textOptions),
-            _ => new DefaultShaper(script, textOptions),
+            _ => textOptions.DoShaping ? new DefaultShaper(script, textOptions) : new NoShaper(),
         };
 }

--- a/src/SixLabors.Fonts/TextOptions.cs
+++ b/src/SixLabors.Fonts/TextOptions.cs
@@ -184,4 +184,9 @@ public class TextOptions
     /// Gets or sets an optional collection of text runs to apply to the body of text.
     /// </summary>
     public IReadOnlyList<TextRun> TextRuns { get; set; } = Array.Empty<TextRun>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to do font shaping. Note that is will break emoji rendering.
+    /// </summary>
+    public bool DoShaping { get; set; } = true;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Add option to TextOptions to skip shaping since it's a large percentage of the text layout.
In my case it increased the FPS of my text stress test from a middling 6 FPS to an incredible 10 FPS, the hot path now being almost completely rending.
Feel free to reject if you don't think it would be useful or would complicate support.
