### PR TITLE
Remove all instances of HasFlag

### DIFF
--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -290,7 +290,7 @@ public sealed class Font
             return metrics;
         }
 
-        if (this.RequestedStyle.HasFlag(FontStyle.Italic))
+        if ((this.RequestedStyle & FontStyle.Italic) == FontStyle.Italic)
         {
             // Can't find style requested and they want one that's at least partial italic.
             // Try the regular italic.
@@ -300,7 +300,7 @@ public sealed class Font
             }
         }
 
-        if (this.RequestedStyle.HasFlag(FontStyle.Bold))
+        if ((this.RequestedStyle & FontStyle.Bold) == FontStyle.Bold)
         {
             // Can't find style requested and they want one that's at least partial bold.
             // Try the regular bold.

--- a/src/SixLabors.Fonts/FontDescription.cs
+++ b/src/SixLabors.Fonts/FontDescription.cs
@@ -172,24 +172,24 @@ public class FontDescription
 
         if (os2 != null)
         {
-            if (os2.FontStyle.HasFlag(OS2Table.FontStyleSelection.BOLD))
+            if ((os2.FontStyle & OS2Table.FontStyleSelection.BOLD) == OS2Table.FontStyleSelection.BOLD)
             {
                 style |= FontStyle.Bold;
             }
 
-            if (os2.FontStyle.HasFlag(OS2Table.FontStyleSelection.ITALIC))
+            if ((os2.FontStyle & OS2Table.FontStyleSelection.ITALIC) == OS2Table.FontStyleSelection.ITALIC)
             {
                 style |= FontStyle.Italic;
             }
         }
         else if (head != null)
         {
-            if (head.MacStyle.HasFlag(HeadTable.HeadMacStyle.Bold))
+            if ((head.MacStyle & HeadTable.HeadMacStyle.Bold) == HeadTable.HeadMacStyle.Bold)
             {
                 style |= FontStyle.Bold;
             }
 
-            if (head.MacStyle.HasFlag(HeadTable.HeadMacStyle.Italic))
+            if ((head.MacStyle & HeadTable.HeadMacStyle.Italic) == HeadTable.HeadMacStyle.Italic)
             {
                 style |= FontStyle.Italic;
             }

--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -50,13 +50,13 @@ public abstract class GlyphMetrics
 
         Vector2 offset = Vector2.Zero;
         Vector2 scaleFactor = new(unitsPerEM * 72F);
-        if (textAttributes.HasFlag(TextAttributes.Subscript))
+        if ((textAttributes & TextAttributes.Subscript) == TextAttributes.Subscript)
         {
             float units = this.UnitsPerEm;
             scaleFactor /= new Vector2(font.SubscriptXSize / units, font.SubscriptYSize / units);
             offset = new(font.SubscriptXOffset, font.SubscriptYOffset < 0 ? font.SubscriptYOffset : -font.SubscriptYOffset);
         }
-        else if (textAttributes.HasFlag(TextAttributes.Superscript))
+        else if ((textAttributes & TextAttributes.Superscript) == TextAttributes.Superscript)
         {
             float units = this.UnitsPerEm;
             scaleFactor /= new Vector2(font.SuperscriptXSize / units, font.SuperscriptYSize / units);

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -423,7 +423,7 @@ internal partial class StreamFontMetrics : FontMetrics
         // 3.If they are zero and the OS/ 2 table exists,
         //    - Use the OS/ 2 table's sTypo* metrics if they are non-zero.
         //    - Otherwise, use the OS / 2 table's usWin* metrics.
-        bool useTypoMetrics = os2.FontStyle.HasFlag(OS2Table.FontStyleSelection.USE_TYPO_METRICS);
+        bool useTypoMetrics = (os2.FontStyle & OS2Table.FontStyleSelection.USE_TYPO_METRICS) == OS2Table.FontStyleSelection.USE_TYPO_METRICS;
         if (useTypoMetrics)
         {
             ascender = os2.TypoAscender;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType3SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType3SubTable.cs
@@ -176,7 +176,7 @@ internal static class LookupType3SubTable
             int parent = nextIndex;
             int xOffset = entryXY.XCoordinate - exitXY.XCoordinate;
             int yOffset = entryXY.YCoordinate - exitXY.YCoordinate;
-            if (this.LookupFlags.HasFlag(LookupFlags.RightToLeft))
+            if ((this.LookupFlags & LookupFlags.RightToLeft) == LookupFlags.RightToLeft)
             {
                 (parent, child) = (child, parent);
 

--- a/src/SixLabors.Fonts/Tables/General/OS2Table.cs
+++ b/src/SixLabors.Fonts/Tables/General/OS2Table.cs
@@ -156,8 +156,11 @@ internal sealed class OS2Table : Table
         this.upperOpticalPointSize = upperOpticalPointSize;
     }
 
+    [Flags]
     internal enum FontStyleSelection : ushort
     {
+        NONE = 0,
+
         // 0    bit 1   ITALIC  Font contains italic or oblique characters, otherwise they are upright.
         ITALIC = 1,
 

--- a/src/SixLabors.Fonts/Tables/TrueType/Glyphs/SimpleGlyphLoader.cs
+++ b/src/SixLabors.Fonts/Tables/TrueType/Glyphs/SimpleGlyphLoader.cs
@@ -75,7 +75,7 @@ internal class SimpleGlyphLoader : GlyphLoader
         var controlPoints = new ControlPoint[xs.Length];
         for (int i = 0; i < flags.Length; i++)
         {
-            controlPoints[i] = new(new Vector2(xs[i], ys[i]), flags[i].HasFlag(Flags.OnCurve));
+            controlPoints[i] = new(new Vector2(xs[i], ys[i]), (flags[i] & Flags.OnCurve) == Flags.OnCurve);
         }
 
         return new SimpleGlyphLoader(controlPoints, endPoints, bounds, instructions);
@@ -96,7 +96,7 @@ internal class SimpleGlyphLoader : GlyphLoader
             else
             {
                 flag = (Flags)reader.ReadUInt8();
-                if (flag.HasFlag(Flags.Repeat))
+                if ((flag & Flags.Repeat) == Flags.Repeat)
                 {
                     repeatCount = reader.ReadByte();
                 }
@@ -115,21 +115,19 @@ internal class SimpleGlyphLoader : GlyphLoader
         for (int i = 0; i < pointCount; i++)
         {
             short dx;
-            if (flags[i].HasFlag(isByte))
+            Flags currentFlag = flags[i];
+            if ((currentFlag & isByte) == isByte)
             {
                 byte b = reader.ReadByte();
-                dx = (short)(flags[i].HasFlag(signOrSame) ? b : -b);
+                dx = (short)((currentFlag & signOrSame) == signOrSame ? b : -b);
+            }
+            else if ((currentFlag & signOrSame) == signOrSame)
+            {
+                dx = 0;
             }
             else
             {
-                if (flags[i].HasFlag(signOrSame))
-                {
-                    dx = 0;
-                }
-                else
-                {
-                    dx = reader.ReadInt16();
-                }
+                dx = reader.ReadInt16();
             }
 
             x += dx;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

See https://github.com/SixLabors/Fonts/discussions/425#discussioncomment-11468049

>HasFlags sometimes still boxes (in tier 0 compilation) if JIT does not optimize it away.

@nolife99 I profiled a couple of unit tests and saw a reduction however it would be useful if you could give this a try by referencing the code directly and report back.

<!-- Thanks for contributing to SixLabors.Fonts! -->
