### PR TITLE
Fix loading SVG table with 0 entries

### DIFF
--- a/src/SixLabors.Fonts/Tables/General/Svg/SvgTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/Svg/SvgTable.cs
@@ -74,8 +74,8 @@ internal class SvgTable : Table
     /// Loads the SVG table from the specified binary reader.
     /// </summary>
     /// <param name="reader">The binary reader positioned at the start of the SVG table.</param>
-    /// <returns>The <see cref="SvgTable"/>.</returns>
-    public static SvgTable Load(BigEndianBinaryReader reader)
+    /// <returns>The <see cref="SvgTable"/>, or <see langword="null"/> if the table is not valid in the font.</returns>
+    public static SvgTable? Load(BigEndianBinaryReader reader)
     {
         // HEADER
         // | Type     | Name              | Description                                               |
@@ -99,6 +99,12 @@ internal class SvgTable : Table
         // | Entry[numEntries] | entries    | Array of SVG Document Index Entries(sorted by startGlyphID).|
         reader.Seek(svgDocIndexOffset, SeekOrigin.Begin);
         ushort numEntries = reader.ReadUInt16();
+        if (numEntries == 0)
+        {
+            // The spec says the number of entries must be non-zero.
+            return null;
+        }
+
         SvgDocumentIndexEntry[] entries = new SvgDocumentIndexEntry[numEntries];
 
         // SVG Document Index Entry

--- a/tests/Fonts/Issues/Issue534.ttf
+++ b/tests/Fonts/Issues/Issue534.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e73d67f92457bd05d24c42f43156bc422e98982e9e62d267ad6d1a3cc595bb01
+size 93580

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_534.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_534.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.Fonts.Tests.Issues;
+
+public class Issues_534
+{
+    [Fact]
+    public void ShouldLoadFontWithSvgTableHavingZeroEntries()
+        => TestFonts.GetFont(TestFonts.Issues.Issue534, 12);
+}

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_534.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_534.cs
@@ -7,5 +7,11 @@ public class Issues_534
 {
     [Fact]
     public void ShouldLoadFontWithSvgTableHavingZeroEntries()
-        => TestFonts.GetFont(TestFonts.Issues.Issue534, 12);
+    {
+        Font font = TestFonts.GetFont(TestFonts.Issues.Issue534, 12);
+
+        FontRectangle size = TextMeasurer.MeasureBounds("ABCabc123", new TextOptions(font));
+
+        Assert.NotEqual(FontRectangle.Empty, size);
+    }
 }

--- a/tests/SixLabors.Fonts.Tests/TestFonts.cs
+++ b/tests/SixLabors.Fonts.Tests/TestFonts.cs
@@ -414,6 +414,8 @@ public static class TestFonts
         public static string Issue512 => GetFullPath("Issues/Issue512.otf");
 
         public static string Issue514 => GetFullPath("Issues/Issue514.ttf");
+
+        public static string Issue534 => GetFullPath("Issues/Issue534.ttf");
     }
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #534.

This changes `SvgTable.Load(BigEndianBinaryReader)` to return `null` when the SVG table has 0 entries. Its only caller is `SvgTable.Load(FontReader)`, which can already return `null` if the table isn't found. 

Added font is licensed CC0: https://ggbot.itch.io/home-video-font

### Thought Process
I have no experience with fonts but it seemed like a straightforward change.

When running the debugger, I saw `BigEndianBinaryReader.ReadBytes` was called with a `-9` count:
<img width="753" height="197" alt="image" src="https://github.com/user-attachments/assets/db4df8f5-2e12-47a7-9d1c-20cb8434d0c0" />

In the caller `SvgTable.Load` the `numEntries` value was read as `0`.
<img width="1031" height="365" alt="image" src="https://github.com/user-attachments/assets/2745c435-edf5-4075-9c53-08698666d414" />

This leaves `minRelOffset` and `maxEnd` at their initial values since the `i < numEntries` loop has nothing to do. The addition to calculate `tableStart` wraps (`(uint) 10 + uint.MaxValue = 9`). Then the integer subtraction calculates a negative `byteCount` (`(int)(0 - 9) = -9`).

<img width="1068" height="198" alt="image" src="https://github.com/user-attachments/assets/361d665f-3f2f-4228-abdf-7e1f346b6844" />

The easiest approach was to treat an empty table as the table being missing, even though having no entries doesn't appear to be allowed in the spec. This specific font was working in the previous Fonts version and other programs are able to load and render it, so I think it isn't _so_ invalid that it can't work.