### PR TITLE
Expose resolved Font in layout and update documentation

### DIFF
--- a/src/SixLabors.Fonts/GlyphLayout.cs
+++ b/src/SixLabors.Fonts/GlyphLayout.cs
@@ -13,6 +13,7 @@ internal readonly struct GlyphLayout
 {
     internal GlyphLayout(
         Glyph glyph,
+        Font font,
         Vector2 advanceOrigin,
         Vector2 glyphOrigin,
         Vector2 decorationOrigin,
@@ -25,6 +26,7 @@ internal readonly struct GlyphLayout
         int stringIndex)
     {
         this.Glyph = glyph;
+        this.Font = font;
         this.CodePoint = glyph.GlyphMetrics.CodePoint;
         this.AdvanceOrigin = advanceOrigin;
         this.GlyphOrigin = glyphOrigin;
@@ -42,6 +44,11 @@ internal readonly struct GlyphLayout
     /// Gets the font-specific glyph for this laid-out glyph entry.
     /// </summary>
     public Glyph Glyph { get; }
+
+    /// <summary>
+    /// Gets the font used to render this laid-out glyph entry.
+    /// </summary>
+    public Font Font { get; }
 
     /// <summary>
     /// Gets the code point represented by this glyph.

--- a/src/SixLabors.Fonts/GlyphLayout.cs
+++ b/src/SixLabors.Fonts/GlyphLayout.cs
@@ -46,7 +46,7 @@ internal readonly struct GlyphLayout
     public Glyph Glyph { get; }
 
     /// <summary>
-    /// Gets the font used to render this laid-out glyph entry.
+    /// Gets the font used to shape and render this laid-out glyph entry.
     /// </summary>
     public Font Font { get; }
 

--- a/src/SixLabors.Fonts/GlyphLayoutData.cs
+++ b/src/SixLabors.Fonts/GlyphLayoutData.cs
@@ -21,6 +21,7 @@ internal struct GlyphLayoutData
     /// Initializes a new instance of the <see cref="GlyphLayoutData"/> struct.
     /// </summary>
     /// <param name="metrics">The shaped glyph metrics for this codepoint.</param>
+    /// <param name="font">The font used to shape and render this entry.</param>
     /// <param name="pointSize">The point size at which the glyph is rendered.</param>
     /// <param name="scaledAdvance">The scaled advance of this entry.</param>
     /// <param name="scaledLineHeight">The scaled line height contributed by this entry.</param>
@@ -39,6 +40,7 @@ internal struct GlyphLayoutData
     /// <param name="hyphenationMarkerIndex">The marker index to use if this entry becomes a selected soft-hyphen break.</param>
     public GlyphLayoutData(
         IReadOnlyList<FontGlyphMetrics> metrics,
+        Font font,
         float pointSize,
         float scaledAdvance,
         float scaledLineHeight,
@@ -57,6 +59,7 @@ internal struct GlyphLayoutData
         int hyphenationMarkerIndex = NoHyphenationMarker)
     {
         this.Metrics = metrics;
+        this.Font = font;
         this.PointSize = pointSize;
         this.ScaledAdvance = scaledAdvance;
         this.ScaledLineHeight = scaledLineHeight;
@@ -80,6 +83,9 @@ internal struct GlyphLayoutData
 
     /// <summary>Gets the shaped glyph metrics produced for this codepoint (one codepoint may map to several glyphs).</summary>
     public IReadOnlyList<FontGlyphMetrics> Metrics { get; }
+
+    /// <summary>Gets the font used to shape and render this entry.</summary>
+    public Font Font { get; }
 
     /// <summary>Gets the point size at which this entry is rendered.</summary>
     public float PointSize { get; }

--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -17,6 +17,7 @@ public readonly struct GlyphMetrics
     /// <param name="advance">The positioned logical advance rectangle for the glyph entry in pixel units.</param>
     /// <param name="bounds">The rendered rectangle for the glyph entry in pixel units.</param>
     /// <param name="renderableBounds">The union of the positioned logical advance rectangle and rendered rectangle in pixel units.</param>
+    /// <param name="font">The font used to render the glyph entry.</param>
     /// <param name="graphemeIndex">The grapheme index in the original text.</param>
     /// <param name="stringIndex">The UTF-16 index in the original text where the glyph entry begins.</param>
     internal GlyphMetrics(
@@ -24,6 +25,7 @@ public readonly struct GlyphMetrics
         in FontRectangle advance,
         in FontRectangle bounds,
         in FontRectangle renderableBounds,
+        Font font,
         int graphemeIndex,
         int stringIndex)
     {
@@ -31,6 +33,7 @@ public readonly struct GlyphMetrics
         this.Advance = advance;
         this.Bounds = bounds;
         this.RenderableBounds = renderableBounds;
+        this.Font = font;
         this.GraphemeIndex = graphemeIndex;
         this.StringIndex = stringIndex;
     }
@@ -54,6 +57,11 @@ public readonly struct GlyphMetrics
     /// Gets the union of the positioned logical advance rectangle and rendered rectangle in pixel units.
     /// </summary>
     public FontRectangle RenderableBounds { get; }
+
+    /// <summary>
+    /// Gets the font used to render the glyph entry.
+    /// </summary>
+    public Font Font { get; }
 
     /// <summary>
     /// Gets the zero-based grapheme index in the original text.

--- a/src/SixLabors.Fonts/GlyphMetrics.cs
+++ b/src/SixLabors.Fonts/GlyphMetrics.cs
@@ -17,7 +17,7 @@ public readonly struct GlyphMetrics
     /// <param name="advance">The positioned logical advance rectangle for the glyph entry in pixel units.</param>
     /// <param name="bounds">The rendered rectangle for the glyph entry in pixel units.</param>
     /// <param name="renderableBounds">The union of the positioned logical advance rectangle and rendered rectangle in pixel units.</param>
-    /// <param name="font">The font used to render the glyph entry.</param>
+    /// <param name="font">The font used to shape and render the glyph entry.</param>
     /// <param name="graphemeIndex">The grapheme index in the original text.</param>
     /// <param name="stringIndex">The UTF-16 index in the original text where the glyph entry begins.</param>
     internal GlyphMetrics(
@@ -59,7 +59,7 @@ public readonly struct GlyphMetrics
     public FontRectangle RenderableBounds { get; }
 
     /// <summary>
-    /// Gets the font used to render the glyph entry.
+    /// Gets the font used to shape and render the glyph entry.
     /// </summary>
     public Font Font { get; }
 

--- a/src/SixLabors.Fonts/GlyphPositioningCollection.cs
+++ b/src/SixLabors.Fonts/GlyphPositioningCollection.cs
@@ -236,7 +236,7 @@ internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
                             : new(0, 0, metrics.AdvanceWidth, 0);
 
                         // Track the number of inserted glyphs at the offset so we can correctly increment our position.
-                        this.glyphs.Insert(i += replacementCount, new(offset, new(shape, true) { Bounds = bounds }, pointSize, metrics.CloneForRendering(shape.TextRun)));
+                        this.glyphs.Insert(i += replacementCount, new(offset, new(shape, true) { Bounds = bounds }, font, pointSize, metrics.CloneForRendering(shape.TextRun)));
                         replacementCount++;
                     }
                 }
@@ -307,7 +307,7 @@ internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
                     IsPositioned = true
                 };
 
-                this.glyphs.Add(new(offset, placeholderData, font.Size, placeholderMetrics));
+                this.glyphs.Add(new(offset, placeholderData, font, font.Size, placeholderMetrics));
                 continue;
             }
 
