### PR TITLE
Allow null AnchorTable

### DIFF
--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/AdvancedTypographicUtils.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/AdvancedTypographicUtils.cs
@@ -249,11 +249,19 @@ internal static class AdvancedTypographicUtils
         FontMetrics fontMetrics,
         GlyphPositioningCollection collection,
         int index,
-        AnchorTable baseAnchor,
+        AnchorTable? baseAnchor,
         MarkRecord markRecord,
         int baseGlyphIndex,
         Tag feature)
     {
+        // baseAnchor may be null because OpenType MarkToBase allows NULL anchor offsets
+        // in BaseArray/BaseRecord. A NULL offset means "this base glyph has no anchor
+        // for this mark class", and the lookup must be ignored for this mark–base pair.
+        if (baseAnchor is null)
+        {
+            return;
+        }
+
         GlyphShapingData baseData = collection[baseGlyphIndex];
         AnchorXY baseXY = baseAnchor.GetAnchor(fontMetrics, baseData, collection);
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType4SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/LookupType4SubTable.cs
@@ -71,10 +71,10 @@ internal static class LookupType4SubTable
             ushort markArrayOffset = reader.ReadOffset16();
             ushort baseArrayOffset = reader.ReadOffset16();
 
-            var markCoverage = CoverageTable.Load(reader, offset + markCoverageOffset);
-            var baseCoverage = CoverageTable.Load(reader, offset + baseCoverageOffset);
-            var markArrayTable = new MarkArrayTable(reader, offset + markArrayOffset);
-            var baseArrayTable = new BaseArrayTable(reader, offset + baseArrayOffset, markClassCount);
+            CoverageTable markCoverage = CoverageTable.Load(reader, offset + markCoverageOffset);
+            CoverageTable baseCoverage = CoverageTable.Load(reader, offset + baseCoverageOffset);
+            MarkArrayTable markArrayTable = new(reader, offset + markArrayOffset);
+            BaseArrayTable baseArrayTable = new(reader, offset + baseArrayOffset, markClassCount);
 
             return new LookupType4Format1SubTable(markCoverage, baseCoverage, markArrayTable, baseArrayTable, lookupFlags);
         }
@@ -106,7 +106,7 @@ internal static class LookupType4SubTable
             while (--baseGlyphIndex >= 0)
             {
                 GlyphShapingData data = collection[baseGlyphIndex];
-                if (!AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, data.GlyphId, data) && !(data.LigatureComponent > 0))
+                if (!AdvancedTypographicUtils.IsMarkGlyph(fontMetrics, data.GlyphId, data) && data.LigatureComponent <= 0)
                 {
                     break;
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #479 
This pull request improves the handling of OpenType MarkToBase positioning in the advanced typographic layout code, focusing on safer anchor processing and minor code style updates. The main changes ensure that the code correctly handles the case where a base glyph does not provide an anchor for a mark class, in line with the OpenType specification.

### Robust handling of null anchors

* Updated `ApplyAnchor` in `AdvancedTypographicUtils.cs` to accept a nullable `AnchorTable` and to safely return early if the anchor is null, preventing errors when a base glyph lacks an anchor for a mark class. This matches OpenType's allowance for null anchor offsets.

### Code style and clarity improvements

* Refactored variable declarations in `LookupType4Format1SubTable.Load` to use explicit types and object initializers for improved readability and consistency.
* Simplified the ligature component check in `TryUpdatePosition` to use a more readable and idiomatic comparison (`data.LigatureComponent <= 0` instead of negating a greater-than check).

<!-- Thanks for contributing to SixLabors.Fonts! -->
