### PR TITLE
Separate glyph/paint transforms; SVG caching & tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
       - release/*
-    types: [ labeled, opened, synchronize, reopened ]
+    types: [ opened, synchronize, reopened ]
 jobs:
   # Prime a single LFS cache and expose the exact key for the matrix
   WarmLFS:

--- a/src/SixLabors.Fonts/StreamFontMetrics.Cff.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.Cff.cs
@@ -163,7 +163,7 @@ internal partial class StreamFontMetrics
                 this,
                 glyphId,
                 codePoint,
-                new SvgGlyphSource(svg),
+                this.GetOrCreateSvgGlyphSource(svg),
                 bounds,
                 advanceWidth,
                 advancedHeight,

--- a/src/SixLabors.Fonts/StreamFontMetrics.TrueType.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.TrueType.cs
@@ -281,7 +281,7 @@ internal partial class StreamFontMetrics
                 this,
                 glyphId,
                 codePoint,
-                new SvgGlyphSource(svg),
+                this.GetOrCreateSvgGlyphSource(svg),
                 bounds,
                 advanceWidth,
                 advancedHeight,

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -12,6 +12,7 @@ using SixLabors.Fonts.Tables.Cff;
 using SixLabors.Fonts.Tables.General;
 using SixLabors.Fonts.Tables.General.Kern;
 using SixLabors.Fonts.Tables.General.Post;
+using SixLabors.Fonts.Tables.General.Svg;
 using SixLabors.Fonts.Tables.TrueType;
 using SixLabors.Fonts.Tables.TrueType.Hinting;
 using SixLabors.Fonts.Unicode;
@@ -34,6 +35,7 @@ internal partial class StreamFontMetrics : FontMetrics
     private readonly ConcurrentDictionary<(int CodePoint, ushort Id, TextAttributes Attributes, ColorFontSupport ColorSupport, bool IsVerticalLayout), GlyphMetrics> glyphCache;
     private readonly ConcurrentDictionary<(int CodePoint, int NextCodePoint), (bool Success, ushort GlyphId, bool SkipNextCodePoint)> glyphIdCache;
     private readonly ConcurrentDictionary<ushort, (bool Success, CodePoint CodePoint)> codePointCache;
+    private SvgGlyphSource? svgGlyphSource;
     private readonly FontDescription description;
     private readonly HorizontalMetrics horizontalMetrics;
     private readonly VerticalMetrics verticalMetrics;
@@ -104,7 +106,8 @@ internal partial class StreamFontMetrics : FontMetrics
         TrueTypeFontTables tables,
         GlyphVariationProcessor processor,
         ConcurrentDictionary<(int CodePoint, int NextCodePoint), (bool Success, ushort GlyphId, bool SkipNextCodePoint)> sharedGlyphIdCache,
-        ConcurrentDictionary<ushort, (bool Success, CodePoint CodePoint)> sharedCodePointCache)
+        ConcurrentDictionary<ushort, (bool Success, CodePoint CodePoint)> sharedCodePointCache,
+        SvgGlyphSource? svgGlyphSource)
     {
         this.trueTypeFontTables = tables;
         this.outlineType = OutlineType.TrueType;
@@ -113,6 +116,7 @@ internal partial class StreamFontMetrics : FontMetrics
         this.glyphIdCache = sharedGlyphIdCache;
         this.codePointCache = sharedCodePointCache;
         this.glyphCache = new();
+        this.svgGlyphSource = svgGlyphSource;
 
         (HorizontalMetrics HorizontalMetrics, VerticalMetrics VerticalMetrics) metrics = this.Initialize(tables);
         this.horizontalMetrics = metrics.HorizontalMetrics;
@@ -130,7 +134,8 @@ internal partial class StreamFontMetrics : FontMetrics
         CompactFontTables tables,
         GlyphVariationProcessor processor,
         ConcurrentDictionary<(int CodePoint, int NextCodePoint), (bool Success, ushort GlyphId, bool SkipNextCodePoint)> sharedGlyphIdCache,
-        ConcurrentDictionary<ushort, (bool Success, CodePoint CodePoint)> sharedCodePointCache)
+        ConcurrentDictionary<ushort, (bool Success, CodePoint CodePoint)> sharedCodePointCache,
+        SvgGlyphSource? svgGlyphSource)
     {
         this.compactFontTables = tables;
         this.outlineType = OutlineType.CFF;
@@ -139,6 +144,7 @@ internal partial class StreamFontMetrics : FontMetrics
         this.glyphIdCache = sharedGlyphIdCache;
         this.codePointCache = sharedCodePointCache;
         this.glyphCache = new();
+        this.svgGlyphSource = svgGlyphSource;
 
         (HorizontalMetrics HorizontalMetrics, VerticalMetrics VerticalMetrics) metrics = this.Initialize(tables);
         this.horizontalMetrics = metrics.HorizontalMetrics;
@@ -519,7 +525,7 @@ internal partial class StreamFontMetrics : FontMetrics
                 tables.Cvar,
                 userCoordinates);
 
-            return new StreamFontMetrics(tables, processor, this.glyphIdCache, this.codePointCache);
+            return new StreamFontMetrics(tables, processor, this.glyphIdCache, this.codePointCache, this.svgGlyphSource);
         }
         else
         {
@@ -535,7 +541,7 @@ internal partial class StreamFontMetrics : FontMetrics
                 tables.MVar,
                 userCoordinates: userCoordinates);
 
-            return new StreamFontMetrics(tables, processor, this.glyphIdCache, this.codePointCache);
+            return new StreamFontMetrics(tables, processor, this.glyphIdCache, this.codePointCache, this.svgGlyphSource);
         }
     }
 
@@ -825,4 +831,7 @@ internal partial class StreamFontMetrics : FontMetrics
             OutlineType.CFF => this.CreateCffGlyphMetrics(in codePoint, glyphId, glyphType, textAttributes, textDecorations, colorSupport, isVerticalLayout, paletteIndex),
             _ => throw new NotSupportedException(),
         };
+
+    private SvgGlyphSource GetOrCreateSvgGlyphSource(SvgTable svgTable)
+        => this.svgGlyphSource ??= new SvgGlyphSource(svgTable);
 }

--- a/src/SixLabors.Fonts/Tables/General/Colr/ColrTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/Colr/ColrTable.cs
@@ -311,7 +311,9 @@ internal class ColrTable : Table
     /// <param name="currentGlyphId">
     /// The glyph id whose outline will receive the paint. Set by <c>PaintGlyph</c>/<c>PaintColrGlyph</c>.
     /// </param>
-    /// <param name="transform">Accumulated transform.</param>
+    /// <param name="glyphTransform">The accumulated transform to apply to the glyph's geometry.</param>
+    /// <param name="paintTransform">The accumulated transform to apply to the paint.</param>
+    /// <param name="transformPaint">Whether wrapper transforms should be applied to the paint (true) or to the glyph geometry (false).</param>
     /// <param name="compositeMode">Accumulated composite mode.</param>
     /// <param name="processor">The glyph variation processor, or null for non-variable fonts.</param>
     /// <param name="outLayers">Accumulator for resolved layers.</param>

--- a/src/SixLabors.Fonts/Tables/General/Colr/ColrTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/Colr/ColrTable.cs
@@ -283,7 +283,7 @@ internal class ColrTable : Table
 
         // 2) Flatten paint graph to layers. Start with no current glyph id.
         List<ResolvedGlyphLayer> acc = [];
-        this.FlattenPaintToLayers(root, null, Matrix3x2.Identity, CompositeMode.SrcOver, processor, acc);
+        this.FlattenPaintToLayers(root, null, Matrix3x2.Identity, Matrix3x2.Identity, false, CompositeMode.SrcOver, processor, acc);
 
         // 3) If nothing emitted, the graph did not bind any geometry (no PaintGlyph/ColrGlyph reached).
         if (acc.Count == 0)
@@ -318,7 +318,9 @@ internal class ColrTable : Table
     private void FlattenPaintToLayers(
         Paint node,
         ushort? currentGlyphId,
-        Matrix3x2 transform,
+        Matrix3x2 glyphTransform,
+        Matrix3x2 paintTransform,
+        bool transformPaint,
         CompositeMode compositeMode,
         GlyphVariationProcessor? processor,
         List<ResolvedGlyphLayer> outLayers)
@@ -346,7 +348,7 @@ internal class ColrTable : Table
 
                     if (this.paintCache!.TryGetValue(off, out Paint? child) && child is not null)
                     {
-                        this.FlattenPaintToLayers(child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                        this.FlattenPaintToLayers(child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                     }
                 }
 
@@ -355,11 +357,11 @@ internal class ColrTable : Table
 
             case PaintColrGlyph pcg:
             {
-                // Resolve the referenced glyph's root paint and recurse under that glyph id.
+                // Resolve the referenced glyph's root paint and recurse through its own bindings.
                 if (this.TryGetRootPaintOffset(pcg.GlyphId, out uint off) && off != 0
                     && this.paintCache!.TryGetValue(off, out Paint? colrRoot) && colrRoot is not null)
                 {
-                    this.FlattenPaintToLayers(colrRoot, pcg.GlyphId, transform, compositeMode, processor, outLayers);
+                    this.FlattenPaintToLayers(colrRoot, null, glyphTransform, Matrix3x2.Identity, false, compositeMode, processor, outLayers);
                 }
 
                 return;
@@ -368,7 +370,7 @@ internal class ColrTable : Table
             case PaintGlyph pg:
             {
                 // Bind geometry to the specified glyph id and recurse into its child paint.
-                this.FlattenPaintToLayers(pg.Child, pg.GlyphId, transform, compositeMode, processor, outLayers);
+                this.FlattenPaintToLayers(pg.Child, pg.GlyphId, glyphTransform, Matrix3x2.Identity, true, compositeMode, processor, outLayers);
                 return;
             }
 
@@ -378,8 +380,17 @@ internal class ColrTable : Table
             case PaintTransform pt:
             {
                 Affine2x3 a = pt.Transform;
-                transform *= new Matrix3x2(a.Xx, a.Yx, a.Xy, a.Yy, a.Dx, a.Dy);
-                this.FlattenPaintToLayers(pt.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = new(a.Xx, a.Yx, a.Xy, a.Yy, a.Dx, a.Dy);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(pt.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
@@ -393,15 +404,33 @@ internal class ColrTable : Table
                 float yy = a.Yy + this.ResolveDelta(processor, vib + 3u);
                 float dx = a.Dx + this.ResolveDelta(processor, vib + 4u);
                 float dy = a.Dy + this.ResolveDelta(processor, vib + 5u);
-                transform *= new Matrix3x2(xx, yx, xy, yy, dx, dy);
-                this.FlattenPaintToLayers(pvt.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = new(xx, yx, xy, yy, dx, dy);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(pvt.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
             case PaintTranslate t:
             {
-                transform *= Matrix3x2.CreateTranslation(t.Dx, t.Dy);
-                this.FlattenPaintToLayers(t.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = Matrix3x2.CreateTranslation(t.Dx, t.Dy);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(t.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
@@ -409,15 +438,33 @@ internal class ColrTable : Table
             {
                 float dx = vt.Dx + this.ResolveDelta(processor, vt.VarIndexBase + 0u);
                 float dy = vt.Dy + this.ResolveDelta(processor, vt.VarIndexBase + 1u);
-                transform *= Matrix3x2.CreateTranslation(dx, dy);
-                this.FlattenPaintToLayers(vt.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = Matrix3x2.CreateTranslation(dx, dy);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(vt.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
             case PaintScale s:
             {
-                transform *= BuildScale(s.ScaleX, s.ScaleY, s.AroundCenter, s.CenterX, s.CenterY);
-                this.FlattenPaintToLayers(s.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = BuildScale(s.ScaleX, s.ScaleY, s.AroundCenter, s.CenterX, s.CenterY);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(s.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
@@ -429,15 +476,33 @@ internal class ColrTable : Table
                 int centerOffset = vs.Uniform ? 1 : 2;
                 float cx = vs.AroundCenter ? vs.CenterX + this.ResolveDelta(processor, vib + (uint)centerOffset) : 0;
                 float cy = vs.AroundCenter ? vs.CenterY + this.ResolveDelta(processor, vib + (uint)centerOffset + 1u) : 0;
-                transform *= BuildScale(sx, sy, vs.AroundCenter, cx, cy);
-                this.FlattenPaintToLayers(vs.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = BuildScale(sx, sy, vs.AroundCenter, cx, cy);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(vs.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
             case PaintRotate r:
             {
-                transform *= BuildRotate(r.Angle, r.AroundCenter, r.CenterX, r.CenterY);
-                this.FlattenPaintToLayers(r.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = BuildRotate(r.Angle, r.AroundCenter, r.CenterX, r.CenterY);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(r.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
@@ -447,15 +512,33 @@ internal class ColrTable : Table
                 float angle = vr.Angle + this.ResolveDelta(processor, vib + 0u);
                 float cx = vr.AroundCenter ? vr.CenterX + this.ResolveDelta(processor, vib + 1u) : 0;
                 float cy = vr.AroundCenter ? vr.CenterY + this.ResolveDelta(processor, vib + 2u) : 0;
-                transform *= BuildRotate(angle, vr.AroundCenter, cx, cy);
-                this.FlattenPaintToLayers(vr.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = BuildRotate(angle, vr.AroundCenter, cx, cy);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(vr.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
             case PaintSkew k:
             {
-                transform *= BuildSkew(k.XSkew, k.YSkew, k.AroundCenter, k.CenterX, k.CenterY);
-                this.FlattenPaintToLayers(k.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = BuildSkew(k.XSkew, k.YSkew, k.AroundCenter, k.CenterX, k.CenterY);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(k.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
@@ -466,8 +549,17 @@ internal class ColrTable : Table
                 float ySkew = vk.YSkew + this.ResolveDelta(processor, vib + 1u);
                 float cx = vk.AroundCenter ? vk.CenterX + this.ResolveDelta(processor, vib + 2u) : 0;
                 float cy = vk.AroundCenter ? vk.CenterY + this.ResolveDelta(processor, vib + 3u) : 0;
-                transform *= BuildSkew(xSkew, ySkew, vk.AroundCenter, cx, cy);
-                this.FlattenPaintToLayers(vk.Child, currentGlyphId, transform, compositeMode, processor, outLayers);
+                Matrix3x2 next = BuildSkew(xSkew, ySkew, vk.AroundCenter, cx, cy);
+                if (transformPaint)
+                {
+                    paintTransform *= next;
+                }
+                else
+                {
+                    glyphTransform *= next;
+                }
+
+                this.FlattenPaintToLayers(vk.Child, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
@@ -476,8 +568,8 @@ internal class ColrTable : Table
                 compositeMode = MapCompositeMode(comp.CompositeMode);
 
                 // Backdrop first, then Source. Both inherit the current glyph id.
-                this.FlattenPaintToLayers(comp.Backdrop, currentGlyphId, transform, compositeMode, processor, outLayers);
-                this.FlattenPaintToLayers(comp.Source, currentGlyphId, transform, compositeMode, processor, outLayers);
+                this.FlattenPaintToLayers(comp.Backdrop, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
+                this.FlattenPaintToLayers(comp.Source, currentGlyphId, glyphTransform, paintTransform, transformPaint, compositeMode, processor, outLayers);
                 return;
             }
 
@@ -497,7 +589,7 @@ internal class ColrTable : Table
                 if (currentGlyphId.HasValue)
                 {
                     _ = this.TryGetClipBox(currentGlyphId.Value, processor, out Bounds? clip);
-                    outLayers.Add(new ResolvedGlyphLayer(currentGlyphId.Value, node, transform, compositeMode, clip));
+                    outLayers.Add(new ResolvedGlyphLayer(currentGlyphId.Value, node, glyphTransform, paintTransform, compositeMode, clip));
                 }
 
                 return;
@@ -1456,7 +1548,7 @@ internal sealed class PaintCaches
 
 /// <summary>
 /// Represents a resolved COLR v1 glyph layer produced by flattening the paint DAG.
-/// Associates a glyph ID with its paint node, accumulated transform, composite mode, and optional clip box.
+/// Associates a glyph ID with its paint node, geometry transform, paint transform, composite mode, and optional clip box.
 /// </summary>
 #pragma warning disable SA1201 // Elements should appear in the correct order
 [DebuggerDisplay("Id: {GlyphId}")]
@@ -1468,14 +1560,16 @@ internal readonly struct ResolvedGlyphLayer
     /// </summary>
     /// <param name="id">The glyph ID whose outline this layer paints.</param>
     /// <param name="paint">The leaf paint node for this layer.</param>
-    /// <param name="transform">The accumulated affine transform.</param>
+    /// <param name="glyphTransform">The accumulated affine transform applied to glyph geometry.</param>
+    /// <param name="paintTransform">The accumulated affine transform applied to the leaf paint.</param>
     /// <param name="mode">The composite mode to apply.</param>
     /// <param name="clipBox">The optional clip box bounds, or <see langword="null"/>.</param>
-    public ResolvedGlyphLayer(ushort id, Paint paint, Matrix3x2 transform, CompositeMode mode, Bounds? clipBox)
+    public ResolvedGlyphLayer(ushort id, Paint paint, Matrix3x2 glyphTransform, Matrix3x2 paintTransform, CompositeMode mode, Bounds? clipBox)
     {
         this.GlyphId = id;
         this.Paint = paint;
-        this.Transform = transform;
+        this.GlyphTransform = glyphTransform;
+        this.PaintTransform = paintTransform;
         this.CompositeMode = mode;
         this.ClipBox = clipBox;
     }
@@ -1491,9 +1585,14 @@ internal readonly struct ResolvedGlyphLayer
     public Paint Paint { get; }
 
     /// <summary>
-    /// Gets the accumulated affine transform from the paint DAG traversal.
+    /// Gets the accumulated affine transform applied to glyph geometry.
     /// </summary>
-    public Matrix3x2 Transform { get; }
+    public Matrix3x2 GlyphTransform { get; }
+
+    /// <summary>
+    /// Gets the accumulated affine transform applied to the leaf paint.
+    /// </summary>
+    public Matrix3x2 PaintTransform { get; }
 
     /// <summary>
     /// Gets the composite mode to apply when rendering this layer.

--- a/src/SixLabors.Fonts/Tables/General/Colr/ColrV1GlyphSource.cs
+++ b/src/SixLabors.Fonts/Tables/General/Colr/ColrV1GlyphSource.cs
@@ -58,24 +58,14 @@ internal sealed class ColrV1GlyphSource : ColrGlyphSourceBase
 
                     // Flatten paint graph: accumulate wrapper transforms; attach composite mode to leaves.
                     List<Rendering.Paint> leafPaints = [];
-                    FlattenPaint(rl.Paint, rl.Transform, rl.CompositeMode, this.Cpal, this.Colr, this.processor, leafPaints);
+                    FlattenPaint(rl.Paint, rl.PaintTransform, rl.CompositeMode, this.Cpal, this.Colr, this.processor, leafPaints);
 
                     // Emit one layer per leaf paint.
                     Bounds? clip = rl.ClipBox;
                     for (int p = 0; p < leafPaints.Count; p++)
                     {
                         Rendering.Paint leaf = leafPaints[p];
-                        Matrix3x2 xForm = Matrix3x2.Identity;
-                        if (leaf is SolidPaint solid)
-                        {
-                            // Move the transform from the paint to the layer.
-                            // We do this so that solid paints are also transformed correctly as
-                            // their location is defined in the local space of the layer.
-                            xForm = solid.Transform;
-                            solid.Transform = Matrix3x2.Identity;
-                        }
-
-                        layers.Add(new PaintedLayer(leaf, FillRule.NonZero, xForm, clip, path));
+                        layers.Add(new PaintedLayer(leaf, FillRule.NonZero, rl.GlyphTransform, clip, path));
                     }
                 }
 

--- a/src/SixLabors.Fonts/Tables/General/Svg/SvgGlyphSource.cs
+++ b/src/SixLabors.Fonts/Tables/General/Svg/SvgGlyphSource.cs
@@ -10,7 +10,6 @@ using System.Xml;
 using System.Xml.Linq;
 using SixLabors.Fonts.Rendering;
 
-#pragma warning disable SA1201 // Elements should appear in the correct order
 namespace SixLabors.Fonts.Tables.General.Svg;
 
 /// <summary>
@@ -20,16 +19,10 @@ namespace SixLabors.Fonts.Tables.General.Svg;
 /// </summary>
 internal sealed class SvgGlyphSource : IPaintedGlyphSource
 {
+    private static readonly SolidPaint DefaultBlackFillPaint = new() { Color = GlyphColor.Black };
     private readonly SvgTable svgTable;
-    private readonly Dictionary<ushort, ParsedDoc> docCache = [];
+    private readonly ConcurrentDictionary<(int Start, int Length), ParsedDoc> docCache = [];
     private readonly ConcurrentDictionary<ushort, (PaintedGlyph Glyph, PaintedCanvasMetadata Canvas)> cachedGlyphs = [];
-
-    private sealed class ParsedDoc
-    {
-        public required XDocument Doc { get; init; }
-
-        public required Dictionary<string, XElement> IdMap { get; init; }
-    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SvgGlyphSource"/> class.
@@ -58,9 +51,10 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                     Walk(
                         glyphRoot,
                         rootTransform,
-                        inheritedPaint: null,
+                        inheritedPaint: DefaultBlackFillPaint,
+                        inheritedOpacityMul: 1F,
                         outputLayers: layers,
-                        idMap: parsed.IdMap);
+                        parsedDoc: parsed);
 
                     if (layers.Count > 0)
                     {
@@ -83,12 +77,13 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
     {
         parsed = default;
 
-        if (!this.svgTable.TryGetDocumentSpan(glyphId, out int _, out int _))
+        if (!this.svgTable.TryGetDocumentSpan(glyphId, out int start, out int length))
         {
             return false;
         }
 
-        if (this.docCache.TryGetValue(glyphId, out parsed))
+        (int Start, int Length) docKey = (start, length);
+        if (this.docCache.TryGetValue(docKey, out parsed))
         {
             return true;
         }
@@ -124,7 +119,7 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                 IdMap = idMap
             };
 
-            this.docCache[glyphId] = parsed;
+            this.docCache[docKey] = parsed;
             return true;
         }
     }
@@ -159,13 +154,17 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
         XElement node,
         Matrix3x2 parentLocalTransform,
         Paint? inheritedPaint,
+        float inheritedOpacityMul,
         List<PaintedLayer> outputLayers,
-        Dictionary<string, XElement> idMap)
+        ParsedDoc parsedDoc)
     {
-        Matrix3x2 localTransform = parentLocalTransform * ParseTransform(node.Attribute("transform")?.Value);
+        Dictionary<string, XElement> idMap = parsedDoc.IdMap;
+        Matrix3x2 nodeTransform = ParseTransform(node.Attribute("transform")?.Value);
+        Matrix3x2 localTransform = parentLocalTransform * nodeTransform;
 
         FillRule fillRule = ResolveFillRule(node, FillRule.NonZero);
-        Paint? paint = ResolvePaint(node, inheritedPaint, idMap, out bool fillNone, out float opacityMul);
+        Paint? paint = ResolvePaint(node, inheritedPaint, parsedDoc, out bool fillNone, out float opacityMul);
+        float combinedOpacityMul = inheritedOpacityMul * opacityMul;
 
         string name = node.Name.LocalName;
         switch (name)
@@ -175,7 +174,7 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
             {
                 foreach (XElement child in node.Elements())
                 {
-                    Walk(child, localTransform, fillNone ? null : paint, outputLayers, idMap);
+                    Walk(child, localTransform, fillNone ? null : paint, combinedOpacityMul, outputLayers, parsedDoc);
                 }
 
                 break;
@@ -191,15 +190,16 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
 
                 float ux = ParseFloat(node.Attribute("x")?.Value);
                 float uy = ParseFloat(node.Attribute("y")?.Value);
-                Matrix3x2 xf = localTransform * Matrix3x2.CreateTranslation(ux, uy);
+                Matrix3x2 xf = parentLocalTransform
+                    * Matrix3x2.CreateTranslation(ux, uy)
+                    * nodeTransform;
 
-                Paint? usePaint = ResolvePaint(node, paint, idMap, out bool useNone, out float _);
-                Paint? childInherited = useNone ? null : usePaint;
+                Paint? childInherited = fillNone ? null : paint;
 
                 XElement? target = LookupById(idMap, href);
                 if (target is not null)
                 {
-                    Walk(target, xf, childInherited, outputLayers, idMap);
+                    Walk(target, xf, childInherited, combinedOpacityMul, outputLayers, parsedDoc);
                 }
 
                 break;
@@ -218,10 +218,10 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                     break;
                 }
 
-                List<PathCommand> cmds = BuildCommandsFromPathData(d);
+                List<PathCommand> cmds = GetOrBuildPathCommands(node, d, parsedDoc);
                 if (cmds.Count > 0)
                 {
-                    Paint? layerPaint = ApplyOpacityToPaint(paint, opacityMul);
+                    Paint? layerPaint = ApplyOpacityToPaint(paint, combinedOpacityMul);
                     outputLayers.Add(new(layerPaint, fillRule, localTransform, null, cmds));
                 }
 
@@ -241,10 +241,10 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                 if (coords.Length >= 4)
                 {
                     bool close = string.Equals(node.Name.LocalName, "polygon", StringComparison.Ordinal);
-                    List<PathCommand> cmds = BuildCommandsFromPoly(coords, close);
+                    List<PathCommand> cmds = GetOrBuildPolyCommands(node, coords, close, parsedDoc);
                     if (cmds.Count > 0)
                     {
-                        Paint? layerPaint = ApplyOpacityToPaint(paint, opacityMul);
+                        Paint? layerPaint = ApplyOpacityToPaint(paint, combinedOpacityMul);
                         outputLayers.Add(new(layerPaint, fillRule, localTransform, null, cmds));
                     }
                 }
@@ -267,18 +267,10 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                 // TODO: Rounded corners (rx/ry) not handled here (could be approximated later if needed).
                 if (w > 0f && h > 0f)
                 {
-                    float[] coords =
-                    [
-                        x, y,
-                        x + w, y,
-                        x + w, y + h,
-                        x, y + h
-                    ];
-
-                    List<PathCommand> cmds = BuildCommandsFromPoly(coords, close: true);
+                    List<PathCommand> cmds = GetOrBuildRectCommands(node, x, y, w, h, parsedDoc);
                     if (cmds.Count > 0)
                     {
-                        Paint? layerPaint = ApplyOpacityToPaint(paint, opacityMul);
+                        Paint? layerPaint = ApplyOpacityToPaint(paint, combinedOpacityMul);
                         outputLayers.Add(new(layerPaint, fillRule, localTransform, null, cmds));
                     }
                 }
@@ -298,10 +290,10 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                 float r = ParseFloat(node.Attribute("r")?.Value);
                 if (r > 0f)
                 {
-                    List<PathCommand> cmds = BuildCommandsForEllipse(cx, cy, r, r);
+                    List<PathCommand> cmds = GetOrBuildEllipseCommands(node, cx, cy, r, r, parsedDoc);
                     if (cmds.Count > 0)
                     {
-                        Paint? layerPaint = ApplyOpacityToPaint(paint, opacityMul);
+                        Paint? layerPaint = ApplyOpacityToPaint(paint, combinedOpacityMul);
                         outputLayers.Add(new(layerPaint, fillRule, localTransform, null, cmds));
                     }
                 }
@@ -322,10 +314,10 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                 float ry = ParseFloat(node.Attribute("ry")?.Value);
                 if (rx > 0f && ry > 0f)
                 {
-                    List<PathCommand> cmds = BuildCommandsForEllipse(cx, cy, rx, ry);
+                    List<PathCommand> cmds = GetOrBuildEllipseCommands(node, cx, cy, rx, ry, parsedDoc);
                     if (cmds.Count > 0)
                     {
-                        Paint? layerPaint = ApplyOpacityToPaint(paint, opacityMul);
+                        Paint? layerPaint = ApplyOpacityToPaint(paint, combinedOpacityMul);
                         outputLayers.Add(new(layerPaint, fillRule, localTransform, null, cmds));
                     }
                 }
@@ -405,7 +397,7 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
     private static Paint? ResolvePaint(
         XElement e,
         Paint? inherited,
-        Dictionary<string, XElement> idMap,
+        ParsedDoc parsedDoc,
         out bool fillNone,
         out float opacityMul)
     {
@@ -453,27 +445,46 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
 
         if (TryExtractUrlId(fill, out string? paintId) && paintId is not null)
         {
-            return ResolvePaintServer(paintId, idMap) ?? inherited;
+            return ResolvePaintServer(paintId, parsedDoc) ?? inherited;
         }
 
         return inherited;
     }
 
-    private static Paint? ResolvePaintServer(string id, Dictionary<string, XElement> idMap)
+    /// <summary>
+    /// Resolves a referenced paint server and caches the parsed paint so repeated
+    /// uses of the same gradient id do not rebuild the gradient definition.
+    /// </summary>
+    /// <param name="id">The referenced paint server identifier.</param>
+    /// <param name="parsedDoc">The parsed SVG document and its caches.</param>
+    /// <returns>The resolved paint, or <see langword="null"/> if the reference is unknown.</returns>
+    private static Paint? ResolvePaintServer(string id, ParsedDoc parsedDoc)
     {
-        if (!idMap.TryGetValue(id, out XElement? server))
+        if (parsedDoc.PaintServerCache.TryGetValue(id, out Paint? cached))
+        {
+            return cached;
+        }
+
+        if (!parsedDoc.IdMap.TryGetValue(id, out XElement? server))
         {
             return null;
         }
 
         string tag = server.Name.LocalName;
-        return tag switch
+        Paint? paint = tag switch
         {
             // SVG only has linearGradient and radialGradient.
-            "linearGradient" => BuildLinearGradient(server, idMap),
-            "radialGradient" => BuildRadialGradient(server, idMap),
+            "linearGradient" => BuildLinearGradient(server, parsedDoc.IdMap),
+            "radialGradient" => BuildRadialGradient(server, parsedDoc.IdMap),
             _ => null
         };
+
+        if (paint is not null)
+        {
+            parsedDoc.PaintServerCache.TryAdd(id, paint);
+        }
+
+        return paint;
     }
 
     private static LinearGradientPaint? BuildLinearGradient(XElement grad, Dictionary<string, XElement> idMap)
@@ -716,7 +727,7 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
             return null;
         }
 
-        if (s!.EndsWith('%'))
+        if (s.EndsWith('%'))
         {
             if (float.TryParse(s.AsSpan(0, s.Length - 1), NumberStyles.Float, CultureInfo.InvariantCulture, out float p))
             {
@@ -938,6 +949,150 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
     {
         XNamespace xlink = "http://www.w3.org/1999/xlink";
         return e.Attribute(xlink + "href")?.Value ?? e.Attribute("href")?.Value;
+    }
+
+    /// <summary>
+    /// Returns cached path commands for an SVG <c>path</c> element, or parses and caches them
+    /// when the element is a reusable definition with an <c>id</c>.
+    /// </summary>
+    /// <param name="node">The SVG node that owns the geometry.</param>
+    /// <param name="d">The raw SVG path data.</param>
+    /// <param name="parsedDoc">The parsed SVG document and its caches.</param>
+    /// <returns>The parsed path commands.</returns>
+    private static List<PathCommand> GetOrBuildPathCommands(XElement node, string d, ParsedDoc parsedDoc)
+    {
+        if (TryGetCachedGeometry(node, parsedDoc, out List<PathCommand>? cached, out string? geometryId))
+        {
+            return cached;
+        }
+
+        return CacheGeometry(geometryId, parsedDoc, BuildCommandsFromPathData(d));
+    }
+
+    /// <summary>
+    /// Returns cached path commands for a polygon or polyline definition, or builds and caches them.
+    /// </summary>
+    /// <param name="node">The SVG node that owns the geometry.</param>
+    /// <param name="coords">The parsed coordinate list.</param>
+    /// <param name="close">Whether the geometry should be explicitly closed.</param>
+    /// <param name="parsedDoc">The parsed SVG document and its caches.</param>
+    /// <returns>The parsed path commands.</returns>
+    private static List<PathCommand> GetOrBuildPolyCommands(XElement node, float[] coords, bool close, ParsedDoc parsedDoc)
+    {
+        if (TryGetCachedGeometry(node, parsedDoc, out List<PathCommand>? cached, out string? geometryId))
+        {
+            return cached;
+        }
+
+        return CacheGeometry(geometryId, parsedDoc, BuildCommandsFromPoly(coords, close));
+    }
+
+    /// <summary>
+    /// Returns cached path commands for a rectangle definition, or builds and caches them.
+    /// </summary>
+    /// <param name="node">The SVG node that owns the geometry.</param>
+    /// <param name="x">The rectangle origin X.</param>
+    /// <param name="y">The rectangle origin Y.</param>
+    /// <param name="w">The rectangle width.</param>
+    /// <param name="h">The rectangle height.</param>
+    /// <param name="parsedDoc">The parsed SVG document and its caches.</param>
+    /// <returns>The parsed path commands.</returns>
+    private static List<PathCommand> GetOrBuildRectCommands(
+        XElement node,
+        float x,
+        float y,
+        float w,
+        float h,
+        ParsedDoc parsedDoc)
+    {
+        if (TryGetCachedGeometry(node, parsedDoc, out List<PathCommand>? cached, out string? geometryId))
+        {
+            return cached;
+        }
+
+        float[] coords =
+        [
+            x, y,
+            x + w, y,
+            x + w, y + h,
+            x, y + h
+        ];
+
+        return CacheGeometry(geometryId, parsedDoc, BuildCommandsFromPoly(coords, close: true));
+    }
+
+    /// <summary>
+    /// Returns cached path commands for an ellipse or circle definition, or builds and caches them.
+    /// </summary>
+    /// <param name="node">The SVG node that owns the geometry.</param>
+    /// <param name="cx">The ellipse center X.</param>
+    /// <param name="cy">The ellipse center Y.</param>
+    /// <param name="rx">The ellipse radius on the X axis.</param>
+    /// <param name="ry">The ellipse radius on the Y axis.</param>
+    /// <param name="parsedDoc">The parsed SVG document and its caches.</param>
+    /// <returns>The parsed path commands.</returns>
+    private static List<PathCommand> GetOrBuildEllipseCommands(
+        XElement node,
+        float cx,
+        float cy,
+        float rx,
+        float ry,
+        ParsedDoc parsedDoc)
+    {
+        if (TryGetCachedGeometry(node, parsedDoc, out List<PathCommand>? cached, out string? geometryId))
+        {
+            return cached;
+        }
+
+        return CacheGeometry(geometryId, parsedDoc, BuildCommandsForEllipse(cx, cy, rx, ry));
+    }
+
+    /// <summary>
+    /// Looks up cached geometry for a reusable SVG element by its <c>id</c>.
+    /// </summary>
+    /// <param name="node">The SVG node that may have cached geometry.</param>
+    /// <param name="parsedDoc">The parsed SVG document and its caches.</param>
+    /// <param name="cached">When this method returns, contains the cached commands if found.</param>
+    /// <param name="geometryId">When this method returns, contains the element id used as the cache key.</param>
+    /// <returns><see langword="true"/> if cached geometry was found; otherwise, <see langword="false"/>.</returns>
+    private static bool TryGetCachedGeometry(
+        XElement node,
+        ParsedDoc parsedDoc,
+        [NotNullWhen(true)] out List<PathCommand>? cached,
+        [NotNullWhen(true)] out string? geometryId)
+    {
+        geometryId = node.Attribute("id")?.Value;
+        if (geometryId is not null && parsedDoc.GeometryCache.TryGetValue(geometryId, out List<PathCommand>? commands))
+        {
+            cached = commands;
+            return true;
+        }
+
+        cached = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Stores geometry in the per-document cache when the
+    /// source element has a reusable <c>id</c>.
+    /// </summary>
+    /// <param name="geometryId">The cache key, or <see langword="null"/> when the element is anonymous.</param>
+    /// <param name="parsedDoc">The parsed SVG document and its caches.</param>
+    /// <param name="commands">The newly built commands.</param>
+    /// <returns>The cached or materialized command list.</returns>
+    private static List<PathCommand> CacheGeometry(string? geometryId, ParsedDoc parsedDoc, List<PathCommand> commands)
+    {
+        if (commands.Count == 0)
+        {
+            return [];
+        }
+
+        if (geometryId is not null)
+        {
+            parsedDoc.GeometryCache.TryAdd(geometryId, commands);
+        }
+
+        return commands;
     }
 
     private static List<PathCommand> BuildCommandsFromPoly(float[] coords, bool close)
@@ -1571,4 +1726,21 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
 
     private static bool NearlyEqual(in Vector2 a, in Vector2 b, float eps = 1e-3f)
         => MathF.Abs(a.X - b.X) <= eps && MathF.Abs(a.Y - b.Y) <= eps;
+
+    private sealed class ParsedDoc
+    {
+        public required XDocument Doc { get; init; }
+
+        public required Dictionary<string, XElement> IdMap { get; init; }
+
+        /// <summary>
+        /// Gets the per-document cache of parsed geometry for reusable SVG defs.
+        /// </summary>
+        public ConcurrentDictionary<string, List<PathCommand>> GeometryCache { get; } = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets the per-document cache of resolved paint servers.
+        /// </summary>
+        public ConcurrentDictionary<string, Paint> PaintServerCache { get; } = new(StringComparer.Ordinal);
+    }
 }

--- a/src/SixLabors.Fonts/Tables/General/Svg/SvgGlyphSource.cs
+++ b/src/SixLabors.Fonts/Tables/General/Svg/SvgGlyphSource.cs
@@ -821,21 +821,23 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
             return null;
         }
 
-        // TODO: Rewrite this using Span.Split to avoid allocations.
-        string[] parts = style.Split(';', StringSplitOptions.RemoveEmptyEntries);
-        for (int i = 0; i < parts.Length; i++)
+        ReadOnlySpan<char> span = style.AsSpan();
+        while (span.Length > 0)
         {
-            string part = parts[i];
-            int c = part.IndexOf(':');
-            if (c <= 0)
+            int semi = span.IndexOf(';');
+            ReadOnlySpan<char> part = semi >= 0 ? span[..semi] : span;
+            span = semi >= 0 ? span[(semi + 1)..] : [];
+
+            int colon = part.IndexOf(':');
+            if (colon <= 0)
             {
                 continue;
             }
 
-            string name = part.AsSpan(0, c).Trim().ToString();
-            if (name.Equals(prop, StringComparison.OrdinalIgnoreCase))
+            ReadOnlySpan<char> name = part[..colon].Trim();
+            if (name.Equals(prop.AsSpan(), StringComparison.OrdinalIgnoreCase))
             {
-                return part.AsSpan(c + 1).Trim().ToString();
+                return part[(colon + 1)..].Trim().ToString();
             }
         }
 
@@ -861,15 +863,16 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
             int r = s.IndexOf(')');
             if (l >= 0 && r > l)
             {
-                // TODO: Rewrite this using Span.Split to avoid allocations.
-                string[] comps = s.Substring(l + 1, r - l - 1).Split(',');
-                if (comps.Length >= 3)
+                ReadOnlySpan<char> inner = s.AsSpan(l + 1, r - l - 1);
+                Span<Range> ranges = stackalloc Range[5];
+                int count = inner.Split(ranges, ',');
+                if (count >= 3)
                 {
-                    byte rr = ParseByte(comps[0]);
-                    byte gg = ParseByte(comps[1]);
-                    byte bb = ParseByte(comps[2]);
+                    byte rr = ParseByte(inner[ranges[0]]);
+                    byte gg = ParseByte(inner[ranges[1]]);
+                    byte bb = ParseByte(inner[ranges[2]]);
                     byte aa = 255;
-                    if (comps.Length >= 4 && float.TryParse(comps[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float af))
+                    if (count >= 4 && float.TryParse(inner[ranges[3]].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out float af))
                     {
                         aa = (byte)Math.Clamp((int)Math.Round(255f * af), 0, 255);
                     }
@@ -1429,7 +1432,7 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                 i++;
             }
 
-            string op = s[start..i];
+            ReadOnlySpan<char> op = s.AsSpan(start, i - start);
 
             SkipSep(s, ref i);
             if (i >= n || s[i] != '(')
@@ -1455,78 +1458,58 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                 i++;
             }
 
-            string args = s.Substring(argsStart, (i - argsStart) - 1);
+            ReadOnlySpan<char> args = s.AsSpan(argsStart, (i - argsStart) - 1);
             float[] a = ParseFloatList(args);
 
             Matrix3x2 t = Matrix3x2.Identity;
-            switch (op)
+            if (op.SequenceEqual("matrix"))
             {
-                case "matrix":
+                if (a.Length >= 6)
                 {
-                    if (a.Length >= 6)
-                    {
-                        t = new Matrix3x2(a[0], a[1], a[2], a[3], a[4], a[5]);
-                    }
-
-                    break;
+                    t = new Matrix3x2(a[0], a[1], a[2], a[3], a[4], a[5]);
                 }
-
-                case "translate":
+            }
+            else if (op.SequenceEqual("translate"))
+            {
+                if (a.Length == 1)
                 {
-                    if (a.Length == 1)
-                    {
-                        t = Matrix3x2.CreateTranslation(a[0], 0f);
-                    }
-                    else if (a.Length >= 2)
-                    {
-                        t = Matrix3x2.CreateTranslation(a[0], a[1]);
-                    }
-
-                    break;
+                    t = Matrix3x2.CreateTranslation(a[0], 0f);
                 }
-
-                case "scale":
+                else if (a.Length >= 2)
                 {
-                    if (a.Length == 1)
-                    {
-                        t = Matrix3x2.CreateScale(a[0], a[0]);
-                    }
-                    else if (a.Length >= 2)
-                    {
-                        t = Matrix3x2.CreateScale(a[0], a[1]);
-                    }
-
-                    break;
+                    t = Matrix3x2.CreateTranslation(a[0], a[1]);
                 }
-
-                case "rotate":
+            }
+            else if (op.SequenceEqual("scale"))
+            {
+                if (a.Length == 1)
                 {
-                    if (a.Length >= 1)
-                    {
-                        t = Matrix3x2.CreateRotation(a[0] * (float)(Math.PI / 180.0));
-                    }
-
-                    break;
+                    t = Matrix3x2.CreateScale(a[0], a[0]);
                 }
-
-                case "skewX":
+                else if (a.Length >= 2)
                 {
-                    if (a.Length >= 1)
-                    {
-                        t = new Matrix3x2(1f, 0f, MathF.Tan(a[0] * (float)(Math.PI / 180.0)), 1f, 0f, 0f);
-                    }
-
-                    break;
+                    t = Matrix3x2.CreateScale(a[0], a[1]);
                 }
-
-                case "skewY":
+            }
+            else if (op.SequenceEqual("rotate"))
+            {
+                if (a.Length >= 1)
                 {
-                    if (a.Length >= 1)
-                    {
-                        t = new Matrix3x2(1f, MathF.Tan(a[0] * (float)(Math.PI / 180.0)), 0f, 1f, 0f, 0f);
-                    }
-
-                    break;
+                    t = Matrix3x2.CreateRotation(a[0] * (float)(Math.PI / 180.0));
+                }
+            }
+            else if (op.SequenceEqual("skewX"))
+            {
+                if (a.Length >= 1)
+                {
+                    t = new Matrix3x2(1f, 0f, MathF.Tan(a[0] * (float)(Math.PI / 180.0)), 1f, 0f, 0f);
+                }
+            }
+            else if (op.SequenceEqual("skewY"))
+            {
+                if (a.Length >= 1)
+                {
+                    t = new Matrix3x2(1f, MathF.Tan(a[0] * (float)(Math.PI / 180.0)), 0f, 1f, 0f, 0f);
                 }
             }
 
@@ -1652,8 +1635,11 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
         => str.IsEmpty ? 0 : float.Parse(str, CultureInfo.InvariantCulture);
 
     private static float[] ParseFloatList(string s)
+        => string.IsNullOrEmpty(s) ? [] : ParseFloatList(s.AsSpan());
+
+    private static float[] ParseFloatList(ReadOnlySpan<char> s)
     {
-        if (string.IsNullOrEmpty(s))
+        if (s.IsEmpty)
         {
             return [];
         }
@@ -1715,7 +1701,7 @@ internal sealed class SvgGlyphSource : IPaintedGlyphSource
                 }
             }
 
-            if (float.TryParse(s.AsSpan(start, i - start), NumberStyles.Float, CultureInfo.InvariantCulture, out float v))
+            if (float.TryParse(s[start..i], NumberStyles.Float, CultureInfo.InvariantCulture, out float v))
             {
                 vals.Add(v);
             }

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -1023,7 +1023,21 @@ internal static class TextLayout
                 charIndex += charsConsumed;
 
                 // Get the glyph id for the codepoint and add to the collection.
-                _ = font.FontMetrics.TryGetGlyphId(current, next, out ushort glyphId, out skipNextCodePoint);
+                bool hasGlyph = font.FontMetrics.TryGetGlyphId(current, next, out ushort glyphId, out skipNextCodePoint);
+
+                // Unsupported default-ignorable code points such as FE0F should not block
+                // GSUB sequences like emoji ZWJ ligatures. Preserve joiners explicitly.
+                if (!hasGlyph &&
+                    UnicodeUtility.IsDefaultIgnorableCodePoint((uint)current.Value) &&
+                    !UnicodeUtility.ShouldRenderWhiteSpaceOnly(current) &&
+                    !CodePoint.IsZeroWidthJoiner(current) &&
+                    !CodePoint.IsZeroWidthNonJoiner(current))
+                {
+                    codePointIndex++;
+                    graphemeCodePointIndex++;
+                    continue;
+                }
+
                 substitutions.AddGlyph(glyphId, current, (TextDirection)bidiRuns[bidiRunIndex].Direction, textRuns[textRunIndex], codePointIndex);
 
                 codePointIndex++;

--- a/tests/Images/ReferenceOutput/CanRenderEmojiSanityMatrix_With_COLRv1_-full-string-.png
+++ b/tests/Images/ReferenceOutput/CanRenderEmojiSanityMatrix_With_COLRv1_-full-string-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2945fb185afcffad2f9e159de1ab1f11647fe436b9f83eeefa148ce5df4f485d
+size 726823

--- a/tests/Images/ReferenceOutput/CanRenderEmojiSanityMatrix_With_SVG_-full-string-.png
+++ b/tests/Images/ReferenceOutput/CanRenderEmojiSanityMatrix_With_SVG_-full-string-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ce73a2d78bbd6f6b00ac030143642a90ad70c20ac74beb010063a5279d115d3
+size 726727

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-clown-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-clown-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79deeaea352f2020521150c49183b793d5ddd0daf115358cd3441f825f3936bb
+size 27287

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-heart-on-fire-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-heart-on-fire-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec8e0d7501ae6664b389d4c1013be40ad655dcda95fb8c8300119f7504ae45c5
+size 26799

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-leg-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-leg-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ec12f3e60343de028a10a0270f4732c800e285731360150f55254904bc19c9d
+size 15966

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-mending-heart-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-mending-heart-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74b930b3d9d3f7482e36455795f092f6124b718bde65f376613dcaabb92f4c5b
+size 11865

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-robot-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_COLRv1_-robot-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:724c12e35905246648e6609542b83a05efb685960129a082956b98db21dccf7d
+size 10346

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-clown-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-clown-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1177e673f105d4b7dfd3624f4a39474ee69ce56d2e92ef857351ac06f6dd4891
+size 27336

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-heart-on-fire-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-heart-on-fire-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f10bdbfbb5784a37c1088bf3ff3b10b33f7fe94d94af984e8b3da2bfbb0d42cb
+size 26833

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-leg-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-leg-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:176d06c0e2b7713439f34b12452c9b694c0b089b7c36b5943468acc5ca67195b
+size 15929

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-mending-heart-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-mending-heart-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74b930b3d9d3f7482e36455795f092f6124b718bde65f376613dcaabb92f4c5b
+size 11865

--- a/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-robot-.png
+++ b/tests/Images/ReferenceOutput/CanRenderProblemEmojiTransforms_With_SVG_-robot-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:412d83398876c453958d6e2cedfce5e204a528c222d19c3e5f3c1305ed753ed7
+size 10371

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_462.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_462.cs
@@ -102,7 +102,7 @@ public class Issues_462
     public void CanRenderEmojiSanityMatrix_With_COLRv1()
         => this.AssertCanRenderEmojiSanityMatrix(ColorFontSupport.ColrV1);
 
-    [Fact(Skip = "Local Only, Parsing the full font is slow.")]
+    [Fact]
     public void CanRenderEmojiSanityMatrix_With_SVG()
         => this.AssertCanRenderEmojiSanityMatrix(ColorFontSupport.Svg);
 

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_462.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_462.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Runtime.CompilerServices;
 using SixLabors.Fonts.Rendering;
 using SixLabors.Fonts.Unicode;
 
@@ -77,5 +78,145 @@ public class Issues_462
             options,
             includeGeometry: true,
             customDecorations: true);
+    }
+
+    [Theory]
+    [InlineData("robot", "🤖")]
+    [InlineData("clown", "🤡")]
+    [InlineData("leg", "🦿")]
+    [InlineData("mending-heart", "❤️‍🩹")]
+    [InlineData("heart-on-fire", "❤️‍🔥")]
+    public void CanRenderProblemEmojiTransforms_With_COLRv1(string name, string text)
+        => this.AssertCanRenderProblemEmojiTransforms(name, text, ColorFontSupport.ColrV1);
+
+    [Theory]
+    [InlineData("robot", "🤖")]
+    [InlineData("clown", "🤡")]
+    [InlineData("leg", "🦿")]
+    [InlineData("mending-heart", "❤️‍🩹")]
+    [InlineData("heart-on-fire", "❤️‍🔥")]
+    public void CanRenderProblemEmojiTransforms_With_SVG(string name, string text)
+        => this.AssertCanRenderProblemEmojiTransforms(name, text, ColorFontSupport.Svg);
+
+    [Fact]
+    public void CanRenderEmojiSanityMatrix_With_COLRv1()
+        => this.AssertCanRenderEmojiSanityMatrix(ColorFontSupport.ColrV1);
+
+    [Fact(Skip = "Local Only, Parsing the full font is slow.")]
+    public void CanRenderEmojiSanityMatrix_With_SVG()
+        => this.AssertCanRenderEmojiSanityMatrix(ColorFontSupport.Svg);
+
+    [Fact]
+    public void Svg_UsesDefaultBlackFillForUnspecifiedCatFaceDetails()
+    {
+        Font font = this.emoji.CreateFont(256);
+
+        TextOptions options = new(font)
+        {
+            ColorFontSupport = ColorFontSupport.Svg,
+            FallbackFontFamilies = new[] { this.noto },
+        };
+
+        LayerCaptureRenderer renderer = new();
+        TextRenderer.RenderTextTo(renderer, "😸", options);
+
+        Assert.Single(renderer.GlyphKeys);
+        Assert.True(renderer.SolidLayers.Count(x => x.Color == GlyphColor.Black && Math.Abs(x.Opacity - 1F) < 0.001F) >= 9);
+    }
+
+    [Fact]
+    public void Svg_PropagatesUseOpacityToReferencedGeometry()
+    {
+        Font font = this.emoji.CreateFont(256);
+
+        TextOptions options = new(font)
+        {
+            ColorFontSupport = ColorFontSupport.Svg,
+            FallbackFontFamilies = new[] { this.noto },
+        };
+
+        LayerCaptureRenderer renderer = new();
+        TextRenderer.RenderTextTo(renderer, "🧐", options);
+
+        Assert.Single(renderer.GlyphKeys);
+        Assert.True(GlyphColor.TryParseHex("#CCCCCC", out GlyphColor monocleColor));
+        Assert.Contains(renderer.SolidLayers, x => x.Color == monocleColor && Math.Abs(x.Opacity - 0.5F) < 0.001F);
+    }
+
+    private void AssertCanRenderProblemEmojiTransforms(
+        string name,
+        string text,
+        ColorFontSupport support,
+        [CallerMemberName] string test = "")
+    {
+        Font font = this.emoji.CreateFont(256);
+
+        TextOptions options = new(font)
+        {
+            ColorFontSupport = support,
+            FallbackFontFamilies = new[] { this.noto },
+        };
+
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTextTo(renderer, text, options);
+        Assert.Single(renderer.GlyphKeys);
+
+        TextLayoutTestUtilities.TestLayout(text, options, test: test, properties: name);
+    }
+
+    private void AssertCanRenderEmojiSanityMatrix(
+        ColorFontSupport support,
+        [CallerMemberName] string test = "")
+    {
+        Font font = this.emoji.CreateFont(64);
+        const string text =
+            "😀😃😄😁😆😅😂🤣😭😉😗😙\n" +
+            "😚😘🥰😍🤩🥳🙃🙂🥲🥹😋😛\n" +
+            "😝😜🤪😇😊☺️😏😌😔😑😐😶\n" +
+            "🫡🤔🤫🫢🤭🥱🤗🫣😱🤨🧐😒\n" +
+            "🙄😮‍💨😤😠😡🤬🥺😟😥😢☹️🙁\n" +
+            "🫤😕🤐😰😨😧😦😮😯😲😳🤯\n" +
+            "😬😓😞😖😣😩😫😵😵‍💫🫥😴😪\n" +
+            "🤤🌛🌜🌚🌝🌞🫠😶‍🌫️🥴🥵🥶🤢\n" +
+            "🤮🤧🤒🤕😷🤠🤑😎🤓🥸🤥🤡\n" +
+            "👻💩👽🤖🎃😈👿👹👺🔥💫⭐\n" +
+            "🌟✨💥💯💢💨💦🫧💤🕳️🎉🎊\n" +
+            "🙈🙉🙊😺😸😹😻😼😽🙀😿😾\n" +
+            "❤️🧡💛💚💙💜🤎🖤🤍♥️💘💝\n" +
+            "💖💗💓💞💕💌💟❣️❤️‍🩹💔❤️‍🔥💋\n" +
+            "🫂👥👤🗣️👣🧠🫀🫁🩸🦠🦷🦴\n" +
+            "☠️💀👀👁️👄🫦👅👃👂🦻🦶🦵\n" +
+            "🦿🦾💪👍👎👏🫶🙌👐🤲🤝🤜\n" +
+            "🤛✊👊🫳🫴🫱🫲🤚👋🖐️✋🖖\n" +
+            "🤟🤘✌️🤞🫰🤙🤌🤏👌🖕☝️👆\n" +
+            "👇👉👈🫵✍️🤳🙏💅";
+
+        TextOptions options = new(font)
+        {
+            ColorFontSupport = support,
+            FallbackFontFamilies = new[] { this.noto },
+            LineSpacing = 1.15F,
+        };
+
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTextTo(renderer, text, options);
+        Assert.NotEmpty(renderer.GlyphKeys);
+
+        TextLayoutTestUtilities.TestLayout(text, options, test: test, properties: "full-string");
+    }
+
+    private sealed class LayerCaptureRenderer : GlyphRenderer
+    {
+        public List<(GlyphColor Color, float Opacity)> SolidLayers { get; } = [];
+
+        public override void BeginLayer(Paint paint, FillRule fillRule, ClipQuad? clipBounds)
+        {
+            if (paint is SolidPaint solidPaint)
+            {
+                this.SolidLayers.Add((solidPaint.Color, solidPaint.Opacity));
+            }
+
+            base.BeginLayer(paint, fillRule, clipBounds);
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request refactors how affine transforms are handled when flattening COLR v1 paint graphs, introducing a distinction between transforms applied to glyph geometry and those applied to paint nodes. It also updates the `ResolvedGlyphLayer` structure to store both transform types, and makes related adjustments in the rendering pipeline. Additionally, it improves caching and default paint handling in the SVG glyph source.

### COLR v1 Paint Graph Flattening and Transform Handling

* Refactored the `FlattenPaintToLayers` method to maintain two separate affine transforms: `glyphTransform` (applied to glyph geometry) and `paintTransform` (applied to the leaf paint node), instead of a single accumulated transform. The method now takes both transforms as parameters and updates them appropriately depending on the paint node type. [[1]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L286-R286) [[2]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L321-R323) [[3]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L349-R351) [[4]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L358-R364) [[5]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L371-R373) [[6]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L381-R393) [[7]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L396-R467) [[8]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L432-R505) [[9]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L450-R541) [[10]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L469-R562) [[11]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L479-R572)
* Updated the `ResolvedGlyphLayer` structure to store both `GlyphTransform` and `PaintTransform`, and adjusted its constructor and documentation accordingly. [[1]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L1459-R1551) [[2]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L1471-R1572) [[3]](diffhunk://#diff-ed9821151a159b3ec30a8a2dd7768981325a7db896548aeb7ea575b685a83b78L1494-R1595)
* Modified the rendering pipeline to use `GlyphTransform` for geometry transformation when constructing `PaintedLayer` instances, ensuring that solid paints are transformed correctly.

### SVG Glyph Source Improvements

* Changed the SVG glyph document cache to use a key based on document span (`(int Start, int Length)`) for improved cache accuracy and concurrency, and replaced the dictionary type with `ConcurrentDictionary`. [[1]](diffhunk://#diff-c1af5e2b5a170b37dd764a73bbdd7cee19822543e91b64cd8667006c824336f8R22-L33) [[2]](diffhunk://#diff-c1af5e2b5a170b37dd764a73bbdd7cee19822543e91b64cd8667006c824336f8L86-R86)
* Introduced a default black fill paint (`DefaultBlackFillPaint`) to be used as the inherited paint when walking SVG elements, ensuring consistent fallback rendering. [[1]](diffhunk://#diff-c1af5e2b5a170b37dd764a73bbdd7cee19822543e91b64cd8667006c824336f8R22-L33) [[2]](diffhunk://#diff-c1af5e2b5a170b37dd764a73bbdd7cee19822543e91b64cd8667006c824336f8L61-R57)
<!-- Thanks for contributing to SixLabors.Fonts! -->
