### PR TITLE
Use correct font metrics for fallback glyph substitutions

### DIFF
--- a/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
+++ b/src/SixLabors.Fonts/GlyphSubstitutionCollection.cs
@@ -17,7 +17,7 @@ internal sealed class GlyphSubstitutionCollection : IGlyphShapingCollection
     /// <summary>
     /// Contains a map the index of a map within the collection, non-sequential codepoint offsets, and their glyph ids.
     /// </summary>
-    private readonly List<OffsetGlyphDataPair> glyphs = new();
+    private readonly List<OffsetGlyphDataPair> glyphs = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GlyphSubstitutionCollection"/> class.

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPosTable.cs
@@ -155,7 +155,7 @@ internal class GPosTable : Table
             }
 
             Tag unicodeScriptTag = this.GetUnicodeScriptTag(current);
-            BaseShaper shaper = ShaperFactory.Create(current, unicodeScriptTag, collection.TextOptions);
+            BaseShaper shaper = ShaperFactory.Create(current, unicodeScriptTag, fontMetrics, collection.TextOptions);
 
             if (shaper.MarkZeroingMode == MarkZeroingMode.PreGPos)
             {

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSubTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GSubTable.cs
@@ -138,7 +138,7 @@ internal class GSubTable : Table
             }
 
             Tag unicodeScriptTag = this.GetUnicodeScriptTag(current);
-            BaseShaper shaper = ShaperFactory.Create(current, unicodeScriptTag, collection.TextOptions);
+            BaseShaper shaper = ShaperFactory.Create(current, unicodeScriptTag, fontMetrics, collection.TextOptions);
 
             // Plan substitution features for each glyph.
             // Shapers can adjust the count during initialization and feature processing so we must capture

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ShaperFactory.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ShaperFactory.cs
@@ -8,13 +8,18 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic.Shapers;
 internal static class ShaperFactory
 {
     /// <summary>
-    /// Creates a Shaper based on the given script language.
+    /// Creates a shaper based on the given script language.
     /// </summary>
     /// <param name="script">The script language.</param>
     /// <param name="unicodeScriptTag">The unicode script tag found in the font matching the script.</param>
-    /// <param name="textOptions">The text options.</param>
+    /// <param name="fontMetrics">The current font metrics.</param>
+    /// <param name="textOptions">The global text options.</param>
     /// <returns>A shaper for the given script.</returns>
-    public static BaseShaper Create(ScriptClass script, Tag unicodeScriptTag, TextOptions textOptions)
+    public static BaseShaper Create(
+        ScriptClass script,
+        Tag unicodeScriptTag,
+        FontMetrics fontMetrics,
+        TextOptions textOptions)
         => script switch
         {
             // Arabic
@@ -28,7 +33,7 @@ internal static class ShaperFactory
             or ScriptClass.PsalterPahlavi => new ArabicShaper(script, textOptions),
 
             // Hangul
-            ScriptClass.Hangul => new HangulShaper(script, textOptions),
+            ScriptClass.Hangul => new HangulShaper(script, textOptions, fontMetrics),
 
             // Indic
             ScriptClass.Bengali
@@ -40,7 +45,7 @@ internal static class ShaperFactory
             or ScriptClass.Oriya
             or ScriptClass.Tamil
             or ScriptClass.Telugu
-            or ScriptClass.Khmer => new IndicShaper(script, unicodeScriptTag, textOptions),
+            or ScriptClass.Khmer => new IndicShaper(script, unicodeScriptTag, textOptions, fontMetrics),
 
             // Universal
             ScriptClass.Balinese
@@ -82,7 +87,7 @@ internal static class ShaperFactory
             or ScriptClass.Tibetan
             or ScriptClass.Tifinagh
             or ScriptClass.Tirhuta
-            => new UniversalShaper(script, textOptions),
+            => new UniversalShaper(script, textOptions, fontMetrics),
             _ => new DefaultShaper(script, textOptions),
         };
 }

--- a/tests/Images/ReferenceOutput/Test_Issue_483-.png
+++ b/tests/Images/ReferenceOutput/Test_Issue_483-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0300a8c5b582a1d2cd914d1415bf80604058ddfa3826166171404929e3e7e343
+size 8124

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_483.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_483.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.Fonts.Tests.Issues;
+
+public class Issues_483
+{
+    [Fact]
+    public void Test_Issue_483()
+    {
+        const string text = "Kannada: ವೇಗವುಳ್ಳ ಕಂದು ನರಿ ಸೋಮಾರಿ ನಾಯಿಯ ಮೇಲೆ ಹಾರುತ್ತದೆ";
+
+        FontCollection fontCollection = new();
+        string noto = fontCollection.Add(TestFonts.NotoSansRegular).Name;
+        string kannada = fontCollection.Add(TestFonts.NotoSansKannadaRegular).Name;
+
+        FontFamily mainFontFamily = fontCollection.Get(noto);
+        Font mainFont = mainFontFamily.CreateFont(30, FontStyle.Regular);
+
+        TextOptions options = new(mainFont)
+        {
+            FallbackFontFamilies =
+            [
+                fontCollection.Get(kannada),
+            ],
+        };
+
+        // There are too many metrics to validate here so we just ensure no exceptions are thrown
+        // and the rendering looks correct by inspecting the snapshot.
+        TextLayoutTestUtilities.TestLayout(
+            text,
+            options,
+            includeGeometry: false);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #483 

This PR fixes a bug where fallback font glyph substitutions were incorrectly using font metrics from the main font instead of the fallback font. This affected complex scripts that require advanced shaping (like Kannada, Indic, Hangul) when rendered with fallback fonts.

- Threaded `FontMetrics` parameter through shaper factory and into shapers that perform font-specific lookups
- Converted static methods to instance methods in shapers to access correct font metrics
- Optimized by hoisting font metric lookups outside loops where possible


<!-- Thanks for contributing to SixLabors.Fonts! -->
