### PR TITLE
Always create new text run, don't assume behavior.

### DIFF
--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -72,23 +72,12 @@ internal static class TextLayout
         // Add a final run if required.
         if (start < end)
         {
-            // Offset error by user, last index in input string
-            // instead of exclusive index.
-            if (start == end - 1)
+            textRuns.Add(new()
             {
-                int prevIndex = textRuns.Count - 1;
-                TextRun previous = textRuns[prevIndex];
-                previous.End++;
-            }
-            else
-            {
-                textRuns.Add(new()
-                {
-                    Start = start,
-                    End = end,
-                    Font = options.Font
-                });
-            }
+                Start = start,
+                End = end,
+                Font = options.Font
+            });
         }
 
         return textRuns;

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_412.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_412.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.Fonts.Tests.Issues;
+
+public class Issues_412
+{
+    [Fact]
+    public void ShouldCreateCorrectTextRunCount()
+    {
+        FontCollection collection = new();
+        FontFamily family = collection.Add(TestFonts.OpenSansFile);
+        Font font = family.CreateFont(24);
+
+        TextOptions options = new(font)
+        {
+            TextRuns = new[]
+            {
+                new TextRun { Start = 0, End = 4 }
+            }
+        };
+
+        IReadOnlyList<TextRun> runs = TextLayout.BuildTextRuns("abcde", options);
+        Assert.Equal(2, runs.Count);
+
+        TextRun run = runs[0];
+        Assert.Equal(0, run.Start);
+        Assert.Equal(4, run.End);
+
+        run = runs[1];
+        Assert.Equal(4, run.Start);
+        Assert.Equal(5, run.End);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #412 to always create a new text run rather than assuming a mistake on the user part. 

<!-- Thanks for contributing to SixLabors.Fonts! -->
