### PR TITLE
Fix memory leak in VerticalMetricsTable

### DIFF
--- a/src/SixLabors.Fonts/BigEndianBinaryReader.cs
+++ b/src/SixLabors.Fonts/BigEndianBinaryReader.cs
@@ -12,7 +12,7 @@ namespace SixLabors.Fonts;
 /// BinaryReader using big-endian encoding.
 /// </summary>
 [DebuggerDisplay("Start: {StartOfStream}, Position: {BaseStream.Position}")]
-internal class BigEndianBinaryReader : IDisposable
+internal sealed class BigEndianBinaryReader : IDisposable
 {
     /// <summary>
     /// Buffer used for temporary storage before conversion into primitives

--- a/src/SixLabors.Fonts/Tables/General/VerticalMetricsTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/VerticalMetricsTable.cs
@@ -47,7 +47,10 @@ internal sealed class VerticalMetricsTable : Table
             return null;
         }
 
-        return Load(binaryReader, headTable.NumberOfVMetrics, profileTable.GlyphCount);
+        using (binaryReader)
+        {
+            return Load(binaryReader, headTable.NumberOfVMetrics, profileTable.GlyphCount);
+        }
     }
 
     public static VerticalMetricsTable Load(BigEndianBinaryReader reader, int metricCount, int glyphCount)


### PR DESCRIPTION
This PR fixes memory leak in `VerticalMetricsTable`
