### PR TITLE
Rewrite Line Breaker.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -155,7 +155,9 @@ jobs:
         if: failure()
         with:
           name: actual_output_${{ runner.os }}_${{ matrix.options.framework }}${{ matrix.options.runtime }}.zip
-          path: tests/Images/ActualOutput/
+          path: |
+              tests/Images/ActualOutput/
+              msbuild.log
 
       - name: Codecov Update
         uses: codecov/codecov-action@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -157,7 +157,7 @@ jobs:
           name: actual_output_${{ runner.os }}_${{ matrix.options.framework }}${{ matrix.options.runtime }}.zip
           path: |
               tests/Images/ActualOutput/
-              msbuild.log
+              **/msbuild.binlog
 
       - name: Codecov Update
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -254,6 +254,8 @@ paket-files/
 *.sln.iml
 /samples/DrawWithImageSharp/Output
 
+# Tests
+**/Images/ActualOutput
 /tests/CodeCoverage/OpenCover.*
 SixLabors.Shapes.Coverage.xml
 /SixLabors.Fonts.Coverage.xml

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -8,4 +8,4 @@ dotnet clean -c Release
 $repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
 
 # Building for a specific framework.
-dotnet build -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl
+dotnet build -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl -bl

--- a/src/SixLabors.Fonts/SixLabors.Fonts.csproj
+++ b/src/SixLabors.Fonts/SixLabors.Fonts.csproj
@@ -19,6 +19,9 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
+
+    <!--Temporarily disable the COM analyzer to work around build issue.-->
+    <NoWarn>$(NoWarn);IL2050;</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_100-usedLines_7_.png
+++ b/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_100-usedLines_7_.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c09ad5c85f708f5cd2135a52b13aa248a130abbc7fe8f0449b44d62f9d360384
-size 4505

--- a/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_100-usedLines_7_.png
+++ b/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_100-usedLines_7_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c09ad5c85f708f5cd2135a52b13aa248a130abbc7fe8f0449b44d62f9d360384
+size 4505

--- a/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_200-usedLines_6_.png
+++ b/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_200-usedLines_6_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d54e2b3f85b01ee45f25e53c8f97e80ca9d7655ff6b8aa643664912812a3976
+size 4521

--- a/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_200-usedLines_6_.png
+++ b/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_200-usedLines_6_.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d54e2b3f85b01ee45f25e53c8f97e80ca9d7655ff6b8aa643664912812a3976
-size 4521

--- a/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_25-usedLines_7_.png
+++ b/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_25-usedLines_7_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1161af3a0ffc7d4835e58bcfa064713fa06971747414a144c3b979fdabf1bbdd
+size 4855

--- a/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_25-usedLines_7_.png
+++ b/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_25-usedLines_7_.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1161af3a0ffc7d4835e58bcfa064713fa06971747414a144c3b979fdabf1bbdd
-size 4855

--- a/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_50-usedLines_7_.png
+++ b/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_50-usedLines_7_.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a11863fa11c93d158560fadddcb4768047c5c7f0069054cbf9392b5dc234759
-size 4853

--- a/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_50-usedLines_7_.png
+++ b/tests/Images/ActualOutput/CountLinesWrappingLength_wrappingLength_50-usedLines_7_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a11863fa11c93d158560fadddcb4768047c5c7f0069054cbf9392b5dc234759
+size 4853

--- a/tests/Images/ReferenceOutput/CountLinesWrappingLength_100-4.png
+++ b/tests/Images/ReferenceOutput/CountLinesWrappingLength_100-4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:071789cee1ac03354e5727bda21321e8bb875ae417adfe5e745877023d62c6d7
+size 2963

--- a/tests/Images/ReferenceOutput/CountLinesWrappingLength_200-3.png
+++ b/tests/Images/ReferenceOutput/CountLinesWrappingLength_200-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e2c7bb91aeeffc4d573d4509f55e58d5051221027003a584411f0b97141da16
+size 2966

--- a/tests/Images/ReferenceOutput/CountLinesWrappingLength_25-6.png
+++ b/tests/Images/ReferenceOutput/CountLinesWrappingLength_25-6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2959540711f38c08a319251355e838daabc3ac7721a89bb90261730732f6abab
+size 3033

--- a/tests/Images/ReferenceOutput/CountLinesWrappingLength_50-5.png
+++ b/tests/Images/ReferenceOutput/CountLinesWrappingLength_50-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:907dcca95723f6b21aa3791e047476e31b2d8b13f88f3c5e6604696ce5b469f5
+size 3022

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalBottomTop-wordBreaking_BreakAll_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalBottomTop-wordBreaking_BreakAll_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e13708fcaf702a91540b1f68803cc2cff14de1a97cef771ca0bcc69e414a706e
+size 13446

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalBottomTop-wordBreaking_BreakWord_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalBottomTop-wordBreaking_BreakWord_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a5ec93c6ece40f6c3577970cd0fa1f97d74d019ed52cf3ce9812b4d805624b0
+size 13613

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalBottomTop-wordBreaking_KeepAll_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalBottomTop-wordBreaking_KeepAll_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcaefcb524334225b07b555b296d3b9030a98b775f726b5c1f61997aed0ce587
+size 14041

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalBottomTop-wordBreaking_Standard_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalBottomTop-wordBreaking_Standard_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2951c4befa6d1ceb5afbdd4b36dc5df51752ad1d3ad1a01be70b717cb5811be
+size 15221

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalTopBottom-wordBreaking_BreakAll_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalTopBottom-wordBreaking_BreakAll_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1896cd5f5d0521261c4b9e366ae56baa89f48cfd21b7d1a5d4a4e4c50b3f8542
+size 13485

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalTopBottom-wordBreaking_BreakWord_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalTopBottom-wordBreaking_BreakWord_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d714d870453515f516af0fe8267795df3b36059a9c8c91b0946889985cd089e
+size 13705

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalTopBottom-wordBreaking_KeepAll_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalTopBottom-wordBreaking_KeepAll_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e6d7e2da8ffab3af8ec50463e38b6c5d96059919c4439271f5ee620b76c74e2
+size 14356

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalTopBottom-wordBreaking_Standard_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreakMatchesMDN_238-_layoutMode_HorizontalTopBottom-wordBreaking_Standard_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe506ff8a945fea5f04fcd34a9a63ffcb89d610021acabe711be83ad19e6a96c
+size 15607

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalBottomTop-wordBreaking_BreakAll_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalBottomTop-wordBreaking_BreakAll_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66b5c1046ab68824efdd3af54c7753a18d7bb12b7a2960c956395b0d20bf19e2
+size 17444

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalBottomTop-wordBreaking_BreakWord_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalBottomTop-wordBreaking_BreakWord_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9820e4f9f1719bf48b098991ee175f7c648f5edaa856b579402e75ea597a125
+size 19470

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalBottomTop-wordBreaking_KeepAll_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalBottomTop-wordBreaking_KeepAll_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7ffff224f6a16286cffa7e02e9d5069b389d9ce7274ed917489652f7e0163e7
+size 12638

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalBottomTop-wordBreaking_Standard_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalBottomTop-wordBreaking_Standard_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f986a3bc5f09bd7c20108d9ed667e86de0b28ef813cc3426452b9d47b1ff31ba
+size 21147

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalTopBottom-wordBreaking_BreakAll_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalTopBottom-wordBreaking_BreakAll_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a99e819c0a8d7380e7afbdd289ebe0a2ee6f8c62b51ab7d10b06cfddf0729c55
+size 17437

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalTopBottom-wordBreaking_BreakWord_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalTopBottom-wordBreaking_BreakWord_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cb4294d6f5f72a6af860d8aab9f11b5224f7206add5d7bbcdc22d959a14a78c
+size 19409

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalTopBottom-wordBreaking_KeepAll_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalTopBottom-wordBreaking_KeepAll_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09cac7e7096c0fc3f92d3620580465f10e758edb0a23882e19af7cbf49238180
+size 20415

--- a/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalTopBottom-wordBreaking_Standard_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordBreak_500-_layoutMode_HorizontalTopBottom-wordBreaking_Standard_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35095f9cb0df878caa355d5fc22474ecd25e43a60bcb67b68293dcd43eafc0c3
+size 21227

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalBottomTop_350-_height_10-width_87.125_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalBottomTop_350-_height_10-width_87.125_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a504887655b5b61de10d5b09496330232136cc6854d28319c3c99375fb5424e8
+size 905

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalBottomTop_350-_height_11.438-width_279.13_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalBottomTop_350-_height_11.438-width_279.13_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e5a90ec1b1cf8d69e0173d4c8a08a3bbbb2a428eee7250dc358e6f5abf6542d
+size 948

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalBottomTop_350-_height_62.625-width_318.86_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalBottomTop_350-_height_62.625-width_318.86_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcf9ccad091fde6016070afcaa24e9040d6a81672f04350e56aa446802675bff
+size 9272

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalTopBottom_350-_height_10-width_87.125_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalTopBottom_350-_height_10-width_87.125_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a504887655b5b61de10d5b09496330232136cc6854d28319c3c99375fb5424e8
+size 905

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalTopBottom_350-_height_11.438-width_279.13_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalTopBottom_350-_height_11.438-width_279.13_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e5a90ec1b1cf8d69e0173d4c8a08a3bbbb2a428eee7250dc358e6f5abf6542d
+size 948

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalTopBottom_350-_height_62.625-width_318.86_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingHorizontalTopBottom_350-_height_62.625-width_318.86_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afd34328b9e945944d90f8e56c33cff7d796a5ab22a55a4b1be5eeb629fb2f5a
+size 9268

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalLeftRight_350-_height_171.25-width_10_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalLeftRight_350-_height_171.25-width_10_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81778b219f78d986e93643c3821c8c2d5c2eb2b488170db3ffa3cf42e6e0e0a
+size 853

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalLeftRight_350-_height_267.25-width_23.875_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalLeftRight_350-_height_267.25-width_23.875_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40e27a17bd7e5fe1d5177cb34e456a91cda7d555cfdd53c4e8a75722cbe41d09
+size 1083

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalLeftRight_350-_height_318.563-width_62.813_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalLeftRight_350-_height_318.563-width_62.813_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57b1755082a3e82879b28ff20f2e4e2cd017aa8b0b236678a8dbf5cc6ddab17d
+size 10317

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalMixedLeftRight_350-_height_279.125-width_11.438_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalMixedLeftRight_350-_height_279.125-width_11.438_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:739c2d5459270188f0c003ee017184c4127a686e04d939d731aa186d0daa68f7
+size 911

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalMixedLeftRight_350-_height_318.563-width_62.813_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalMixedLeftRight_350-_height_318.563-width_62.813_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57b1755082a3e82879b28ff20f2e4e2cd017aa8b0b236678a8dbf5cc6ddab17d
+size 10317

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalMixedLeftRight_350-_height_87.125-width_10_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalMixedLeftRight_350-_height_87.125-width_10_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cab59d7637dd6820a15b63fc68fc541482916d555ef38337fe5f583136bce5d5
+size 873

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalRightLeft_350-_height_171.25-width_10_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalRightLeft_350-_height_171.25-width_10_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81778b219f78d986e93643c3821c8c2d5c2eb2b488170db3ffa3cf42e6e0e0a
+size 853

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalRightLeft_350-_height_267.25-width_23.875_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalRightLeft_350-_height_267.25-width_23.875_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:902799aae2e8229dcacbf04554eb5b64d30c7c47fe9a9794be8ac34616a414db
+size 1091