@@ -336,7 +336,7 @@ internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
                 ? new(0, 0, 0, metrics.AdvanceHeight)
                 : new(0, 0, metrics.AdvanceWidth, 0);
 
-            this.glyphs.Add(new(offset, new(data, true) { Bounds = bounds }, font.Size, metrics.CloneForRendering(data.TextRun)));
+            this.glyphs.Add(new(offset, new(data, true) { Bounds = bounds }, font, font.Size, metrics.CloneForRendering(data.TextRun)));
         }
 
         return !hasFallBacks;
@@ -433,10 +433,11 @@ internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GlyphPositioningData
     {
-        public GlyphPositioningData(int offset, GlyphShapingData data, float pointSize, FontGlyphMetrics metrics)
+        public GlyphPositioningData(int offset, GlyphShapingData data, Font font, float pointSize, FontGlyphMetrics metrics)
         {
             this.Offset = offset;
             this.Data = data;
+            this.Font = font;
             this.PointSize = pointSize;
             this.Metrics = metrics;
         }
@@ -444,6 +445,8 @@ internal sealed class GlyphPositioningCollection : IGlyphShapingCollection
         public int Offset { get; set; }
 
         public GlyphShapingData Data { get; set; }
+
+        public Font Font { get; set; }
 
         public float PointSize { get; set; }
 

--- a/src/SixLabors.Fonts/GraphemeMetrics.cs
+++ b/src/SixLabors.Fonts/GraphemeMetrics.cs
@@ -14,6 +14,7 @@ public readonly struct GraphemeMetrics
     /// <param name="advance">The positioned logical advance rectangle for the grapheme in pixel units.</param>
     /// <param name="bounds">The rendered glyph bounds for the grapheme in pixel units.</param>
     /// <param name="renderableBounds">The union of the positioned logical advance bounds and rendered glyph bounds in pixel units.</param>
+    /// <param name="font">The font used for the grapheme's first glyph entry.</param>
     /// <param name="graphemeIndex">The grapheme index in the original text.</param>
     /// <param name="stringIndex">The UTF-16 index in the original text where the grapheme begins.</param>
     /// <param name="bidiLevel">The resolved bidi embedding level.</param>
@@ -22,6 +23,7 @@ public readonly struct GraphemeMetrics
         FontRectangle advance,
         FontRectangle bounds,
         FontRectangle renderableBounds,
+        Font font,
         int graphemeIndex,
         int stringIndex,
         int bidiLevel,
@@ -30,6 +32,7 @@ public readonly struct GraphemeMetrics
         this.Advance = advance;
         this.Bounds = bounds;
         this.RenderableBounds = renderableBounds;
+        this.Font = font;
         this.GraphemeIndex = graphemeIndex;
         this.StringIndex = stringIndex;
         this.BidiLevel = bidiLevel;
@@ -50,6 +53,11 @@ public readonly struct GraphemeMetrics
     /// Gets the union of the positioned logical advance bounds and rendered glyph bounds in pixel units.
     /// </summary>
     public FontRectangle RenderableBounds { get; }
+
+    /// <summary>
+    /// Gets the font used for the grapheme's first glyph entry.
+    /// </summary>
+    public Font Font { get; }
 
     /// <summary>
     /// Gets the zero-based grapheme index in the original text.

--- a/src/SixLabors.Fonts/GraphemeMetrics.cs
+++ b/src/SixLabors.Fonts/GraphemeMetrics.cs
@@ -14,7 +14,7 @@ public readonly struct GraphemeMetrics
     /// <param name="advance">The positioned logical advance rectangle for the grapheme in pixel units.</param>
     /// <param name="bounds">The rendered glyph bounds for the grapheme in pixel units.</param>
     /// <param name="renderableBounds">The union of the positioned logical advance bounds and rendered glyph bounds in pixel units.</param>
-    /// <param name="font">The font used for the grapheme's first glyph entry.</param>
+    /// <param name="font">The font used to shape and render the grapheme.</param>
     /// <param name="graphemeIndex">The grapheme index in the original text.</param>
     /// <param name="stringIndex">The UTF-16 index in the original text where the grapheme begins.</param>
     /// <param name="bidiLevel">The resolved bidi embedding level.</param>
@@ -55,7 +55,7 @@ public readonly struct GraphemeMetrics
     public FontRectangle RenderableBounds { get; }
 
     /// <summary>
-    /// Gets the font used for the grapheme's first glyph entry.
+    /// Gets the font used to shape and render the grapheme.
     /// </summary>
     public Font Font { get; }
 

--- a/src/SixLabors.Fonts/TextBlock.Visitors.cs
+++ b/src/SixLabors.Fonts/TextBlock.Visitors.cs
@@ -77,6 +77,7 @@ public sealed partial class TextBlock
         private int stringIndex;
         private int bidiLevel;
         private bool isLineBreak;
+        private Font? font;
         private FontRectangle advanceBounds;
         private FontRectangle bounds;
         private bool hasCurrent;
@@ -95,6 +96,7 @@ public sealed partial class TextBlock
             this.stringIndex = 0;
             this.bidiLevel = 0;
             this.isLineBreak = false;
+            this.font = null;
             this.advanceBounds = FontRectangle.Empty;
             this.bounds = FontRectangle.Empty;
             this.hasCurrent = false;
@@ -174,6 +176,7 @@ public sealed partial class TextBlock
             this.stringIndex = glyph.StringIndex;
             this.bidiLevel = glyph.BidiLevel;
             this.isLineBreak = CodePoint.IsNewLine(glyph.CodePoint);
+            this.font = glyph.Font;
             this.advanceBounds = advanceBounds;
             this.bounds = bounds;
             this.hasCurrent = true;
@@ -197,6 +200,7 @@ public sealed partial class TextBlock
                 this.advanceBounds,
                 this.bounds,
                 renderableBounds,
+                this.font!,
                 this.graphemeIndex,
                 this.stringIndex,
                 this.bidiLevel,
@@ -750,6 +754,7 @@ public sealed partial class TextBlock
                 advance,
                 bounds,
                 renderableBounds,
+                glyph.Font,
                 glyph.GraphemeIndex,
                 glyph.StringIndex);
 

