### PR TITLE
Do not insert mandatory break when line is broken by wrapping.

### DIFF
--- a/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
+++ b/samples/DrawWithImageSharp/DrawWithImageSharp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <DebugType>portable</DebugType>
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_431.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_431.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Numerics;
+
+namespace SixLabors.Fonts.Tests.Issues;
+
+public class Issues_431
+{
+    [Fact]
+    public void ShouldNotInsertExtraLineBreaks()
+    {
+        if (SystemFonts.TryGet("Arial", out FontFamily family))
+        {
+            Font font = family.CreateFont(60);
+            const string text = "- Lorem ipsullll\ndolor sit amet\n-consectetur elit";
+
+            TextOptions options = new(font)
+            {
+                Origin = new Vector2(50, 20),
+                WrappingLength = 400,
+            };
+
+            int lineCount = TextMeasurer.CountLines(text, options);
+            Assert.Equal(4, lineCount);
+
+            IReadOnlyList<GlyphLayout> layout = TextLayout.GenerateLayout(text, options);
+            Assert.Equal(46, layout.Count);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #431 

Added a new check to handle cases where a new line starts with a mandatory line break after a non-mandatory break has been added due to wrapping.

Output rendered using sample project.

![testImg3](https://github.com/user-attachments/assets/ac8320f7-77e2-4688-aaf2-de5d32588887)


<!-- Thanks for contributing to SixLabors.Fonts! -->