--- a/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalRightLeft_350-_height_318.563-width_62.813_.png
+++ b/tests/Images/ReferenceOutput/MeasureTextWordWrappingVerticalRightLeft_350-_height_318.563-width_62.813_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4b0bc75fa8b2ff464b38401741a58ce0fd7095767883d8fcd227e336a8f9c08
+size 10241

--- a/tests/Images/ReferenceOutput/ShouldInsertExtraLineBreaksA_400-4.png
+++ b/tests/Images/ReferenceOutput/ShouldInsertExtraLineBreaksA_400-4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:576b23370c4d5ba88e835169c80babeda2ed03c32c767193724ee14ab3f18c48
+size 15102

--- a/tests/Images/ReferenceOutput/ShouldInsertExtraLineBreaksB_400-4.png
+++ b/tests/Images/ReferenceOutput/ShouldInsertExtraLineBreaksB_400-4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:435603a3488351bfd79647eb11e598dcb14e90cde9e849832e2a1f2f5cf53e14
+size 15691

--- a/tests/Images/ReferenceOutput/ShouldMatchBrowserBreak__WrappingLength_372_.png
+++ b/tests/Images/ReferenceOutput/ShouldMatchBrowserBreak__WrappingLength_372_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82acb3f6de8b9682037417ddffb5f9815b0a74c727ee52f817c9b624ce3a7735
+size 5935

--- a/tests/Images/ReferenceOutput/ShouldNotInsertExtraLineBreaks__WrappingLength_400_.png
+++ b/tests/Images/ReferenceOutput/ShouldNotInsertExtraLineBreaks__WrappingLength_400_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18b14563c798925aaeee959bbeb12bd392af681ab620fb15a0264f7f2904f2a6
+size 14829

--- a/tests/Images/ReferenceOutput/TextJustification_InterCharacter_Horizontal_400-_direction_LeftToRight-TextJustification_InterCharacter_.png
+++ b/tests/Images/ReferenceOutput/TextJustification_InterCharacter_Horizontal_400-_direction_LeftToRight-TextJustification_InterCharacter_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a34f20be58409060a7a0c071de1ad19be52861b47d42af70e814a11605fc6d43
+size 8774

--- a/tests/Images/ReferenceOutput/TextJustification_InterCharacter_Horizontal_400-_direction_RightToLeft-TextJustification_InterCharacter_.png
+++ b/tests/Images/ReferenceOutput/TextJustification_InterCharacter_Horizontal_400-_direction_RightToLeft-TextJustification_InterCharacter_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9d261076440457a717da33a8681738e06a52182ef5430ea1c874c320a53c0e9
+size 8792

--- a/tests/Images/ReferenceOutput/TextJustification_InterCharacter_Vertical_400-_direction_LeftToRight-TextJustification_InterCharacter_.png
+++ b/tests/Images/ReferenceOutput/TextJustification_InterCharacter_Vertical_400-_direction_LeftToRight-TextJustification_InterCharacter_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41c2eb051160a94e3b63f789916daba0093af365b54bcd6fbd3c65a0114b295d
+size 7507

--- a/tests/Images/ReferenceOutput/TextJustification_InterCharacter_Vertical_400-_direction_RightToLeft-TextJustification_InterCharacter_.png
+++ b/tests/Images/ReferenceOutput/TextJustification_InterCharacter_Vertical_400-_direction_RightToLeft-TextJustification_InterCharacter_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8e48085ea9ffbe30b4be7de45aad642645a61edef7a4dd0b19a612c37e66bc7
+size 7432

--- a/tests/Images/ReferenceOutput/TextJustification_InterWord_Horizontal_400-_direction_LeftToRight-TextJustification_InterWord_.png
+++ b/tests/Images/ReferenceOutput/TextJustification_InterWord_Horizontal_400-_direction_LeftToRight-TextJustification_InterWord_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d6b060baad2258565758b6eebe3cd23061490a861dcb2b7b3b9276714dc5174
+size 8842

--- a/tests/Images/ReferenceOutput/TextJustification_InterWord_Horizontal_400-_direction_RightToLeft-TextJustification_InterWord_.png
+++ b/tests/Images/ReferenceOutput/TextJustification_InterWord_Horizontal_400-_direction_RightToLeft-TextJustification_InterWord_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f675cd2d88ed4e69b6710d002e73f9b43530c60a748f1112f39d040840b0f498
+size 8696

--- a/tests/Images/ReferenceOutput/TextJustification_InterWord_Vertical_400-_direction_LeftToRight-TextJustification_InterWord_.png
+++ b/tests/Images/ReferenceOutput/TextJustification_InterWord_Vertical_400-_direction_LeftToRight-TextJustification_InterWord_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a8a54b0c1707f57d99afdcd3cfb5518636e96f40ebab213e83cc8ef9a85edb7
+size 6725

