### PR TITLE
Fix TrueTypeInterpreter pool state pollution

### DIFF
--- a/src/SixLabors.Fonts/Tables/TrueType/Hinting/TrueTypeInterpreter.cs
+++ b/src/SixLabors.Fonts/Tables/TrueType/Hinting/TrueTypeInterpreter.cs
@@ -55,6 +55,13 @@ internal partial class TrueTypeInterpreter
     // (see WS instruction) so that prep state is preserved across glyphs.
     private int[] storage;
     private int[]? prepStorage;
+
+    // Snapshot of the storage area immediately after the font program (fpgm) runs. A freshly
+    // created interpreter executes fpgm once, which may seed storage locations that the prep
+    // (CVT) program later reads. When a pooled interpreter is reused for a new pixel size the
+    // prep program is re-run, so storage must be restored to this post-fpgm baseline rather
+    // than being left in its previous (glyph-modified) state.
+    private int[] fpgmStorage;
     private bool inGlyphProgram;
 
     private IReadOnlyList<ushort> contours;
@@ -131,6 +138,7 @@ internal partial class TrueTypeInterpreter
         this.twilight = new Zone(maxTwilightPoints, isTwilight: true);
         this.controlValueTable = [];
         this.baseControlValueTable = [];
+        this.fpgmStorage = [];
         this.contours = [];
     }
 
@@ -148,7 +156,13 @@ internal partial class TrueTypeInterpreter
     /// </summary>
     /// <param name="instructions">The raw font program bytecode.</param>
     public void InitializeFunctionDefs(byte[] instructions)
-        => this.Execute(new StackInstructionStream(instructions, 0), false, true);
+    {
+        this.Execute(new StackInstructionStream(instructions, 0), false, true);
+
+        // Capture the post-fpgm storage so it can be restored whenever the prep program is
+        // re-run for a new size on a reused (pooled) interpreter.
+        this.fpgmStorage = (int[])this.storage.Clone();
+    }
 
     /// <summary>
     /// Scales the Control Value Table and executes the prep (CVT) program.
@@ -181,9 +195,39 @@ internal partial class TrueTypeInterpreter
 
         this.scale = scale;
         this.ppem = (int)Math.Round(ppem);
-        this.zp0 = this.zp1 = this.zp2 = this.points;
         this.state.Reset();
         this.stack.Clear();
+
+        // Restore the interpreter to the same state a freshly created interpreter would be in
+        // immediately before running the prep program. A pooled interpreter may have been used
+        // to hint glyphs at a previous size, leaving behind storage writes, twilight points,
+        // rounding state and zone pointers. The prep program reads and builds on this state, so
+        // without restoring it the prep result — and therefore the hinted outline — depends on
+        // the interpreter's history. That made hinting non-deterministic when a font family was
+        // rendered concurrently from a shared interpreter pool (see issue #484).
+        this.ResetTwilightZone();
+        if (this.storage.Length == this.fpgmStorage.Length)
+        {
+            Array.Copy(this.fpgmStorage, this.storage, this.fpgmStorage.Length);
+        }
+        else
+        {
+            this.storage = (int[])this.fpgmStorage.Clone();
+        }
+
+        this.prepStorage = null;
+        this.inGlyphProgram = false;
+        this.callStackSize = 0;
+        this.fdotp = 0;
+        this.roundThreshold = 0;
+        this.roundPhase = 0;
+        this.roundPeriod = 0;
+        this.iupXCalled = false;
+        this.iupYCalled = false;
+        this.isComposite = false;
+        this.contours = [];
+        this.points = default;
+        this.zp0 = this.zp1 = this.zp2 = this.points;
 
         if (cvProgram != null)
         {

--- a/tests/SixLabors.Fonts.Tests/HintingTests.cs
+++ b/tests/SixLabors.Fonts.Tests/HintingTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Numerics;
 using System.Text;
+using SixLabors.Fonts.Rendering;
 using SixLabors.Fonts.Unicode;
 
 namespace SixLabors.Fonts.Tests;
@@ -69,5 +71,59 @@ public class HintingTests
             text,
             options,
             properties: name);
+    }
+
+    // The TrueType bytecode interpreter is pooled and reused across renders for the same
+    // font. When a pooled interpreter is reused for a different pixel size it re-runs the
+    // font's prep (CVT) program, which must execute from the same pristine state as a freshly
+    // created interpreter. If transient interpreter state (twilight zone, storage, rounding
+    // state, zone pointers, ...) is not reset first, the prep result — and therefore the
+    // hinted glyph outline — depends on which sizes were rendered previously on that
+    // interpreter. Because interpreters are shared through a pool, that made hinting output
+    // non-deterministic when a single font family was rendered concurrently from multiple
+    // threads
+    [Fact]
+    public void Hinting_OutputIsIndependentOfPreviouslyRenderedSizes()
+    {
+        const string text = "The quick brown fox 12345";
+        const float dpi = 150F;
+        const float targetSize = 7F;
+        const float otherSize = 12F;
+
+        static List<Vector2> RenderControlPoints(string text, float size, float dpi, float? warmUpSize)
+        {
+            FontCollection collection = new();
+            FontFamily family = collection.Add(TestFonts.Arial);
+
+            if (warmUpSize is { } w)
+            {
+                RenderTo(family, text, w, dpi, new GlyphRenderer());
+            }
+
+            GlyphRenderer renderer = new();
+            RenderTo(family, text, size, dpi, renderer);
+            return renderer.ControlPoints;
+        }
+
+        static void RenderTo(FontFamily family, string text, float size, float dpi, GlyphRenderer renderer)
+        {
+            Font font = family.CreateFont(size);
+            TextOptions options = new(font)
+            {
+                Dpi = dpi,
+                HintingMode = HintingMode.Standard,
+            };
+
+            TextRenderer.RenderTextTo(renderer, text, options);
+        }
+
+        // Render the target size on a font whose interpreter has processed nothing else.
+        List<Vector2> reference = RenderControlPoints(text, targetSize, dpi, warmUpSize: null);
+
+        // Render the same target size, but on a font whose pooled interpreter has already
+        // processed a different size. With a correct per-size reset this is byte-for-byte equal.
+        List<Vector2> afterOtherSize = RenderControlPoints(text, targetSize, dpi, warmUpSize: otherSize);
+
+        Assert.Equal(reference, afterOtherSize);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Some of our tests were non-deterministic. Fonts drawing would _sometimes_ be different when running under load (here's a repro of the behavior we are seeing: [truetype_pool_leak.zip](https://github.com/user-attachments/files/29643952/truetype_pool_leak.zip))

It turns out to be caused by the TrueTypeInterpreter pool not fully reinitializing between uses, which has unexpected side effects when rendering different font sizes. Related to https://github.com/SixLabors/Fonts/pull/486.

A simpler repro is in the commit's unit tests. Note that I added the state reset in SetControlValueTable because that's where the other Reset\Clear were, but it might be better to put this reset code when pulling an instance out of the pool instead (Reset method called after this.interpreterPool.Get()), could be a refactor if you want. Also note that I'm resetting a bit more than strictly necessary to avoid other potential issues I might have missed.