--- a/src/SixLabors.Fonts/TextLayout.LineBreaking.cs
+++ b/src/SixLabors.Fonts/TextLayout.LineBreaking.cs
@@ -269,6 +269,8 @@ internal static partial class TextLayout
                     int graphemeCodePointMax = CodePoint.GetCodePointCount(grapheme) - 1;
 
                     // For non-decomposed glyphs the length is always 1.
+                    int glyphDataIndex = 0;
+
                     for (int i = 0; i < decomposedAdvances.Length; i++)
                     {
                         // Determine if this is the last codepoint in the grapheme.
@@ -277,7 +279,13 @@ internal static partial class TextLayout
                         float decomposedAdvance = decomposedAdvances[i];
 
                         // Work out the scaled metrics for the glyph.
-                        FontGlyphMetrics metric = metrics[i];
+                        while (glyphData[glyphDataIndex].Data.IsPlaceholder)
+                        {
+                            glyphDataIndex++;
+                        }
+
+                        GlyphPositioningCollection.GlyphPositioningData positionedGlyph = glyphData[glyphDataIndex];
+                        FontGlyphMetrics metric = positionedGlyph.Metrics;
 
                         // Adjust the advance for the last decomposed glyph to add tracking if applicable.
                         // Tracking should only be added once per grapheme, so only on the last codepoint of the grapheme.
@@ -357,12 +365,14 @@ internal static partial class TextLayout
                                 stringIndex,
                                 hyphenationMarkerCodePoint.Value,
                                 shapedText.LayoutMode,
+                                positionedGlyph.Font,
                                 options));
                         }
 
                         // Add our metrics to the line.
                         textLine.Add(
                             isDecomposed ? new FontGlyphMetrics[] { metric } : metrics,
+                            positionedGlyph.Font,
                             pointSize,
                             decomposedAdvance,
                             lineHeight,
@@ -380,6 +390,8 @@ internal static partial class TextLayout
                             mode,
                             options.LineSpacing,
                             hyphenationMarkerIndex);