--- a/tests/Images/ReferenceOutput/TextJustification_InterWord_Vertical_400-_direction_RightToLeft-TextJustification_InterWord_.png
+++ b/tests/Images/ReferenceOutput/TextJustification_InterWord_Vertical_400-_direction_RightToLeft-TextJustification_InterWord_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73d1573b88cc105218d1a557c7b096a50ed7aeca0a76d3719d2243ef7f764020
+size 6721

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/ExactImageComparer.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/ExactImageComparer.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.Fonts.Tests.ImageComparison;
+
+public class ExactImageComparer : ImageComparer
+{
+    public static ExactImageComparer Instance { get; } = new ExactImageComparer();
+
+    public override ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(
+        int index,
+        ImageFrame<TPixelA> expected,
+        ImageFrame<TPixelB> actual)
+    {
+        if (expected.Size != actual.Size)
+        {
+            throw new InvalidOperationException("Calling ImageComparer is invalid when dimensions mismatch!");
+        }
+
+        int width = actual.Width;
+
+        // TODO: Comparing through Rgba64 may not be robust enough because of the existence of super high precision pixel types.
+        Rgba64[] aBuffer = new Rgba64[width];
+        Rgba64[] bBuffer = new Rgba64[width];
+
+        List<PixelDifference> differences = new();
+        Configuration configuration = expected.Configuration;
+        Buffer2D<TPixelA> expectedBuffer = expected.PixelBuffer;
+        Buffer2D<TPixelB> actualBuffer = actual.PixelBuffer;
+
+        for (int y = 0; y < actual.Height; y++)
+        {
+            Span<TPixelA> aSpan = expectedBuffer.DangerousGetRowSpan(y);
+            Span<TPixelB> bSpan = actualBuffer.DangerousGetRowSpan(y);
+
+            PixelOperations<TPixelA>.Instance.ToRgba64(configuration, aSpan, aBuffer);
+            PixelOperations<TPixelB>.Instance.ToRgba64(configuration, bSpan, bBuffer);
+
+            for (int x = 0; x < width; x++)
+            {
+                Rgba64 aPixel = aBuffer[x];
+                Rgba64 bPixel = bBuffer[x];
+
+                if (aPixel != bPixel)
+                {
+                    PixelDifference diff = new(new Point(x, y), aPixel, bPixel);
+                    differences.Add(diff);
+                }
+            }
+        }
+
+        return new ImageSimilarityReport<TPixelA, TPixelB>(index, expected, actual, differences);
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/Exceptions/ImageDifferenceIsOverThresholdException.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/Exceptions/ImageDifferenceIsOverThresholdException.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Globalization;
+using System.Text;
+
+namespace SixLabors.Fonts.Tests.ImageComparison;
+
+public class ImageDifferenceIsOverThresholdException : ImagesSimilarityException
+{
+    public ImageSimilarityReport[] Reports { get; }
+
+    public ImageDifferenceIsOverThresholdException(params ImageSimilarityReport[] reports)
+        : base("Image difference is over threshold!" + FormatReports(reports))
+        => this.Reports = reports.ToArray();
+
+    private static string FormatReports(IEnumerable<ImageSimilarityReport> reports)
+    {
+        StringBuilder sb = new();
+
+        sb.Append(Environment.NewLine);
+        sb.AppendFormat(CultureInfo.InvariantCulture, "Test Environment OS : {0}", GetEnvironmentName());
+        sb.Append(Environment.NewLine);
+
+        sb.AppendFormat(CultureInfo.InvariantCulture, "Test Environment is CI : {0}", TestEnvironment.RunsOnCI);
+        sb.Append(Environment.NewLine);
+
+        sb.AppendFormat(CultureInfo.InvariantCulture, "Test Environment OS Architecture : {0}", TestEnvironment.OSArchitecture);
+        sb.Append(Environment.NewLine);
+
+        sb.AppendFormat(CultureInfo.InvariantCulture, "Test Environment Process Architecture : {0}", TestEnvironment.ProcessArchitecture);
+        sb.Append(Environment.NewLine);
+
+        foreach (ImageSimilarityReport r in reports)
+        {
+            sb.AppendFormat(CultureInfo.InvariantCulture, "Report ImageFrame {0}: ", r.Index)
+              .Append(r)
+              .Append(Environment.NewLine);
+        }
+
+        return sb.ToString();
+    }
+
+    private static string GetEnvironmentName()
+    {
+        if (TestEnvironment.IsMacOS)
+        {
+            return "MacOS";
+        }
+
+        if (TestEnvironment.IsLinux)
+        {
+            return "Linux";
+        }
+
+        if (TestEnvironment.IsWindows)
+        {
+            return "Windows";
+        }
+
+        return "Unknown";
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/Exceptions/ImageDimensionsMismatchException.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/Exceptions/ImageDimensionsMismatchException.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp;
+
+namespace SixLabors.Fonts.Tests.ImageComparison;
+
+public class ImageDimensionsMismatchException : ImagesSimilarityException
+{
+    public ImageDimensionsMismatchException(Size expectedSize, Size actualSize)
+        : base($"The image dimensions {actualSize} do not match the expected {expectedSize}!")
+    {
+        this.ExpectedSize = expectedSize;
+        this.ActualSize = actualSize;
+    }
+
+    public Size ExpectedSize { get; }
+
+    public Size ActualSize { get; }
+}

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/Exceptions/ImagesSimilarityException.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/Exceptions/ImagesSimilarityException.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.Fonts.Tests.ImageComparison;
+
+using System;
+
+public class ImagesSimilarityException : Exception
+{
+    public ImagesSimilarityException(string message)
+        : base(message)
+    {
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/ImageComparer.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/ImageComparer.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.Fonts.Tests.ImageComparison;
+
+public abstract class ImageComparer
+{
+    public static ImageComparer Exact { get; } = Tolerant(0, 0);
+
+    /// <summary>
+    /// Returns an instance of <see cref="TolerantImageComparer"/>.
+    /// Individual Manhattan pixel difference is only added to total image difference when the individual difference is over 'perPixelManhattanThreshold'.
+    /// </summary>
+    /// <param name="imageThreshold">The maximal tolerated difference represented by a value between 0 and 1.</param>
+    /// <param name="perPixelManhattanThreshold">Gets the threshold of the individual pixels before they accumulate towards the overall difference.</param>
+    /// <returns>A ImageComparer instance.</returns>
+    public static ImageComparer Tolerant(
+        float imageThreshold = TolerantImageComparer.DefaultImageThreshold,
+        int perPixelManhattanThreshold = 0) =>
+        new TolerantImageComparer(imageThreshold, perPixelManhattanThreshold);
+
+    /// <summary>
+    /// Returns Tolerant(imageThresholdInPercent/100)
+    /// </summary>
+    /// <param name="imageThresholdInPercent">The maximal tolerated difference represented by a value between 0 and 100.</param>
+    /// <param name="perPixelManhattanThreshold">Gets the threshold of the individual pixels before they accumulate towards the overall difference.</param>
+    /// <returns>A ImageComparer instance.</returns>
+    public static ImageComparer TolerantPercentage(float imageThresholdInPercent, int perPixelManhattanThreshold = 0)
+        => Tolerant(imageThresholdInPercent / 100F, perPixelManhattanThreshold);
+
+    public abstract ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(
+        int index,
+        ImageFrame<TPixelA> expected,
+        ImageFrame<TPixelB> actual)
+        where TPixelA : unmanaged, IPixel<TPixelA>
+        where TPixelB : unmanaged, IPixel<TPixelB>;
+}
+
+public static class ImageComparerExtensions
+{
+    public static ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(
+        this ImageComparer comparer,
+        Image<TPixelA> expected,
+        Image<TPixelB> actual)
+        where TPixelA : unmanaged, IPixel<TPixelA>
+        where TPixelB : unmanaged, IPixel<TPixelB> => comparer.CompareImagesOrFrames(0, expected.Frames.RootFrame, actual.Frames.RootFrame);
+
+    public static IEnumerable<ImageSimilarityReport<TPixelA, TPixelB>> CompareImages<TPixelA, TPixelB>(
+        this ImageComparer comparer,
+        Image<TPixelA> expected,
+        Image<TPixelB> actual,
+        Func<int, int, bool> predicate = null)
+        where TPixelA : unmanaged, IPixel<TPixelA>
+        where TPixelB : unmanaged, IPixel<TPixelB>
+    {
+        List<ImageSimilarityReport<TPixelA, TPixelB>> result = new();
+
+        int expectedFrameCount = actual.Frames.Count;
+        if (predicate != null)
+        {
+            expectedFrameCount = 0;
+            for (int i = 0; i < actual.Frames.Count; i++)
+            {
+                if (predicate(i, actual.Frames.Count))
+                {
+                    expectedFrameCount++;
+                }
+            }
+        }
+
+        if (expected.Frames.Count != expectedFrameCount)
+        {
+            throw new ImagesSimilarityException("Frame count does not match!");
+        }
+
+        for (int i = 0; i < expected.Frames.Count; i++)
+        {
+            if (predicate != null && !predicate(i, expected.Frames.Count))
+            {
+                continue;
+            }
+
+            ImageSimilarityReport<TPixelA, TPixelB> report = comparer.CompareImagesOrFrames(i, expected.Frames[i], actual.Frames[i]);
+            if (!report.IsEmpty)
+            {
+                result.Add(report);
+            }
+        }
+
+        return result;
+    }
+
+    public static void VerifySimilarity<TPixelA, TPixelB>(
+        this ImageComparer comparer,
+        Image<TPixelA> expected,
+        Image<TPixelB> actual,
+        Func<int, int, bool> predicate = null)
+        where TPixelA : unmanaged, IPixel<TPixelA>
+        where TPixelB : unmanaged, IPixel<TPixelB>
+    {
+        if (expected.Size != actual.Size)
+        {
+            throw new ImageDimensionsMismatchException(expected.Size, actual.Size);
+        }
+
+        int expectedFrameCount = actual.Frames.Count;
+        if (predicate != null)
+        {
+            expectedFrameCount = 0;
+            for (int i = 0; i < actual.Frames.Count; i++)
+            {
+                if (predicate(i, actual.Frames.Count))
+                {
+                    expectedFrameCount++;
+                }
+            }
+        }
+
+        if (expected.Frames.Count != expectedFrameCount)
+        {
+            throw new ImagesSimilarityException("Image frame count does not match!");
+        }
+
+        IEnumerable<ImageSimilarityReport> reports = comparer.CompareImages(expected, actual, predicate);
+        if (reports.Any())
+        {
+            throw new ImageDifferenceIsOverThresholdException(reports.ToArray());
+        }
+    }
+
+    public static void VerifySimilarityIgnoreRegion<TPixelA, TPixelB>(
+        this ImageComparer comparer,
+        Image<TPixelA> expected,
+        Image<TPixelB> actual,
+        Rectangle ignoredRegion)
+        where TPixelA : unmanaged, IPixel<TPixelA>
+        where TPixelB : unmanaged, IPixel<TPixelB>
+    {
+        if (expected.Size != actual.Size)
+        {
+            throw new ImageDimensionsMismatchException(expected.Size, actual.Size);
+        }
+
+        if (expected.Frames.Count != actual.Frames.Count)
+        {
+            throw new ImagesSimilarityException("Image frame count does not match!");
+        }
+
+        IEnumerable<ImageSimilarityReport<TPixelA, TPixelB>> reports = comparer.CompareImages(expected, actual);
+        if (reports.Any())
+        {
+            List<ImageSimilarityReport<TPixelA, TPixelB>> cleanedReports = new(reports.Count());
+            foreach (ImageSimilarityReport<TPixelA, TPixelB> r in reports)
+            {
+                IEnumerable<PixelDifference> outsideChanges = r.Differences.Where(
+                    x =>
+                    !(ignoredRegion.X <= x.Position.X
+                    && x.Position.X <= ignoredRegion.Right
+                    && ignoredRegion.Y <= x.Position.Y
+                    && x.Position.Y <= ignoredRegion.Bottom));
+
+                if (outsideChanges.Any())
+                {
+                    cleanedReports.Add(new ImageSimilarityReport<TPixelA, TPixelB>(r.Index, r.ExpectedImage, r.ActualImage, outsideChanges, null));
+                }
+            }
+
+            if (cleanedReports.Count > 0)
+            {
+                throw new ImageDifferenceIsOverThresholdException(cleanedReports.ToArray());
+            }
+        }
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/ImageSimilarityReport.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/ImageSimilarityReport.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Globalization;
+using System.Text;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.Fonts.Tests.ImageComparison;
+
+public class ImageSimilarityReport
+{
+    protected ImageSimilarityReport(
+        int index,
+        object expectedImage,
+        object actualImage,
+        IEnumerable<PixelDifference> differences,
+        float? totalNormalizedDifference = null)
+    {
+        this.Index = index;
+        this.ExpectedImage = expectedImage;
+        this.ActualImage = actualImage;
+        this.TotalNormalizedDifference = totalNormalizedDifference;
+        this.Differences = differences.ToArray();
+    }
+
+    public int Index { get; }
+
+    public object ExpectedImage { get; }
+
+    public object ActualImage { get; }
+
+    // TODO: This should not be a nullable value!
+    public float? TotalNormalizedDifference { get; }
+
+    public string DifferencePercentageString
+    {
+        get
+        {
+            if (!this.TotalNormalizedDifference.HasValue)
+            {
+                return "?";
+            }
+            else if (this.TotalNormalizedDifference == 0)
+            {
+                return "0%";
+            }
+            else
+            {
+                return $"{this.TotalNormalizedDifference.Value * 100:0.0000}%";
+            }
+        }
+    }
+
+    public PixelDifference[] Differences { get; }
+
+    public bool IsEmpty => this.Differences.Length == 0;
+
+    public override string ToString() => this.IsEmpty ? "[SimilarImages]" : this.PrintDifference();
+
+    private string PrintDifference()
+    {
+        StringBuilder sb = new();
+        if (this.TotalNormalizedDifference.HasValue)
+        {
+            sb.AppendLine()
+               .AppendLine(CultureInfo.InvariantCulture, $"Total difference: {this.DifferencePercentageString}");
+        }
+
+        int max = Math.Min(5, this.Differences.Length);
+
+        for (int i = 0; i < max; i++)
+        {
+            sb.Append(this.Differences[i]);
+            if (i < max - 1)
+            {
+                sb.AppendFormat(CultureInfo.InvariantCulture, ";{0}", Environment.NewLine);
+            }
+        }
+
+        if (this.Differences.Length >= 5)
+        {
+            sb.Append("...");
+        }
+
+        return sb.ToString();
+    }
+}
+
+public class ImageSimilarityReport<TPixelA, TPixelB> : ImageSimilarityReport
+    where TPixelA : unmanaged, IPixel<TPixelA>
+    where TPixelB : unmanaged, IPixel<TPixelB>
+{
+    public ImageSimilarityReport(
+        int index,
+        ImageFrame<TPixelA> expectedImage,
+        ImageFrame<TPixelB> actualImage,
+        IEnumerable<PixelDifference> differences,
+        float? totalNormalizedDifference = null)
+        : base(index, expectedImage, actualImage, differences, totalNormalizedDifference)
+    {
+    }
+
+    public static ImageSimilarityReport<TPixelA, TPixelB> Empty =>
+        new(0, null, null, Enumerable.Empty<PixelDifference>(), 0f);
+
+    public new ImageFrame<TPixelA> ExpectedImage => (ImageFrame<TPixelA>)base.ExpectedImage;
+
+    public new ImageFrame<TPixelB> ActualImage => (ImageFrame<TPixelB>)base.ActualImage;
+}

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/PixelDifference.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/PixelDifference.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.Fonts.Tests.ImageComparison;
+
+public readonly struct PixelDifference
+{
+    public PixelDifference(
+        Point position,
+        int redDifference,
+        int greenDifference,
+        int blueDifference,
+        int alphaDifference)
+    {
+        this.Position = position;
+        this.RedDifference = redDifference;
+        this.GreenDifference = greenDifference;
+        this.BlueDifference = blueDifference;
+        this.AlphaDifference = alphaDifference;
+    }
+
+    public PixelDifference(Point position, Rgba64 expected, Rgba64 actual)
+        : this(
+            position,
+            actual.R - expected.R,
+            actual.G - expected.G,
+            actual.B - expected.B,
+            actual.A - expected.A)
+    {
+    }
+
+    public Point Position { get; }
+
+    public int RedDifference { get; }
+
+    public int GreenDifference { get; }
+
+    public int BlueDifference { get; }
+
+    public int AlphaDifference { get; }
+
+    public override string ToString() =>
+        $"[Δ({this.RedDifference},{this.GreenDifference},{this.BlueDifference},{this.AlphaDifference}) @ ({this.Position.X},{this.Position.Y})]";
+}

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/TestImageExtensions.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/TestImageExtensions.cs
@@ -84,9 +84,7 @@ public static class TestImageExtensions
         }
         else if (properties is Dictionary<string, object> dictionary)
         {
-            return FormattableString.Invariant($"_{string.Join(
-                "-",
-                dictionary.Select(x => FormattableString.Invariant($"{x.Key}_{x.Value}")))}_");
+            return FormattableString.Invariant($"_{string.Join("-", dictionary.Select(x => FormattableString.Invariant($"{x.Key}_{x.Value}")))}_");
         }
 
         Type type = properties.GetType();
@@ -97,9 +95,6 @@ public static class TestImageExtensions
         }
 
         IEnumerable<PropertyInfo> runtimeProperties = type.GetRuntimeProperties();
-        return FormattableString.Invariant($"_{string.Join(
-            "-",
-            runtimeProperties.ToDictionary(x => x.Name, x => x.GetValue(properties))
-                .Select(x => FormattableString.Invariant($"{x.Key}_{x.Value}")))}_");
+        return FormattableString.Invariant($"_{string.Join("-", runtimeProperties.ToDictionary(x => x.Name, x => x.GetValue(properties)).Select(x => FormattableString.Invariant($"{x.Key}_{x.Value}")))}_");
     }
 }

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/TestImageExtensions.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/TestImageExtensions.cs
@@ -47,7 +47,7 @@ public static class TestImageExtensions
         }
 
         using Image<Rgba64> expected = Image.Load<Rgba64>(referencePath);
-        TolerantImageComparer comparer = new(percentageTolerance / 100F);
+        ImageComparer comparer = ImageComparer.TolerantPercentage(percentageTolerance);
         ImageSimilarityReport report = comparer.CompareImagesOrFrames(expected, image);
 
         if (!report.IsEmpty)

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/TestImageExtensions.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/TestImageExtensions.cs
@@ -32,7 +32,7 @@ public static class TestImageExtensions
 
     public static void CompareToReference<TPixel>(
         this Image<TPixel> image,
-        float percentageTolerance = 0F,
+        float percentageTolerance = 0.05F,
         string extension = null,
         [CallerMemberName] string test = "",
         params object[] properties)

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/TestImageExtensions.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/TestImageExtensions.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using SixLabors.Fonts.Tests.ImageComparison;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.Fonts.Tests.TestUtilities;
+
+public static class TestImageExtensions
+{
+    public static string DebugSave(
+        this Image image,
+        string extension = null,
+        [CallerMemberName] string test = "",
+        object properties = null)
+    {
+        string outputDirectory = TestEnvironment.ActualOutputDirectoryFullPath;
+        if (!Directory.Exists(outputDirectory))
+        {
+            Directory.CreateDirectory(outputDirectory);
+        }
+
+        string path = Path.Combine(outputDirectory, $"{test}{FormatTestDetails(properties)}.{extension ?? "png"}");
+        image.Save(path);
+
+        return path;
+    }
+
+    public static void CompareToReference<TPixel>(
+        this Image<TPixel> image,
+        float percentageTolerance = 0F,
+        string extension = null,
+        [CallerMemberName] string test = "",
+        object properties = null)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        string path = image.DebugSave(extension, test, properties: properties);
+        string referencePath = path.Replace(TestEnvironment.ActualOutputDirectoryFullPath, TestEnvironment.ReferenceOutputDirectoryFullPath);
+
+        if (!File.Exists(referencePath))
+        {
+            throw new FileNotFoundException($"The reference image file was not found: {referencePath}");
+        }
+
+        using Image<Rgba64> expected = Image.Load<Rgba64>(referencePath);
+        TolerantImageComparer comparer = new(percentageTolerance / 100F);
+        ImageSimilarityReport report = comparer.CompareImagesOrFrames(expected, image);
+
+        if (!report.IsEmpty)
+        {
+            throw new ImageDifferenceIsOverThresholdException(report);
+        }
+    }
+
+    private static string FormatTestDetails(object properties)
+    {
+        if (properties is null)
+        {
+            return "-";
+        }
+
+        if (properties is FormattableString fs)
+        {
+            return FormattableString.Invariant(fs);
+        }
+        else if (properties is string s)
+        {
+            return FormattableString.Invariant($"-{s}-");
+        }
+
+        IEnumerable<PropertyInfo> runtimeProperties = properties.GetType().GetRuntimeProperties();
+
+        return FormattableString.Invariant($"_{string.Join(
+            "-",
+            runtimeProperties.ToDictionary(x => x.Name, x => x.GetValue(properties))
+                .Select(x => FormattableString.Invariant($"{x.Key}_{x.Value}")))}_");
+    }
+}
+

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/TolerantImageComparer.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/TolerantImageComparer.cs
@@ -58,7 +58,7 @@ public class TolerantImageComparer : ImageComparer
 
     public override ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(int index, ImageFrame<TPixelA> expected, ImageFrame<TPixelB> actual)
     {
-        if (expected.Size != actual.Size)
+        if (expected.Size() != actual.Size())
         {
             throw new InvalidOperationException("Calling ImageComparer is invalid when dimensions mismatch!");
         }

--- a/tests/SixLabors.Fonts.Tests/ImageComparison/TolerantImageComparer.cs
+++ b/tests/SixLabors.Fonts.Tests/ImageComparison/TolerantImageComparer.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Runtime.CompilerServices;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.Fonts.Tests.ImageComparison;
+
+public class TolerantImageComparer : ImageComparer
+{
+    // 1% of all pixels in a 100*100 pixel area are allowed to have a difference of 1 unit
+    // 257 = (1 / 255) * 65535.
+    public const float DefaultImageThreshold = 257F / (100 * 100 * 65535);
+
+    /// <summary>
+    /// Individual Manhattan pixel difference is only added to total image difference when the individual difference is over 'perPixelManhattanThreshold'.
+    /// </summary>
+    /// <param name="imageThreshold">The maximal tolerated difference represented by a value between 0.0 and 1.0 scaled to 0 and 65535.</param>
+    /// <param name="perPixelManhattanThreshold">Gets the threshold of the individual pixels before they accumulate towards the overall difference.</param>
+    public TolerantImageComparer(float imageThreshold, int perPixelManhattanThreshold = 0)
+    {
+        Guard.MustBeGreaterThanOrEqualTo(imageThreshold, 0, nameof(imageThreshold));
+
+        this.ImageThreshold = imageThreshold;
+        this.PerPixelManhattanThreshold = perPixelManhattanThreshold;
+    }
+
+    /// <summary>
+    /// <para>
+    /// Gets the maximal tolerated difference represented by a value between 0.0 and 1.0 scaled to 0 and 65535.
+    /// Examples of percentage differences on a single pixel:
+    /// 1. PixelA = (65535,65535,65535,0) PixelB =(0,0,0,65535) leads to 100% difference on a single pixel
+    /// 2. PixelA = (65535,65535,65535,0) PixelB =(65535,65535,65535,65535) leads to 25% difference on a single pixel
+    /// 3. PixelA = (65535,65535,65535,0) PixelB =(32767,32767,32767,32767) leads to 50% difference on a single pixel
+    /// </para>
+    /// <para>
+    /// The total differences is the sum of all pixel differences normalized by image dimensions!
+    /// The individual distances are calculated using the Manhattan function:
+    /// <see>
+    ///     <cref>https://en.wikipedia.org/wiki/Taxicab_geometry</cref>
+    /// </see>
+    /// ImageThresholdInPercent = 1/255 =  257/65535 means that we allow one unit difference per channel on a 1x1 image
+    /// ImageThresholdInPercent = 1/(100*100*255) = 257/(100*100*65535) means that we allow only one unit difference per channel on a 100x100 image
+    /// </para>
+    /// </summary>
+    public float ImageThreshold { get; }
+
+    /// <summary>
+    /// Gets the threshold of the individual pixels before they accumulate towards the overall difference.
+    /// For an individual <see cref="Rgba64"/> pixel pair the value is the Manhattan distance of pixels:
+    /// <see>
+    ///     <cref>https://en.wikipedia.org/wiki/Taxicab_geometry</cref>
+    /// </see>
+    /// </summary>
+    public int PerPixelManhattanThreshold { get; }
+
+    public override ImageSimilarityReport<TPixelA, TPixelB> CompareImagesOrFrames<TPixelA, TPixelB>(int index, ImageFrame<TPixelA> expected, ImageFrame<TPixelB> actual)
+    {
+        if (expected.Size != actual.Size)
+        {
+            throw new InvalidOperationException("Calling ImageComparer is invalid when dimensions mismatch!");
+        }
+
+        int width = actual.Width;
+
+        // TODO: Comparing through Rgba64 may not robust enough because of the existence of super high precision pixel types.
+        Rgba64[] aBuffer = new Rgba64[width];
+        Rgba64[] bBuffer = new Rgba64[width];
+
+        float totalDifference = 0F;
+
+        List<PixelDifference> differences = new();
+        Configuration configuration = expected.Configuration;
+        Buffer2D<TPixelA> expectedBuffer = expected.PixelBuffer;
+        Buffer2D<TPixelB> actualBuffer = actual.PixelBuffer;
+
+        for (int y = 0; y < actual.Height; y++)
+        {
+            Span<TPixelA> aSpan = expectedBuffer.DangerousGetRowSpan(y);
+            Span<TPixelB> bSpan = actualBuffer.DangerousGetRowSpan(y);
+
+            PixelOperations<TPixelA>.Instance.ToRgba64(configuration, aSpan, aBuffer);
+            PixelOperations<TPixelB>.Instance.ToRgba64(configuration, bSpan, bBuffer);
+
+            for (int x = 0; x < width; x++)
+            {
+                int d = GetManhattanDistanceInRgbaSpace(ref aBuffer[x], ref bBuffer[x]);
+
+                if (d > this.PerPixelManhattanThreshold)
+                {
+                    PixelDifference diff = new(new Point(x, y), aBuffer[x], bBuffer[x]);
+                    differences.Add(diff);
+
+                    totalDifference += d;
+                }
+            }
+        }
+
+        float normalizedDifference = totalDifference / (actual.Width * (float)actual.Height);
+        normalizedDifference /= 4F * 65535F;
+
+        if (normalizedDifference > this.ImageThreshold)
+        {
+            return new ImageSimilarityReport<TPixelA, TPixelB>(index, expected, actual, differences, normalizedDifference);
+        }
+
+        return ImageSimilarityReport<TPixelA, TPixelB>.Empty;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetManhattanDistanceInRgbaSpace(ref Rgba64 a, ref Rgba64 b)
+        => Diff(a.R, b.R) + Diff(a.G, b.G) + Diff(a.B, b.B) + Diff(a.A, b.A);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Diff(ushort a, ushort b) => Math.Abs(a - b);
+}

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_33.cs
@@ -13,8 +13,8 @@ public class Issues_33
     [InlineData("\n\tHelloworld", 310, 10)]
     [InlineData("\tHelloworld", 310, 10)]
     [InlineData("  Helloworld", 340, 10)]
-    [InlineData("Hell owor ld\t", 390, 10)]
-    [InlineData("Helloworld  ", 360, 10)]
+    [InlineData("Hell owor ld\t", 340, 10)]
+    [InlineData("Helloworld  ", 280, 10)]
     public void WhiteSpaceAtStartOfLineNotMeasured(string text, float width, float height)
     {
         Font font = CreateFont(text);

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_367.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_367.cs
@@ -25,6 +25,8 @@ public class Issues_367
         Assert.Equal(3, lineCount);
 
         FontRectangle advance = TextMeasurer.MeasureAdvance(text, options);
+        TextLayoutTestUtilities.TestLayout(text, options);
+
         Assert.Equal(354.968658F, advance.Width, Comparer);
         Assert.Equal(48, advance.Height, Comparer);
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_400.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_400.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Text;
+
 namespace SixLabors.Fonts.Tests.Issues;
 public class Issues_400
 {
@@ -14,11 +16,13 @@ public class Issues_400
             WrappingLength = 1900
         };
 
-        const string content = """
-                          NEWS_CATEGORY=EWF&NEWS_HASH=4b298ff9277ef9fdf515356be95ea3caf57cd36&OFFSET=0&SEARCH_VALUE=CA88105E1088&ID_NEWS
-          """;
+        StringBuilder stringBuilder = new();
+        stringBuilder
+            .AppendLine()
+            .AppendLine("                NEWS_CATEGORY=EWF&NEWS_HASH=4b298ff9277ef9fdf515356be95ea3caf57cd36&OFFSET=0&SEARCH_VALUE=CA88105E1088&ID_NEWS")
+            .Append("          ");
 
-        int lineCount = TextMeasurer.CountLines(content, options);
+        int lineCount = TextMeasurer.CountLines(stringBuilder.ToString(), options);
         Assert.Equal(2, lineCount);
 #endif
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_431.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_431.cs
@@ -22,10 +22,12 @@ public class Issues_431
             };
 
             int lineCount = TextMeasurer.CountLines(text, options);
-            Assert.Equal(3, lineCount);
+            Assert.Equal(4, lineCount);
 
             IReadOnlyList<GlyphLayout> layout = TextLayout.GenerateLayout(text, options);
-            Assert.Equal(47, layout.Count);
+            Assert.Equal(46, layout.Count);
+
+            TextLayoutTestUtilities.TestLayout(text, options);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_434.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_434.cs
@@ -5,16 +5,16 @@ using System.Numerics;
 
 namespace SixLabors.Fonts.Tests.Issues;
 
-public class Issues_431
+public class Issues_434
 {
-    [Fact]
-    public void ShouldNotInsertExtraLineBreaks()
+    [Theory]
+    [InlineData("- Lorem ipsullll\n\ndolor sit amet\n-consectetur elit", 3)]
+    [InlineData("- Lorem ipsullll\n\n\ndolor sit amet\n-consectetur elit", 3)]
+    public void ShouldNotInsertExtraLineBreaks(string text, int expectedLineCount)
     {
         if (SystemFonts.TryGet("Arial", out FontFamily family))
         {
             Font font = family.CreateFont(60);
-            const string text = "- Lorem ipsullll\ndolor sit amet\n-consectetur elit";
-
             TextOptions options = new(font)
             {
                 Origin = new Vector2(50, 20),
@@ -22,7 +22,7 @@ public class Issues_431
             };
 
             int lineCount = TextMeasurer.CountLines(text, options);
-            Assert.Equal(3, lineCount);
+            Assert.Equal(expectedLineCount, lineCount);
 
             IReadOnlyList<GlyphLayout> layout = TextLayout.GenerateLayout(text, options);
             Assert.Equal(47, layout.Count);

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_434.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_434.cs
@@ -8,9 +8,8 @@ namespace SixLabors.Fonts.Tests.Issues;
 public class Issues_434
 {
     [Theory]
-    [InlineData("- Lorem ipsullll\n\ndolor sit amet\n-consectetur elit", 3)]
-    [InlineData("- Lorem ipsullll\n\n\ndolor sit amet\n-consectetur elit", 3)]
-    public void ShouldNotInsertExtraLineBreaks(string text, int expectedLineCount)
+    [InlineData("- Lorem ipsullll\n\ndolor sit amet\n-consectetur elit", 4)]
+    public void ShouldInsertExtraLineBreaksA(string text, int expectedLineCount)
     {
         if (SystemFonts.TryGet("Arial", out FontFamily family))
         {
@@ -21,11 +20,40 @@ public class Issues_434
                 WrappingLength = 400,
             };
 
+            // Line count includes rendered lines only.
+            // Line breaks cause offsetting of subsequent lines.
             int lineCount = TextMeasurer.CountLines(text, options);
             Assert.Equal(expectedLineCount, lineCount);
 
             IReadOnlyList<GlyphLayout> layout = TextLayout.GenerateLayout(text, options);
-            Assert.Equal(47, layout.Count);
+            Assert.Equal(46, layout.Count);
+
+            TextLayoutTestUtilities.TestLayout(text, options, properties: expectedLineCount);
+        }
+    }
+
+    [Theory]
+    [InlineData("- Lorem ipsullll\n\n\ndolor sit amet\n-consectetur elit", 4)]
+    public void ShouldInsertExtraLineBreaksB(string text, int expectedLineCount)
+    {
+        if (SystemFonts.TryGet("Arial", out FontFamily family))
+        {
+            Font font = family.CreateFont(60);
+            TextOptions options = new(font)
+            {
+                Origin = new Vector2(50, 20),
+                WrappingLength = 400,
+            };
+
+            // Line count includes rendered lines only.
+            // Line breaks cause offsetting of subsequent lines.
+            int lineCount = TextMeasurer.CountLines(text, options);
+            Assert.Equal(expectedLineCount, lineCount);
+
+            IReadOnlyList<GlyphLayout> layout = TextLayout.GenerateLayout(text, options);
+            Assert.Equal(46, layout.Count);
+
+            TextLayoutTestUtilities.TestLayout(text, options, properties: expectedLineCount);
         }
     }
 }

--- a/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
+++ b/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
     <PackageReference Include="Pegasus" Version="4.1.0" PrivateAssets="all" />    
     <Compile Include="..\..\src\UnicodeTrieGenerator\StateAutomation\DeterministicFiniteAutomata.cs" Link="Unicode\StateAutomation\DeterministicFiniteAutomata.cs" />
     <Compile Include="..\..\src\UnicodeTrieGenerator\StateAutomation\Compile.cs" Link="Unicode\StateAutomation\Compile.cs" />

--- a/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
+++ b/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
@@ -10,7 +10,7 @@
     <!--Avoid culture analysis in FontCollection overloads-->
     <NoWarn>CA1304</NoWarn>
   </PropertyGroup>
-  
+
   <Choose>
     <When Condition="$(SIXLABORS_TESTING_PREVIEW) == true">
       <PropertyGroup>
@@ -23,7 +23,20 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  
+
+  <PropertyGroup>
+    <!--
+    Comment out this constant declaration to disable all tests based upon image generation.
+    This allows us to make breaking changes to the Fonts API without breaking the tests.
+    -->
+    <DefineConstants>$(DefineConstants);SUPPORTS_DRAWING</DefineConstants>
+    <HasSupportForDrawing Condition="$(DefineConstants.Contains('SUPPORTS_DRAWING'))">true</HasSupportForDrawing>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(HasSupportForDrawing) == false">
+    <Compile Remove="ImageComparison\**" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" />
   </ItemGroup>
@@ -35,8 +48,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
-    <PackageReference Include="Pegasus" Version="4.1.0" PrivateAssets="all" />    
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" Condition="$(HasSupportForDrawing)" />
+    <PackageReference Include="Pegasus" Version="4.1.0" PrivateAssets="all" />
     <Compile Include="..\..\src\UnicodeTrieGenerator\StateAutomation\DeterministicFiniteAutomata.cs" Link="Unicode\StateAutomation\DeterministicFiniteAutomata.cs" />
     <Compile Include="..\..\src\UnicodeTrieGenerator\StateAutomation\Compile.cs" Link="Unicode\StateAutomation\Compile.cs" />
     <Compile Include="..\..\src\UnicodeTrieGenerator\StateAutomation\State.cs" Link="Unicode\StateAutomation\State.cs" />

--- a/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
+++ b/tests/SixLabors.Fonts.Tests/SixLabors.Fonts.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DebugSymbols>True</DebugSymbols>
     <Platforms>AnyCPU;x64;x86</Platforms>
-    <LangVersion>11</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTestUtilities.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTestUtilities.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Runtime.CompilerServices;
+
+#if SUPPORTS_DRAWING
+using SixLabors.Fonts.Tables.AdvancedTypographic;
+using SixLabors.Fonts.Tests.TestUtilities;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+#endif
+
+namespace SixLabors.Fonts.Tests;
+
+internal static class TextLayoutTestUtilities
+{
+    public static void TestLayout(
+        string text,
+        TextOptions options,
+        float percentageTolerance = 0F,
+        [CallerMemberName] string test = "",
+        params object[] properties)
+    {
+#if SUPPORTS_DRAWING
+        FontRectangle advance = TextMeasurer.MeasureAdvance(text, options);
+        int width = (int)(Math.Ceiling(advance.Width) + Math.Ceiling(options.Origin.X));
+        int height = (int)(Math.Ceiling(advance.Height) + Math.Ceiling(options.Origin.Y));
+
+        bool isVertical = !options.LayoutMode.IsHorizontal();
+        int wrappingLength = isVertical
+            ? (int)(Math.Ceiling(options.WrappingLength) + Math.Ceiling(options.Origin.Y))
+            : (int)(Math.Ceiling(options.WrappingLength) + Math.Ceiling(options.Origin.X));
+
+        int imageWidth = isVertical ? width : Math.Max(width, wrappingLength + 1);
+        int imageHeight = isVertical ? Math.Max(height, wrappingLength + 1) : height;
+
+        using Image<Rgba32> img = new(imageWidth, imageHeight, Color.White);
+
+        img.Mutate(ctx => ctx.DrawText(FromTextOptions(options), text, Color.Black));
+
+        if (wrappingLength > 0)
+        {
+            if (!options.LayoutMode.IsHorizontal())
+            {
+                img.Mutate(x => x.DrawLine(Color.Red, 1, new(0, wrappingLength), new(width, wrappingLength)));
+            }
+            else
+            {
+                img.Mutate(x => x.DrawLine(Color.Red, 1, new(wrappingLength, 0), new(wrappingLength, height)));
+            }
+
+            if (properties.Any())
+            {
+                List<object> extended = properties.ToList();
+                extended.Insert(0, options.WrappingLength);
+                img.CompareToReference(percentageTolerance: percentageTolerance, test: test, properties: extended.ToArray());
+            }
+            else
+            {
+                img.CompareToReference(percentageTolerance: percentageTolerance, test: test, properties: new { options.WrappingLength });
+            }
+        }
+        else
+        {
+            img.CompareToReference(percentageTolerance: percentageTolerance, test: test, properties: properties);
+        }
+
+#endif
+    }
+
+#if SUPPORTS_DRAWING
+    private static RichTextOptions FromTextOptions(TextOptions options)
+    {
+        RichTextOptions result = new(options.Font)
+        {
+            FallbackFontFamilies = new List<FontFamily>(options.FallbackFontFamilies),
+            TabWidth = options.TabWidth,
+            HintingMode = options.HintingMode,
+            Dpi = options.Dpi,
+            LineSpacing = options.LineSpacing,
+            Origin = options.Origin,
+            WrappingLength = options.WrappingLength,
+            WordBreaking = options.WordBreaking,
+            TextDirection = options.TextDirection,
+            TextAlignment = options.TextAlignment,
+            TextJustification = options.TextJustification,
+            HorizontalAlignment = options.HorizontalAlignment,
+            VerticalAlignment = options.VerticalAlignment,
+            LayoutMode = options.LayoutMode,
+            KerningMode = options.KerningMode,
+            ColorFontSupport = options.ColorFontSupport,
+            FeatureTags = new List<Tag>(options.FeatureTags),
+        };
+
+        if (options.TextRuns.Count > 0)
+        {
+            List<RichTextRun> runs = new(options.TextRuns.Count);
+            foreach (TextRun run in options.TextRuns)
+            {
+                runs.Add(new RichTextRun()
+                {
+                    Font = run.Font,
+                    Start = run.Start,
+                    End = run.End,
+                    TextAttributes = run.TextAttributes,
+                    TextDecorations = run.TextDecorations
+                });
+            }
+        }
+
+        return result;
+    }
+#endif
+}

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTestUtilities.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTestUtilities.cs
@@ -19,7 +19,7 @@ internal static class TextLayoutTestUtilities
     public static void TestLayout(
         string text,
         TextOptions options,
-        float percentageTolerance = 0F,
+        float percentageTolerance = 0.05F,
         [CallerMemberName] string test = "",
         params object[] properties)
     {

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -4,12 +4,8 @@
 using System.Globalization;
 using System.Numerics;
 using SixLabors.Fonts.Tests.Fakes;
-using SixLabors.Fonts.Tests.TestUtilities;
 using SixLabors.Fonts.Unicode;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing.Processing;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 
 namespace SixLabors.Fonts.Tests;
 
@@ -276,172 +272,195 @@ public class TextLayoutTests
     }
 
     [Theory]
-    [InlineData("hello world", 10, 310)]
-    [InlineData(
-        "hello world hello world hello world",
-        70, // 30 actual line height * 2 + 10 actual height
-        310)]
+    [InlineData("hello world", 10, 87.125F)]
+    [InlineData("hello world hello world hello world", 11.438F, 279.13F)]
     [InlineData(// issue https://github.com/SixLabors/ImageSharp.Drawing/issues/115
         "这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。",
-        160, // 30 actual line height * 2 + 10 actual height
-        310)]
+        62.625,
+        318.86F)]
     public void MeasureTextWordWrappingHorizontalTopBottom(string text, float height, float width)
     {
-        Font font = CreateFont(text);
-        FontRectangle size = TextMeasurer.MeasureBounds(text, new TextOptions(font)
+        if (SystemFonts.TryGet("SimSun", out FontFamily family))
         {
-            Dpi = font.FontMetrics.ScaleFactor,
-            WrappingLength = 350,
-            LayoutMode = LayoutMode.HorizontalTopBottom
-        });
+            Font font = family.CreateFont(16);
+            TextOptions options = new(font)
+            {
+                WrappingLength = 350,
+                LayoutMode = LayoutMode.HorizontalTopBottom
+            };
 
-        Assert.Equal(width, size.Width, 4F);
-        Assert.Equal(height, size.Height, 4F);
+            FontRectangle size = TextMeasurer.MeasureBounds(text, options);
+
+            Assert.Equal(width, size.Width, 4F);
+            Assert.Equal(height, size.Height, 4F);
+            TextLayoutTestUtilities.TestLayout(text, options, properties: new { height, width });
+        }
     }
 
     [Theory]
-    [InlineData("hello world", 10, 310)]
-    [InlineData(
-        "hello world hello world hello world",
-        70, // 30 actual line height * 2 + 10 actual height
-        310)]
+    [InlineData("hello world", 10, 87.125F)]
+    [InlineData("hello world hello world hello world", 11.438F, 279.13F)]
     [InlineData(// issue https://github.com/SixLabors/ImageSharp.Drawing/issues/115
         "这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。",
-        160, // 30 actual line height * 2 + 10 actual height
-        310)]
+        62.625,
+        318.86F)]
     public void MeasureTextWordWrappingHorizontalBottomTop(string text, float height, float width)
     {
-        Font font = CreateFont(text);
-        FontRectangle size = TextMeasurer.MeasureBounds(text, new TextOptions(font)
+        if (SystemFonts.TryGet("SimSun", out FontFamily family))
         {
-            Dpi = font.FontMetrics.ScaleFactor,
-            WrappingLength = 350,
-            LayoutMode = LayoutMode.HorizontalBottomTop
-        });
+            Font font = family.CreateFont(16);
+            TextOptions options = new(font)
+            {
+                WrappingLength = 350,
+                LayoutMode = LayoutMode.HorizontalBottomTop
+            };
 
-        Assert.Equal(width, size.Width, 4F);
-        Assert.Equal(height, size.Height, 4F);
+            FontRectangle size = TextMeasurer.MeasureBounds(text, options);
+
+            Assert.Equal(width, size.Width, 4F);
+            Assert.Equal(height, size.Height, 4F);
+            TextLayoutTestUtilities.TestLayout(text, options, properties: new { height, width });
+        }
     }
 
     [Theory]
