### PR TITLE
Fix #448 and #450

### DIFF
--- a/src/SixLabors.Fonts/Unicode/LineBreakEnumerator.cs
+++ b/src/SixLabors.Fonts/Unicode/LineBreakEnumerator.cs
@@ -347,11 +347,52 @@ internal ref struct LineBreakEnumerator
                 }
 
                 // LB25
-                if (this.lb25ex && (this.nextClass == LineBreakClass.PR || this.nextClass == LineBreakClass.NU))
+                if (this.lb25ex)
                 {
-                    shouldBreak = true;
-                    this.lb25ex = false;
-                    break;
+                    switch (lastClass)
+                    {
+                        case LineBreakClass.PO:
+                        case LineBreakClass.PR:
+                            if (this.currentClass == LineBreakClass.NU)
+                            {
+                                this.lb25ex = false;
+                                return false;
+                            }
+
+                            LineBreakClass ahead = this.PeekNextCharClass();
+                            if (ahead == LineBreakClass.NU && this.nextClass is LineBreakClass.OP or LineBreakClass.HY)
+                            {
+                                this.lb25ex = false;
+                                return false;
+                            }
+
+                            break;
+                        case LineBreakClass.HY:
+                        case LineBreakClass.OP:
+                            if (this.currentClass == LineBreakClass.NU)
+                            {
+                                this.lb25ex = false;
+                                return false;
+                            }
+
+                            break;
+
+                        case LineBreakClass.NU:
+                            if (this.currentClass is LineBreakClass.PO or LineBreakClass.PR or LineBreakClass.NU)
+                            {
+                                this.lb25ex = false;
+                                return false;
+                            }
+
+                            break;
+                    }
+
+                    if (this.nextClass is LineBreakClass.PR or LineBreakClass.NU)
+                    {
+                        shouldBreak = true;
+                        this.lb25ex = false;
+                        break;
+                    }
                 }
 
                 // LB24

--- a/tests/Images/ReferenceOutput/Issue_448__WrappingLength_150_.png
+++ b/tests/Images/ReferenceOutput/Issue_448__WrappingLength_150_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5310d037cd18198ddf0d70c97754d45f5917236859b28b13a306e0ccbeb20046
+size 2578

--- a/tests/Images/ReferenceOutput/Issue_450__WrappingLength_960_.png
+++ b/tests/Images/ReferenceOutput/Issue_450__WrappingLength_960_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c5b081acda3b2754a29ffd499c2571e285b1efe01bf5e6b793c8ec8c00848e1
+size 19688

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_448.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_448.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.Fonts.Tests.Issues;
+public class Issues_448
+{
+    [Fact]
+    public void Issue_448()
+    {
+        if (SystemFonts.TryGet("Arial", out FontFamily family))
+        {
+            Font font = family.CreateFont(20);
+
+            TextLayoutTestUtilities.TestLayout(
+                "aaaaa bbbbb/ccccc ddddd",
+                new TextOptions(font)
+                {
+                    WrappingLength = 150
+                });
+        }
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_450.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_450.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Numerics;
+
+namespace SixLabors.Fonts.Tests.Issues;
+public class Issues_450
+{
+    [Fact]
+    public void Issue_450()
+    {
+        if (SystemFonts.TryGet("Arial", out FontFamily family))
+        {
+            Font font = family.CreateFont(92);
+
+            TextLayoutTestUtilities.TestLayout(
+                "Super, Smash Bros (1999)",
+                new TextOptions(font)
+                {
+                    Origin = new Vector2(50, 20),
+                    WrappingLength = 960,
+                });
+        }
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/Unicode/LineBreakEnumeratorTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Unicode/LineBreakEnumeratorTests.cs
@@ -69,6 +69,7 @@ public class LineBreakEnumeratorTests
 
         List<LineBreak> breaks2 = new();
         foreach (LineBreak lineBreak in new LineBreakEnumerator(text2.AsSpan()))
+        {
             breaks2.Add(lineBreak);
         }
 

--- a/tests/SixLabors.Fonts.Tests/Unicode/LineBreakEnumeratorTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Unicode/LineBreakEnumeratorTests.cs
@@ -47,6 +47,42 @@ public class LineBreakEnumeratorTests
     }
 
     [Fact]
+    public void NumericTests()
+    {
+        const string text1 = "Super Smash Bros (1999)";
+        const string text2 = "Super, Smash Bros (1999)";
+        List<LineBreak> breaks1 = new();
+
+        foreach (LineBreak lineBreak in new LineBreakEnumerator(text1.AsSpan()))
+        {
+            breaks1.Add(lineBreak);
+        }
+
+        Assert.Equal(5, breaks1[0].PositionMeasure);
+        Assert.Equal(6, breaks1[0].PositionWrap);
+        Assert.Equal(11, breaks1[1].PositionMeasure);
+        Assert.Equal(12, breaks1[1].PositionWrap);
+        Assert.Equal(16, breaks1[2].PositionMeasure);
+        Assert.Equal(17, breaks1[2].PositionWrap);
+        Assert.Equal(23, breaks1[3].PositionMeasure);
+        Assert.Equal(23, breaks1[3].PositionWrap);
+
+        List<LineBreak> breaks2 = new();
+        foreach (LineBreak lineBreak in new LineBreakEnumerator(text2.AsSpan()))
+            breaks2.Add(lineBreak);
+        }
+
+        Assert.Equal(6, breaks2[0].PositionMeasure);
+        Assert.Equal(7, breaks2[0].PositionWrap);
+        Assert.Equal(12, breaks2[1].PositionMeasure);
+        Assert.Equal(13, breaks2[1].PositionWrap);
+        Assert.Equal(17, breaks2[2].PositionMeasure);
+        Assert.Equal(18, breaks2[2].PositionWrap);
+        Assert.Equal(24, breaks2[3].PositionMeasure);
+        Assert.Equal(24, breaks2[3].PositionWrap);
+    }
+
+    [Fact]
     public void ForwardTextWithOuterWhitespace()
     {
         string text = " Apples Pears Bananas   ";


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Fix #448 and #450

<!-- Thanks for contributing to SixLabors.Fonts! -->
