### PR TITLE
Rename FeatureTags to match standard

### DIFF
--- a/src/SixLabors.Fonts/GlyphPositioningCollection.cs
+++ b/src/SixLabors.Fonts/GlyphPositioningCollection.cs
@@ -118,9 +118,9 @@ internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
         isVerticalSubstitution = false;
         isDecomposed = false;
 
-        Tag vert = FeatureTags.VerticalAlternates;
-        Tag vrt2 = FeatureTags.VerticalAlternatesAndRotation;
-        Tag vrtr = FeatureTags.VerticalAlternatesForRotation;
+        Tag vert = KnownFeatureTags.VerticalAlternates;
+        Tag vrt2 = KnownFeatureTags.VerticalAlternatesAndRotation;
+        Tag vrtr = KnownFeatureTags.VerticalAlternatesForRotation;
 
         for (int i = startIndex; i < this.glyphs.Count; i++)
         {
@@ -171,9 +171,9 @@ internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
         bool hasFallBacks = false;
         List<int> orphans = [];
 
-        Tag vert = FeatureTags.VerticalAlternates;
-        Tag vrt2 = FeatureTags.VerticalAlternatesAndRotation;
-        Tag vrtr = FeatureTags.VerticalAlternatesForRotation;
+        Tag vert = KnownFeatureTags.VerticalAlternates;
+        Tag vrt2 = KnownFeatureTags.VerticalAlternatesAndRotation;
+        Tag vrtr = KnownFeatureTags.VerticalAlternatesForRotation;
 
         for (int i = 0; i < this.glyphs.Count; i++)
         {
@@ -268,9 +268,9 @@ internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
         LayoutMode layoutMode = this.TextOptions.LayoutMode;
         ColorFontSupport colorFontSupport = this.TextOptions.ColorFontSupport;
 
-        Tag vert = FeatureTags.VerticalAlternates;
-        Tag vrt2 = FeatureTags.VerticalAlternatesAndRotation;
-        Tag vrtr = FeatureTags.VerticalAlternatesForRotation;
+        Tag vert = KnownFeatureTags.VerticalAlternates;
+        Tag vrt2 = KnownFeatureTags.VerticalAlternatesAndRotation;
+        Tag vrtr = KnownFeatureTags.VerticalAlternatesForRotation;
 
         for (int i = 0; i < collection.Count; i++)
         {
@@ -358,9 +358,9 @@ internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
     public void Advance(FontMetrics fontMetrics, int index, ushort glyphId, short dx, short dy)
     {
         LayoutMode layoutMode = this.TextOptions.LayoutMode;
-        Tag vert = FeatureTags.VerticalAlternates;
-        Tag vrt2 = FeatureTags.VerticalAlternatesAndRotation;
-        Tag vrtr = FeatureTags.VerticalAlternatesForRotation;
+        Tag vert = KnownFeatureTags.VerticalAlternates;
+        Tag vrt2 = KnownFeatureTags.VerticalAlternatesAndRotation;
+        Tag vrtr = KnownFeatureTags.VerticalAlternatesForRotation;
 
         GlyphPositioningData glyph = this.glyphs[index];
         GlyphMetrics m = glyph.Metrics;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/KnownFeatureTags.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/KnownFeatureTags.cs
@@ -7,7 +7,7 @@ namespace SixLabors.Fonts.Tables.AdvancedTypographic;
 /// Provides enumeration for the different font features.
 /// <see href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"/>
 /// </summary>
-public enum FeatureTags : uint
+public enum KnownFeatureTags : uint
 {
     /// <summary>
     /// Access All Alternates. Shortcode: aalt.

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
@@ -309,7 +309,7 @@ internal sealed class HangulShaper : DefaultShaper
             ii[1] = vjmo;
             ii[0] = ljmo;
 
-            collection.Replace(index, ii, FeatureTags.GlyphCompositionDecomposition);
+            collection.Replace(index, ii, KnownFeatureTags.GlyphCompositionDecomposition);
             collection.EnableShapingFeature(index, LjmoTag);
             collection.EnableShapingFeature(index + 1, VjmoTag);
             return index + 1;
@@ -320,7 +320,7 @@ internal sealed class HangulShaper : DefaultShaper
         iii[1] = vjmo;
         iii[0] = ljmo;
 
-        collection.Replace(index, iii, FeatureTags.GlyphCompositionDecomposition);
+        collection.Replace(index, iii, KnownFeatureTags.GlyphCompositionDecomposition);
         collection.EnableShapingFeature(index, LjmoTag);
         collection.EnableShapingFeature(index + 1, VjmoTag);
         collection.EnableShapingFeature(index + 2, TjmoTag);
@@ -393,7 +393,7 @@ internal sealed class HangulShaper : DefaultShaper
             {
                 int del = prevType == V ? 3 : 2;
                 int idx = index - del + 1;
-                collection.Replace(idx, del - 1, id, FeatureTags.GlyphCompositionDecomposition);
+                collection.Replace(idx, del - 1, id, KnownFeatureTags.GlyphCompositionDecomposition);
                 collection[idx].CodePoint = s;
                 return idx;
             }
@@ -496,7 +496,7 @@ internal sealed class HangulShaper : DefaultShaper
                 glyphs[0] = id;
             }
 
-            collection.Replace(index, glyphs, FeatureTags.GlyphCompositionDecomposition);
+            collection.Replace(index, glyphs, KnownFeatureTags.GlyphCompositionDecomposition);
             return index + 1;
         }
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HebrewShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HebrewShaper.cs
@@ -147,7 +147,7 @@ internal class HebrewShaper : DefaultShaper
             if (composed != 0 && fontMetrics.TryGetGlyphId(new CodePoint(composed), out ushort composedGlyphId))
             {
                 // Replace the two glyphs with the composed form.
-                collection.Replace(i - 1, 2, composedGlyphId, FeatureTags.GlyphCompositionDecomposition);
+                collection.Replace(i - 1, 2, composedGlyphId, KnownFeatureTags.GlyphCompositionDecomposition);
                 end--;
                 i--;
             }

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/IndicShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/IndicShaper.cs
@@ -193,7 +193,7 @@ internal sealed class IndicShaper : DefaultShaper
 
                 if (shouldDecompose)
                 {
-                    substitutionCollection.Replace(i, ids, FeatureTags.GlyphCompositionDecomposition);
+                    substitutionCollection.Replace(i, ids, KnownFeatureTags.GlyphCompositionDecomposition);
                     for (int j = 0; j < decompositions.Length; j++)
                     {
                         substitutionCollection[i + j].CodePoint = new(decompositions[j]);
@@ -382,7 +382,7 @@ internal sealed class IndicShaper : DefaultShaper
                         glyphs[0] = circleId;
                         glyphs[1] = current.GlyphId;
 
-                        substitutionCollection.Replace(i, glyphs, FeatureTags.GlyphCompositionDecomposition);
+                        substitutionCollection.Replace(i, glyphs, KnownFeatureTags.GlyphCompositionDecomposition);
 
                         // The dotted circle is now at position i (inherits original shaping info).
                         // Update it to be a dotted circle base.

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/MyanmarShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/MyanmarShaper.cs
@@ -220,7 +220,7 @@ internal sealed class MyanmarShaper : DefaultShaper
                         glyphs[0] = current.GlyphId;
                         glyphs[1] = circleId;
 
-                        substitutionCollection.Replace(i, glyphs, FeatureTags.GlyphCompositionDecomposition);
+                        substitutionCollection.Replace(i, glyphs, KnownFeatureTags.GlyphCompositionDecomposition);
 
                         // Update shaping info for newly inserted data.
                         GlyphShapingData dotted = substitutionCollection[i + 1];

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ThaiShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/ThaiShaper.cs
@@ -241,7 +241,7 @@ internal class ThaiShaper : DefaultShaper
 
             // Decompose SARA AM into [NIKHAHIT, SARA AA].
             // Replace puts NIKHAHIT at index i, SARA AA at index i+1.
-            collection.Replace(i, [nikhahitId, saraAAId], FeatureTags.GlyphCompositionDecomposition);
+            collection.Replace(i, [nikhahitId, saraAAId], KnownFeatureTags.GlyphCompositionDecomposition);
             collection[i].CodePoint = new CodePoint(nikhahitCodepoint);
             collection[i + 1].CodePoint = new CodePoint(saraAACodepoint);
             end++;

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/UniversalShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/UniversalShaper.cs
@@ -163,7 +163,7 @@ internal sealed class UniversalShaper : DefaultShaper
 
                 if (shouldDecompose)
                 {
-                    substitutionCollection.Replace(i, ids, FeatureTags.GlyphCompositionDecomposition);
+                    substitutionCollection.Replace(i, ids, KnownFeatureTags.GlyphCompositionDecomposition);
                     for (int j = 0; j < decompositions.Length; j++)
                     {
                         substitutionCollection[i + j].CodePoint = new(decompositions[j]);
@@ -353,7 +353,7 @@ internal sealed class UniversalShaper : DefaultShaper
                         glyphs[0] = current.GlyphId;
                         glyphs[1] = circleId;
 
-                        substitutionCollection.Replace(i, glyphs, FeatureTags.GlyphCompositionDecomposition);
+                        substitutionCollection.Replace(i, glyphs, KnownFeatureTags.GlyphCompositionDecomposition);
 
                         // Update shaping info for newly inserted data.
                         GlyphShapingData dotted = substitutionCollection[i + 1];

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Tag.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Tag.cs
@@ -30,10 +30,10 @@ public readonly struct Tag : IEquatable<Tag>
     public static implicit operator Tag(uint value) => new(value);
 
     /// <summary>
-    /// Implicitly converts a <see cref="FeatureTags"/> to a <see cref="Tag"/>.
+    /// Implicitly converts a <see cref="KnownFeatureTags"/> to a <see cref="Tag"/>.
     /// </summary>
     /// <param name="value">The feature tag enum value.</param>
-    public static implicit operator Tag(FeatureTags value) => new((uint)value);
+    public static implicit operator Tag(KnownFeatureTags value) => new((uint)value);
 
     /// <summary>
     /// Determines whether two <see cref="Tag"/> instances are equal.

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -1061,7 +1061,7 @@ internal static class TextLayout
 
             if (fontMetrics.TryGetGlyphId(mirror, out ushort glyphId))
             {
-                collection.Replace(i, glyphId, FeatureTags.RightToLeftMirroredForms);
+                collection.Replace(i, glyphId, KnownFeatureTags.RightToLeftMirroredForms);
             }
         }
 
@@ -1087,7 +1087,7 @@ internal static class TextLayout
 
             if (fontMetrics.TryGetGlyphId(mirror, out ushort glyphId))
             {
-                collection.Replace(i, glyphId, FeatureTags.VerticalAlternates);
+                collection.Replace(i, glyphId, KnownFeatureTags.VerticalAlternates);
             }
         }
     }

--- a/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/AdvancedTypographic/Gsub/GSubTableTests.cs
@@ -81,7 +81,7 @@ public partial class GSubTableTests
         int[] expectedGlyphIndices = [580, 404, 453];
 
         // act
-        TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new Tag[] { FeatureTags.Numerators, FeatureTags.Denominators } });
+        TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new Tag[] { KnownFeatureTags.Numerators, KnownFeatureTags.Denominators } });
 
         // assert
         Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