-    [InlineData("hello world", 310, 10)]
-    [InlineData("hello world hello world hello world", 310, 70)]
-    [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 160)]
+    [InlineData("hello world", 171.25F, 10)]
+    [InlineData("hello world hello world hello world", 267.25F, 23.875F)]
+    [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 318.563F, 62.813F)]
     public void MeasureTextWordWrappingVerticalLeftRight(string text, float height, float width)
     {
-        Font font = CreateFont(text);
-        FontRectangle size = TextMeasurer.MeasureBounds(text, new TextOptions(font)
+        if (SystemFonts.TryGet("SimSun", out FontFamily family))
         {
-            Dpi = font.FontMetrics.ScaleFactor,
-            WrappingLength = 350,
-            LayoutMode = LayoutMode.VerticalLeftRight
-        });
+            Font font = family.CreateFont(16);
+            TextOptions options = new(font)
+            {
+                WrappingLength = 350,
+                LayoutMode = LayoutMode.VerticalLeftRight
+            };
 
-        Assert.Equal(width, size.Width, 4F);
-        Assert.Equal(height, size.Height, 4F);
+            FontRectangle size = TextMeasurer.MeasureBounds(text, options);
+
+            Assert.Equal(width, size.Width, 4F);
+            Assert.Equal(height, size.Height, 4F);
+            TextLayoutTestUtilities.TestLayout(text, options, properties: new { height, width });
+        }
     }
 
     [Theory]