+
+                        glyphDataIndex++;
                     }
 
                     codePointIndex++;
@@ -548,6 +560,7 @@ internal static partial class TextLayout
     /// <param name="stringIndex">The UTF-16 source index to map the marker to.</param>
     /// <param name="markerCodePoint">The marker codepoint to create.</param>
     /// <param name="layoutMode">The layout mode used to calculate marker orientation.</param>
+    /// <param name="font">The font used to shape and render the marker.</param>
     /// <param name="options">The text options used for layout.</param>
     /// <returns>The generated marker entry.</returns>
     internal static GlyphLayoutData CreateGeneratedMarker(
@@ -561,6 +574,7 @@ internal static partial class TextLayout
         int stringIndex,
         CodePoint markerCodePoint,
         LayoutMode layoutMode,
+        Font font,
         TextOptions options)
     {
         anchorMetric.FontMetrics.TryGetGlyphId(markerCodePoint, out ushort markerGlyphId);
@@ -624,6 +638,7 @@ internal static partial class TextLayout
 
         return new GlyphLayoutData(
             new FontGlyphMetrics[] { markerMetric },
+            font,
             pointSize,
             markerAdvance,
             markerLineHeight * options.LineSpacing,

--- a/src/SixLabors.Fonts/TextLayout.cs
+++ b/src/SixLabors.Fonts/TextLayout.cs
@@ -562,6 +562,7 @@ internal static partial class TextLayout
                 visitor.Visit(
                     new GlyphLayout(
                     new Glyph(metric, data.PointSize),
+                    data.Font,
                     boundsLocation,
                     hardBreakGlyphOrigin,
                     penLocation,
@@ -590,6 +591,7 @@ internal static partial class TextLayout
                 visitor.Visit(
                     new GlyphLayout(
                     new Glyph(metric, data.PointSize),
+                    data.Font,
                     boundsLocation,
                     glyphOrigin,
                     glyphOrigin,
@@ -770,6 +772,7 @@ internal static partial class TextLayout
                 visitor.Visit(
                     new GlyphLayout(
                     new Glyph(metric, data.PointSize),
+                    data.Font,
                     boundsLocation,
                     hardBreakGlyphOrigin,
                     hardBreakDecorationOrigin,
@@ -924,6 +927,7 @@ internal static partial class TextLayout
                 visitor.Visit(
                     new GlyphLayout(
                     new Glyph(metric, data.PointSize),
+                    data.Font,
                     boundsLocation,
                     glyphOrigin,
                     decorationOrigin,
@@ -1103,6 +1107,7 @@ internal static partial class TextLayout
                 visitor.Visit(
                     new GlyphLayout(
                     new Glyph(metric, data.PointSize),
+                    data.Font,
                     boundsLocation,
                     hardBreakGlyphOrigin,
                     hardBreakDecorationOrigin,
@@ -1148,6 +1153,7 @@ internal static partial class TextLayout
                     visitor.Visit(
                         new GlyphLayout(
                         new Glyph(metric, data.PointSize),
+                        data.Font,
                         boundsLocation,
                         glyphOrigin,
                         glyphOrigin,
@@ -1182,6 +1188,7 @@ internal static partial class TextLayout
                     visitor.Visit(
                         new GlyphLayout(
                         new Glyph(metric, data.PointSize),
+                        data.Font,
                         boundsLocation,
                         glyphOrigin,
                         decorationOrigin,

--- a/src/SixLabors.Fonts/TextLine.cs
+++ b/src/SixLabors.Fonts/TextLine.cs
@@ -142,6 +142,7 @@ internal sealed class TextLine
     /// Appends a shaped entry to this line, updating the aggregated line-level metrics.
     /// </summary>
     /// <param name="metrics">The glyph metrics produced by shaping this entry's codepoint.</param>
+    /// <param name="font">The font used to shape and render this entry.</param>
     /// <param name="pointSize">The point size at which the entry is rendered.</param>
     /// <param name="scaledAdvance">The scaled advance contributed by this entry.</param>
     /// <param name="scaledLineHeight">The scaled line height contributed by this entry (before line-spacing).</param>
@@ -161,6 +162,7 @@ internal sealed class TextLine
     /// <param name="hyphenationMarkerIndex">The marker index to use if this entry becomes a selected soft-hyphen break.</param>
     public void Add(
         IReadOnlyList<FontGlyphMetrics> metrics,
+        Font font,
         float pointSize,
         float scaledAdvance,
         float scaledLineHeight,
@@ -224,6 +226,7 @@ internal sealed class TextLine
 
         this.data.Add(new(
             metrics,
+            font,
             pointSize,
             scaledAdvance,
             scaledLineHeight,
@@ -300,6 +303,7 @@ internal sealed class TextLine
         // but they do not consume source grapheme, codepoint, or UTF-16 indexes.
         this.Add(
             new FontGlyphMetrics[] { placeholderGlyph },
+            placeholder.Font,
             placeholder.PointSize,
             placeholderAdvance,
             placeholderLineHeight,
@@ -419,6 +423,7 @@ internal sealed class TextLine
             anchor.StringIndex,
             markerCodePoint,
             options.LayoutMode,
+            anchor.Font,
             options);
 
         while (this.data.Count > 0 &&

--- a/tests/SixLabors.Fonts.Tests/TextBlockTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextBlockTests.cs
@@ -351,6 +351,26 @@ public class TextBlockTests
     }
 
     [Fact]
+    public void CharacterMeasurements_ExposeResolvedFallbackFont()
+    {
+        FontCollection collection = new();
+        FontFamily hebrew = TestFonts.GetFontFamily(collection, TestFonts.NotoSansHebrewRegular);
+        Font primary = TextLayoutTests.CreateFont("A");
+        Font fallback = hebrew.CreateFont(12);
+        TextOptions options = new(primary)
+        {
+            FallbackFontFamilies = [hebrew]
+        };
+
+        TextMetrics metrics = TextMeasurer.Measure("Aא", options);
+        GlyphMetrics hebrewGlyph = FindGlyph(metrics.GetGlyphMetrics().Span, 1);
+        GraphemeMetrics hebrewGrapheme = FindGrapheme(metrics.GraphemeMetrics, 1);
+
+        Assert.Equal(fallback.Name, hebrewGlyph.Font.Name);
+        Assert.Equal(fallback.Name, hebrewGrapheme.Font.Name);
+    }
+
+    [Fact]
     public void TextHyphenation_None_IgnoresSoftHyphenBreak()
     {
         const string text = "extra\u00ADordinary";
@@ -1337,6 +1357,19 @@ public class TextBlockTests
         throw new InvalidOperationException("The expected grapheme was not measured.");
     }
 
+    private static GlyphMetrics FindGlyph(ReadOnlySpan<GlyphMetrics> glyphs, int stringIndex)
+    {
+        for (int i = 0; i < glyphs.Length; i++)
+        {
+            if (glyphs[i].StringIndex == stringIndex)
+            {
+                return glyphs[i];
+            }
+        }
+
+        throw new InvalidOperationException("The expected glyph was not measured.");
+    }
+
     private static bool SelectionContains(ReadOnlySpan<FontRectangle> selection, Vector2 point)
     {
         for (int i = 0; i < selection.Length; i++)
@@ -1400,6 +1433,7 @@ public class TextBlockTests
         Assert.Equal(expected.Advance, actual.Advance, Comparer);
         Assert.Equal(expected.Bounds, actual.Bounds, Comparer);
         Assert.Equal(expected.RenderableBounds, actual.RenderableBounds, Comparer);
+        Assert.Equal(expected.Font.Name, actual.Font.Name);
         Assert.Equal(expected.GraphemeIndex, actual.GraphemeIndex);
         Assert.Equal(expected.StringIndex, actual.StringIndex);
     }
@@ -1412,6 +1446,7 @@ public class TextBlockTests
             Assert.Equal(expected[i].Advance, actual[i].Advance, Comparer);
             Assert.Equal(expected[i].Bounds, actual[i].Bounds, Comparer);
             Assert.Equal(expected[i].RenderableBounds, actual[i].RenderableBounds, Comparer);
+            Assert.Equal(expected[i].Font.Name, actual[i].Font.Name);
             Assert.Equal(expected[i].GraphemeIndex, actual[i].GraphemeIndex);
             Assert.Equal(expected[i].StringIndex, actual[i].StringIndex);
             Assert.Equal(expected[i].BidiLevel, actual[i].BidiLevel);

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -236,15 +236,14 @@ public class TextLayoutTests
     public void GetGlyphMetrics()
     {
         const string text = "a b\nc";
+        Font font = CreateFont(text);
         GlyphMetrics[] expectedGlyphMetrics =
         [
-            new(new CodePoint('a'), FontRectangle.Empty, new FontRectangle(10, 0, 10, 10), FontRectangle.Empty, 0, 0),
-            new(new CodePoint(' '), FontRectangle.Empty, new FontRectangle(40, 0, 30, 10), FontRectangle.Empty, 1, 1),
-            new(new CodePoint('b'), FontRectangle.Empty, new FontRectangle(70, 0, 10, 10), FontRectangle.Empty, 2, 2),
-            new(new CodePoint('c'), FontRectangle.Empty, new FontRectangle(10, 30, 10, 10), FontRectangle.Empty, 4, 4),
+            new(new CodePoint('a'), FontRectangle.Empty, new FontRectangle(10, 0, 10, 10), FontRectangle.Empty, font, 0, 0),
+            new(new CodePoint(' '), FontRectangle.Empty, new FontRectangle(40, 0, 30, 10), FontRectangle.Empty, font, 1, 1),
+            new(new CodePoint('b'), FontRectangle.Empty, new FontRectangle(70, 0, 10, 10), FontRectangle.Empty, font, 2, 2),
+            new(new CodePoint('c'), FontRectangle.Empty, new FontRectangle(10, 30, 10, 10), FontRectangle.Empty, font, 4, 4),
         ];
-
-        Font font = CreateFont(text);
 
         ReadOnlySpan<GlyphMetrics> glyphs = TextMeasurer.GetGlyphMetrics(
             text.AsSpan(),

--- a/tests/SixLabors.Fonts.Tests/TextMeasurerReferenceTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextMeasurerReferenceTests.cs
@@ -177,6 +177,7 @@ public class TextMeasurerReferenceTests
                 new FontRectangle(0, 0, 8.8477f, 12f),
                 new FontRectangle(1.1719f, 2.0889f, 6.4922f, 8.5664f),
                 new FontRectangle(0f, 0f, 8.8477f, 12f),
+                Font,
                 0,
                 0),
             new(
@@ -184,6 +185,7 @@ public class TextMeasurerReferenceTests
                 new FontRectangle(8.8477f, 0, 3.0293f, 12f),
                 new FontRectangle(9.7852f, 1.8311f, 1.1719f, 8.8242f),
                 new FontRectangle(8.8477f, 0f, 3.0293f, 12f),
+                Font,
                 1,
                 1),
             new(
@@ -191,6 +193,7 @@ public class TextMeasurerReferenceTests
                 new FontRectangle(11.877f, 0, 3.1699f, 12f),
                 new FontRectangle(12.7559f, 2.0889f, 1.3945f, 8.7305f),
                 new FontRectangle(11.877f, 0f, 3.1699f, 12f),
+                Font,
                 2,
                 2),
         ];
@@ -210,6 +213,7 @@ public class TextMeasurerReferenceTests
                 new FontRectangle(0, 0, 8.8477f, 12f),
                 new FontRectangle(1.1719f, 2.0889f, 6.4922f, 8.5664f),
                 new FontRectangle(0, 0, 8.8477f, 12f),
+                Font,
                 0,
                 0,
                 0,
@@ -218,6 +222,7 @@ public class TextMeasurerReferenceTests
                 new FontRectangle(8.8477f, 0, 3.0293f, 12f),
                 new FontRectangle(9.7852f, 1.8311f, 1.1719f, 8.8242f),
                 new FontRectangle(8.8477f, 0, 3.0293f, 12f),
+                Font,
                 1,
                 1,
                 0,
@@ -226,6 +231,7 @@ public class TextMeasurerReferenceTests
                 new FontRectangle(11.877f, 0, 3.1699f, 12f),
                 new FontRectangle(12.7559f, 2.0889f, 1.3945f, 8.7305f),
                 new FontRectangle(11.877f, 0, 3.1699f, 12f),
+                Font,
                 2,
                 2,
                 0,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request enhances the font rendering pipeline by ensuring that the `Font` used for shaping and rendering is explicitly tracked and propagated throughout the glyph layout, metrics, and positioning data structures. This change improves traceability and correctness in text rendering, especially in scenarios involving multiple fonts.

Key changes include:

**Propagation of Font Information:**

* Added a `Font` property to the `GlyphLayout`, `GlyphLayoutData`, `GlyphMetrics`, `GraphemeMetrics`, and `GlyphPositioningData` structs/classes, and updated their constructors to accept and store the font used for shaping and rendering. [[1]](diffhunk://#diff-246439e4b06e25ef1a1e96c95ddea25c91a581d6c03ad358bbe5f4c1a7f3b9e3R16) [[2]](diffhunk://#diff-246439e4b06e25ef1a1e96c95ddea25c91a581d6c03ad358bbe5f4c1a7f3b9e3R29) [[3]](diffhunk://#diff-246439e4b06e25ef1a1e96c95ddea25c91a581d6c03ad358bbe5f4c1a7f3b9e3R48-R52) [[4]](diffhunk://#diff-968b3e1345ffa0eee2b24d645fd33a0262350a18410936e13d17b8ccc0e29241R24) [[5]](diffhunk://#diff-968b3e1345ffa0eee2b24d645fd33a0262350a18410936e13d17b8ccc0e29241R43) [[6]](diffhunk://#diff-968b3e1345ffa0eee2b24d645fd33a0262350a18410936e13d17b8ccc0e29241R62) [[7]](diffhunk://#diff-968b3e1345ffa0eee2b24d645fd33a0262350a18410936e13d17b8ccc0e29241R87-R89) [[8]](diffhunk://#diff-8bbd68bd7967f4b40c17ea6f4de2c092859c9cd2162625eee2b5662037ad9669R20-R36) [[9]](diffhunk://#diff-8bbd68bd7967f4b40c17ea6f4de2c092859c9cd2162625eee2b5662037ad9669R61-R65) [[10]](diffhunk://#diff-e378d71b3d2927a367942503e71b8fb6b7da490e84fee3a329fffc44e307ee0fR17) [[11]](diffhunk://#diff-e378d71b3d2927a367942503e71b8fb6b7da490e84fee3a329fffc44e307ee0fR26) [[12]](diffhunk://#diff-e378d71b3d2927a367942503e71b8fb6b7da490e84fee3a329fffc44e307ee0fR35) [[13]](diffhunk://#diff-e378d71b3d2927a367942503e71b8fb6b7da490e84fee3a329fffc44e307ee0fR57-R61) [[14]](diffhunk://#diff-9b3d3fc181553c69d3f2a43e3cb4eb89e48f6c71e0a5b7163853463c649170fdL436-R440) [[15]](diffhunk://#diff-9b3d3fc181553c69d3f2a43e3cb4eb89e48f6c71e0a5b7163853463c649170fdR449-R450)

**Updates to Glyph Positioning and Line Breaking:**

* Modified `GlyphPositioningCollection` methods and `GlyphPositioningData` to receive and store the `Font` instance, ensuring that font information is preserved during glyph substitution and addition. [[1]](diffhunk://#diff-9b3d3fc181553c69d3f2a43e3cb4eb89e48f6c71e0a5b7163853463c649170fdL239-R239) [[2]](diffhunk://#diff-9b3d3fc181553c69d3f2a43e3cb4eb89e48f6c71e0a5b7163853463c649170fdL310-R310) [[3]](diffhunk://#diff-9b3d3fc181553c69d3f2a43e3cb4eb89e48f6c71e0a5b7163853463c649170fdL339-R339)
* Updated line breaking and text layout logic to propagate the `Font` when creating `GlyphLayoutData` and generated markers, and to use the correct font when constructing metrics and visiting glyphs. [[1]](diffhunk://#diff-5aad0c488bfef82a34591a4b24d849191a7c64118bc568f7e3fde88f0d8f445dR272-R273) [[2]](diffhunk://#diff-5aad0c488bfef82a34591a4b24d849191a7c64118bc568f7e3fde88f0d8f445dL280-R288) [[3]](diffhunk://#diff-5aad0c488bfef82a34591a4b24d849191a7c64118bc568f7e3fde88f0d8f445dR368-R375) [[4]](diffhunk://#diff-5aad0c488bfef82a34591a4b24d849191a7c64118bc568f7e3fde88f0d8f445dR393-R394) [[5]](diffhunk://#diff-5aad0c488bfef82a34591a4b24d849191a7c64118bc568f7e3fde88f0d8f445dR563) [[6]](diffhunk://#diff-5aad0c488bfef82a34591a4b24d849191a7c64118bc568f7e3fde88f0d8f445dR577) [[7]](diffhunk://#diff-5aad0c488bfef82a34591a4b24d849191a7c64118bc568f7e3fde88f0d8f445dR641) [[8]](diffhunk://#diff-d4b7f4ba1427f72f4e4ef98a983bee5e58250bc7260f41922b8647f3ff6514e3R565)

**Internal Visitor and Accumulator Adjustments:**

* Extended the `GraphemeMetricsAccumulator` and related visitor logic to track and pass the `Font` for each grapheme, ensuring accurate font association during text block processing. [[1]](diffhunk://#diff-ba3f59e468d47255a959d447eb0765601d7c4ea70ae402524f84317ec2a8fe56R80) [[2]](diffhunk://#diff-ba3f59e468d47255a959d447eb0765601d7c4ea70ae402524f84317ec2a8fe56R99) [[3]](diffhunk://#diff-ba3f59e468d47255a959d447eb0765601d7c4ea70ae402524f84317ec2a8fe56R179) [[4]](diffhunk://#diff-ba3f59e468d47255a959d447eb0765601d7c4ea70ae402524f84317ec2a8fe56R203) [[5]](diffhunk://#diff-ba3f59e468d47255a959d447eb0765601d7c4ea70ae402524f84317ec2a8fe56R757)

These changes collectively improve the accuracy and maintainability of font handling in the text rendering pipeline.
<!-- Thanks for contributing to SixLabors.Fonts! -->