@@ -101,7 +101,7 @@ public partial class GSubTableTests
         int[] expectedGlyphIndices = [580, 404, 453];
 
         // act
-        TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new Tag[] { FeatureTags.Fractions } });
+        TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font) { FeatureTags = new Tag[] { KnownFeatureTags.Fractions } });
 
         // assert
         Assert.Equal(expectedGlyphIndices.Length, renderer.GlyphKeys.Count);
@@ -357,7 +357,7 @@ public partial class GSubTableTests
         // act
         TextRenderer.RenderTextTo(renderer, testStr, new TextOptions(font)
         {
-            FeatureTags = new List<Tag> { FeatureTags.OldstyleFigures }
+            FeatureTags = new List<Tag> { KnownFeatureTags.OldstyleFigures }
         });
 
         // assert

--- a/tests/SixLabors.Fonts.Tests/TextOptionsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextOptionsTests.cs
@@ -313,7 +313,7 @@ public class TextOptionsTests
             DecorationPositioningMode = DecorationPositioningMode.GlyphFont,
             WrappingLength = 42F,
             Tracking = 66F,
-            FeatureTags = new List<Tag> { FeatureTags.OldstyleFigures }
+            FeatureTags = new List<Tag> { KnownFeatureTags.OldstyleFigures }
         };
 
         TextOptions actual = new(expected);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request refactors the handling of OpenType feature tags throughout the codebase. The main change is renaming the `FeatureTags` enum to `KnownFeatureTags` and updating all references to use the new name. This improves clarity and consistency, as well as future-proofs the code for distinguishing between known and custom feature tags. The changes affect both the main library and related tests.

<!-- Thanks for contributing to SixLabors.Fonts! -->