-    [InlineData("hello world", 310, 10)]
-    [InlineData("hello world hello world hello world", 310, 70)]
-    [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 160)]
+    [InlineData("hello world", 171.25F, 10)]
+    [InlineData("hello world hello world hello world", 267.25F, 23.875F)]
+    [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 318.563F, 62.813F)]
     public void MeasureTextWordWrappingVerticalRightLeft(string text, float height, float width)
     {
-        Font font = CreateFont(text);
-        FontRectangle size = TextMeasurer.MeasureBounds(text, new TextOptions(font)
+        if (SystemFonts.TryGet("SimSun", out FontFamily family))
         {
-            Dpi = font.FontMetrics.ScaleFactor,
-            WrappingLength = 350,
-            LayoutMode = LayoutMode.VerticalRightLeft
-        });
+            Font font = family.CreateFont(16);
+            TextOptions options = new(font)
+            {
+                WrappingLength = 350,
+                LayoutMode = LayoutMode.VerticalRightLeft
+            };
 
-        Assert.Equal(width, size.Width, 4F);
-        Assert.Equal(height, size.Height, 4F);
+            FontRectangle size = TextMeasurer.MeasureBounds(text, options);
+
+            Assert.Equal(width, size.Width, 4F);
+            Assert.Equal(height, size.Height, 4F);
+            TextLayoutTestUtilities.TestLayout(text, options, properties: new { height, width });
+        }
     }
 
     [Theory]
