### PR TITLE
Ensure only trailing whitespace is trimmed.

### DIFF
--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -1396,7 +1396,7 @@ internal static class TextLayout
                 index--;
             }
 
-            if (index < this.data.Count)
+            if (index < this.data.Count && index != 0)
             {
                 this.data.RemoveRange(index, this.data.Count - index);
             }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_400.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_400.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.Fonts.Tests.Issues;
+public class Issues_400
+{
+    [Fact]
+    public void RenderingTextIncludesAllGlyphs()
+    {
+#if OS_WINDOWS
+
+        TextOptions options = new(new Font(SystemFonts.Get("Arial"), 16 * 2))
+        {
+            WrappingLength = 1900
+        };
+
+        const string content = """
+                          NEWS_CATEGORY=EWF&NEWS_HASH=4b298ff9277ef9fdf515356be95ea3caf57cd36&OFFSET=0&SEARCH_VALUE=CA88105E1088&ID_NEWS
+          """;
+
+        int lineCount = TextMeasurer.CountLines(content, options);
+        Assert.Equal(2, lineCount);
+#endif
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
+++ b/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <DebugSymbols>True</DebugSymbols>
     <Platforms>AnyCPU;x64;x86</Platforms>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #400 

We were not checking the index when trimming entire lines full of whitespace; this meant the entire lines data was incorrectly removed. 

We need to preserve full lines to ensure line breaks are laid out correctly. 

<!-- Thanks for contributing to SixLabors.Fonts! -->
