### PR TITLE
Copy DecorationPositioningMode value when creating new text options from another one

### DIFF
--- a/src/SixLabors.Fonts/TextOptions.cs
+++ b/src/SixLabors.Fonts/TextOptions.cs
@@ -47,6 +47,7 @@ public class TextOptions
         this.ColorFontSupport = options.ColorFontSupport;
         this.FeatureTags = new List<Tag>(options.FeatureTags);
         this.TextRuns = new List<TextRun>(options.TextRuns);
+        this.DecorationPositioningMode = options.DecorationPositioningMode;
     }
 
     /// <summary>

--- a/tests/SixLabors.Fonts.Tests/TextOptionsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextOptionsTests.cs
@@ -310,8 +310,9 @@ public class TextOptionsTests
             TabWidth = 3F,
             LineSpacing = -1F,
             VerticalAlignment = VerticalAlignment.Bottom,
+            DecorationPositioningMode = DecorationPositioningMode.GlyphFont,
             WrappingLength = 42F,
-            FeatureTags = new List<Tag> { FeatureTags.OldstyleFigures }
+            FeatureTags = new List<Tag> { FeatureTags.OldstyleFigures },
         };
 
         TextOptions actual = new(expected);
@@ -323,6 +324,7 @@ public class TextOptionsTests
         Assert.Equal(expected.TabWidth, actual.TabWidth);
         Assert.Equal(expected.VerticalAlignment, actual.VerticalAlignment);
         Assert.Equal(expected.WrappingLength, actual.WrappingLength);
+        Assert.Equal(expected.DecorationPositioningMode, actual.DecorationPositioningMode);
         Assert.Equal(expected.FeatureTags, actual.FeatureTags);
     }
 
@@ -339,6 +341,7 @@ public class TextOptionsTests
             LineSpacing = 2F,
             VerticalAlignment = VerticalAlignment.Bottom,
             TextJustification = TextJustification.InterCharacter,
+            DecorationPositioningMode = DecorationPositioningMode.GlyphFont,
             WrappingLength = 42F
         };
 
@@ -349,6 +352,7 @@ public class TextOptionsTests
         Assert.NotEqual(expected.TabWidth, actual.TabWidth);
         Assert.NotEqual(expected.VerticalAlignment, actual.VerticalAlignment);
         Assert.NotEqual(expected.WrappingLength, actual.WrappingLength);
+        Assert.NotEqual(expected.DecorationPositioningMode, actual.DecorationPositioningMode);
         Assert.NotEqual(expected.TextJustification, actual.TextJustification);
     }
 
@@ -363,6 +367,7 @@ public class TextOptionsTests
         Assert.Equal(TextJustification.None, options.TextJustification);
         Assert.Equal(TextDirection.Auto, options.TextDirection);
         Assert.Equal(LayoutMode.HorizontalTopBottom, options.LayoutMode);
+        Assert.Equal(DecorationPositioningMode.PrimaryFont, options.DecorationPositioningMode);
         Assert.Equal(1, options.LineSpacing);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Add a missing value not copied when using `new TextOptions(otherOptions)`