-    [InlineData("hello world", 310, 10)]
-    [InlineData("hello world hello world hello world", 310, 70)]
-    [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 310, 160)]
+    [InlineData("hello world", 87.125F, 10)]
+    [InlineData("hello world hello world hello world", 279.125F, 11.438F)]
+    [InlineData("这是一段长度超出设定的换行宽度的文本，但是没有在设定的宽度处换行。这段文本用于演示问题。希望可以修复。如果有需要可以联系我。", 318.563F, 62.813F)]
     public void MeasureTextWordWrappingVerticalMixedLeftRight(string text, float height, float width)
     {
-        Font font = CreateFont(text);
-        FontRectangle size = TextMeasurer.MeasureBounds(text, new TextOptions(font)
+        if (SystemFonts.TryGet("SimSun", out FontFamily family))
         {
-            Dpi = font.FontMetrics.ScaleFactor,
-            WrappingLength = 350,
-            LayoutMode = LayoutMode.VerticalMixedLeftRight
-        });
+            Font font = family.CreateFont(16);
+            TextOptions options = new(font)
+            {
+                WrappingLength = 350,
+                LayoutMode = LayoutMode.VerticalMixedLeftRight
+            };
 
-        Assert.Equal(width, size.Width, 4F);
-        Assert.Equal(height, size.Height, 4F);
+            FontRectangle size = TextMeasurer.MeasureBounds(text, options);
+
+            Assert.Equal(width, size.Width, 4F);
+            Assert.Equal(height, size.Height, 4F);
+            TextLayoutTestUtilities.TestLayout(text, options, properties: new { height, width });
+        }
     }
 
-#if OS_WINDOWS
     [Theory]
-    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.Standard, 100, 870)]
-    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakAll, 120, 399)]
-    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakWord, 120, 400)]
-    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.KeepAll, 60, 699)]
-    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.Standard, 101, 870)]
-    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakAll, 121, 399)]
-    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakWord, 121, 400)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.KeepAll, 61, 699)]
+    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.Standard, 100, 696.51F)]
+    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakAll, 129.29F, 237.53F)]
+    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakWord, 128, 237.53F)]
+    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.KeepAll, 65.29F, 699)]
+    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.Standard, 96F, 696.51F)]
+    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakAll, 129.29F, 237.53F)]
+    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakWord, 128, 237.53F)]
+    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.KeepAll, 61, 699)]
     public void MeasureTextWordBreakMatchesMDN(string text, LayoutMode layoutMode, WordBreaking wordBreaking, float height, float width)
     {
-        // Testing using Windows only to ensure that actual glyphs are rendered
-        // against known physically tested values.
-        FontFamily arial = SystemFonts.Get("Arial");
-        FontFamily jhengHei = SystemFonts.Get("Microsoft JhengHei");
-
-        Font font = arial.CreateFont(16);
-        FontRectangle size = TextMeasurer.MeasureAdvance(
-            text,
-            new TextOptions(font)
+        // See https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
+        if (SystemFonts.TryGet("Arial", out FontFamily arial) &&
+            SystemFonts.TryGet("Microsoft JhengHei", out FontFamily jhengHei))
+        {
+            Font font = arial.CreateFont(16);
+            TextOptions options = new(font)
             {
-                Dpi = 96,
                 WrappingLength = 238,
                 LayoutMode = layoutMode,
                 WordBreaking = wordBreaking,
                 FallbackFontFamilies = new[] { jhengHei }
-            });
+            };
 
-        Assert.Equal(width, size.Width, 4F);
-        Assert.Equal(height, size.Height, 4F);
+            FontRectangle size = TextMeasurer.MeasureAdvance(
+                text,
+                options);
+
+            Assert.Equal(width, size.Width, 4F);
+            Assert.Equal(height, size.Height, 4F);
+
+            TextLayoutTestUtilities.TestLayout(text, options, properties: new { layoutMode, wordBreaking });
+        }
     }
 
-
     [Theory]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.Standard, 100, 870)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakAll, 120, 399)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakWord, 120, 400)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.KeepAll, 60, 699)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.Standard, 101, 870)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakAll, 121, 399)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakWord, 121, 400)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.Standard, 100, 870.635F)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakAll, 100, 500)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakWord, 120, 490.35F)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.KeepAll, 81.89F, 870.635F)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.Standard, 101, 870.635F)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakAll, 100, 500)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakWord, 121, 490.35F)]
     [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.KeepAll, 61, 699)]
     public void MeasureTextWordBreak(string text, LayoutMode layoutMode, WordBreaking wordBreaking, float height, float width)
     {
-        // Testing using Windows only to ensure that actual glyphs are rendered
-        // against known physically tested values.
-        FontFamily arial = SystemFonts.Get("Arial");
-        FontFamily jhengHei = SystemFonts.Get("Microsoft JhengHei");
-
-        Font font = arial.CreateFont(20);
-        FontRectangle size = TextMeasurer.MeasureAdvance(
-            text,
-            new TextOptions(font)
+        // See https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
+        if (SystemFonts.TryGet("Arial", out FontFamily arial) &&
+            SystemFonts.TryGet("Microsoft JhengHei", out FontFamily jhengHei))
+        {
+            Font font = arial.CreateFont(20);
+            TextOptions options = new(font)
             {
-                WrappingLength = 400,
+                WrappingLength = 500,
                 LayoutMode = layoutMode,
                 WordBreaking = wordBreaking,
                 FallbackFontFamilies = new[] { jhengHei }
-            });
+            };
 
-        Assert.Equal(width, size.Width, 4F);
-        Assert.Equal(height, size.Height, 4F);
+            FontRectangle size = TextMeasurer.MeasureAdvance(
+                text,
+                options);
+
+            Assert.Equal(width, size.Width, 4F);
+            Assert.Equal(height, size.Height, 4F);
+
+            TextLayoutTestUtilities.TestLayout(text, options, properties: new { layoutMode, wordBreaking });
+        }
     }
-#endif
 
     [Theory]
     [InlineData("ab", 477, 1081, false)] // no kerning rules defined for lowercase ab so widths should stay the same
@@ -530,30 +549,21 @@ public class TextLayoutTests
     }
 
     [Theory]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 25, 7)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 50, 7)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 100, 7)]
-    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 200, 6)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 25, 6)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 50, 5)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 100, 4)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious", 200, 3)]
     public void CountLinesWrappingLength(string text, int wrappingLength, int usedLines)
     {
         Font font = CreateRenderingFont();
         RichTextOptions options = new(font)
         {
-            // Dpi = font.FontMetrics.ScaleFactor,
             WrappingLength = wrappingLength
         };
 
         int count = TextMeasurer.CountLines(text, options);
-
-        // Assert.Equal(usedLines, count);
-        FontRectangle advance = TextMeasurer.MeasureAdvance(text, options);
-        int width = (int)Math.Ceiling(advance.Width);
-        int height = (int)Math.Ceiling(advance.Height);
-
-        using Image<Rgba32> img = new(Math.Max(wrappingLength + 1, width), height, Color.White);
-        img.Mutate(x => x.DrawLine(Color.Red, 1, new(wrappingLength, 0), new(wrappingLength, height)));
-        img.Mutate(ctx => ctx.DrawText(options, text, Color.Black));
-        img.DebugSave(properties: new { wrappingLength, usedLines });
+        Assert.Equal(usedLines, count);
+        TextLayoutTestUtilities.TestLayout(text, options, properties: usedLines);
     }
 
     [Fact]
@@ -660,8 +670,8 @@ public class TextLayoutTests
     {
         const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.";
         const float wrappingLength = 400;
-        const float pointSize = 20;
-        Font font = CreateFont(text, pointSize);
+        const float pointSize = 12;
+        Font font = CreateRenderingFont(pointSize);
         TextOptions options = new(font)
         {
             TextDirection = direction,
@@ -672,9 +682,11 @@ public class TextLayoutTests
         // Collect the first line so we can compare it to the target wrapping length.
         IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
         IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
-        TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out ReadOnlySpan<GlyphBounds> justifiedCharacterBounds);
+        TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out ReadOnlySpan<GlyphBounds> advances);
 
-        Assert.Equal(wrappingLength, justifiedCharacterBounds.ToArray().Sum(x => x.Bounds.Width), 4F);
+        TextLayoutTestUtilities.TestLayout(text, options, properties: new { direction, options.TextJustification });
+
+        Assert.Equal(wrappingLength, advances.ToArray().Sum(x => x.Bounds.Width), 4F);
 
         // Now compare character widths.
         options.TextJustification = TextJustification.None;
@@ -688,11 +700,11 @@ public class TextLayoutTests
         {
             if (i == characterBounds.Length - 1)
             {
-                Assert.Equal(justifiedCharacterBounds[i].Bounds.Width, characterBounds[i].Bounds.Width);
+                Assert.Equal(advances[i].Bounds.Width, characterBounds[i].Bounds.Width);
             }
             else
             {
-                Assert.True(justifiedCharacterBounds[i].Bounds.Width > characterBounds[i].Bounds.Width);
+                Assert.True(advances[i].Bounds.Width > characterBounds[i].Bounds.Width);
             }
         }
     }
@@ -704,8 +716,8 @@ public class TextLayoutTests
     {
         const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.";
         const float wrappingLength = 400;
-        const float pointSize = 20;
-        Font font = CreateFont(text, pointSize);
+        const float pointSize = 12;
+        Font font = CreateRenderingFont(pointSize);
         TextOptions options = new(font)
         {
             TextDirection = direction,
@@ -717,6 +729,8 @@ public class TextLayoutTests
         IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
         IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
         TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out ReadOnlySpan<GlyphBounds> justifiedCharacterBounds);
+
+        TextLayoutTestUtilities.TestLayout(text, options, properties: new { direction, options.TextJustification });
 
         Assert.Equal(wrappingLength, justifiedCharacterBounds.ToArray().Sum(x => x.Bounds.Width), 4F);
 
@@ -748,8 +762,8 @@ public class TextLayoutTests
     {
         const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.";
         const float wrappingLength = 400;
-        const float pointSize = 20;
-        Font font = CreateFont(text, pointSize);
+        const float pointSize = 12;
+        Font font = CreateRenderingFont(pointSize);
         TextOptions options = new(font)
         {
             LayoutMode = LayoutMode.VerticalLeftRight,
@@ -762,6 +776,8 @@ public class TextLayoutTests
         IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
         IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
         TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out ReadOnlySpan<GlyphBounds> justifiedCharacterBounds);
+
+        TextLayoutTestUtilities.TestLayout(text, options, properties: new { direction, options.TextJustification });
 
         Assert.Equal(wrappingLength, justifiedCharacterBounds.ToArray().Sum(x => x.Bounds.Height), 4F);
 
@@ -793,8 +809,8 @@ public class TextLayoutTests
     {
         const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ornare maximus vehicula. Duis nisi velit, dictum id mauris vitae, lobortis pretium quam. Quisque sed nisi pulvinar, consequat justo id, feugiat leo. Cras eu elementum dui.";
         const float wrappingLength = 400;
-        const float pointSize = 20;
-        Font font = CreateFont(text, pointSize);
+        const float pointSize = 12;
+        Font font = CreateRenderingFont(pointSize);
         TextOptions options = new(font)
         {
             LayoutMode = LayoutMode.VerticalLeftRight,
@@ -807,6 +823,8 @@ public class TextLayoutTests
         IReadOnlyList<GlyphLayout> justifiedGlyphs = TextLayout.GenerateLayout(text.AsSpan(), options);
         IReadOnlyList<GlyphLayout> justifiedLine = CollectFirstLine(justifiedGlyphs);
         TextMeasurer.TryGetCharacterAdvances(justifiedLine, options.Dpi, out ReadOnlySpan<GlyphBounds> justifiedCharacterBounds);
+
+        TextLayoutTestUtilities.TestLayout(text, options, properties: new { direction, options.TextJustification });
 
         Assert.Equal(wrappingLength, justifiedCharacterBounds.ToArray().Sum(x => x.Bounds.Height), 4F);
 
@@ -1370,10 +1388,8 @@ public class TextLayoutTests
     private static readonly Font Arial = SystemFonts.CreateFont("Arial", 12);
 #endif
 
-    public static Font CreateRenderingFont()
-    {
-        return new FontCollection().Add(TestFonts.OpenSansFile).CreateFont(12);
-    }
+    public static Font CreateRenderingFont(float pointSize = 12)
+        => new FontCollection().Add(TestFonts.OpenSansFile).CreateFont(pointSize);
 
     public static Font CreateFont(string text)
     {

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -374,6 +374,39 @@ public class TextLayoutTests
 
 #if OS_WINDOWS
     [Theory]
+    [InlineData("Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.Standard, 100, 870)]
+    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakAll, 120, 399)]
+    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakWord, 120, 400)]
+    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.KeepAll, 60, 699)]
+    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.Standard, 101, 870)]
+    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakAll, 121, 399)]
+    //[InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.BreakWord, 121, 400)]
+    [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalBottomTop, WordBreaking.KeepAll, 61, 699)]
+    public void MeasureTextWordBreakMatchesMDN(string text, LayoutMode layoutMode, WordBreaking wordBreaking, float height, float width)
+    {
+        // Testing using Windows only to ensure that actual glyphs are rendered
+        // against known physically tested values.
+        FontFamily arial = SystemFonts.Get("Arial");
+        FontFamily jhengHei = SystemFonts.Get("Microsoft JhengHei");
+
+        Font font = arial.CreateFont(16);
+        FontRectangle size = TextMeasurer.MeasureAdvance(
+            text,
+            new TextOptions(font)
+            {
+                Dpi = 96,
+                WrappingLength = 238,
+                LayoutMode = layoutMode,
+                WordBreaking = wordBreaking,
+                FallbackFontFamilies = new[] { jhengHei }
+            });
+
+        Assert.Equal(width, size.Width, 4F);
+        Assert.Equal(height, size.Height, 4F);
+    }
+
+
+    [Theory]
     [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.Standard, 100, 870)]
     [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakAll, 120, 399)]
     [InlineData("This is a long and Honorificabilitudinitatibus califragilisticexpialidocious Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉", LayoutMode.HorizontalTopBottom, WordBreaking.BreakWord, 120, 400)]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
A complete rewrite of the line breaker to fix a series of issues including #434 I've not benchmarked this but in addition to fixing bugs the code is now doing far less work per code point so should be faster. 

I've also added testing that will generate output using ImageSharp.Drawing which allows us to better visualize the layout. Adding this helped identify multiple issues. The generation code is togglable via a compiler condition introduced via the `csproj` file. This allows us to turn them off should we introduce breaking changes. 

All output has been sense checked and compared to browser output to ensure correctness.

<!-- Thanks for contributing to SixLabors.Fonts! -->
