### PR TITLE
Fix TrueTypeInterpreter pool state pollution

### DIFF
--- a/src/SixLabors.Fonts/Tables/TrueType/Hinting/TrueTypeInterpreter.cs
+++ b/src/SixLabors.Fonts/Tables/TrueType/Hinting/TrueTypeInterpreter.cs
@@ -55,13 +55,6 @@ internal partial class TrueTypeInterpreter
     // (see WS instruction) so that prep state is preserved across glyphs.
     private int[] storage;
     private int[]? prepStorage;
-
-    // Snapshot of the storage area immediately after the font program (fpgm) runs. A freshly
-    // created interpreter executes fpgm once, which may seed storage locations that the prep
-    // (CVT) program later reads. When a pooled interpreter is reused for a new pixel size the
-    // prep program is re-run, so storage must be restored to this post-fpgm baseline rather
-    // than being left in its previous (glyph-modified) state.
-    private int[] fpgmStorage;
     private bool inGlyphProgram;
 
     private IReadOnlyList<ushort> contours;
@@ -138,7 +131,6 @@ internal partial class TrueTypeInterpreter
         this.twilight = new Zone(maxTwilightPoints, isTwilight: true);
         this.controlValueTable = [];
         this.baseControlValueTable = [];
-        this.fpgmStorage = [];
         this.contours = [];
     }
 
@@ -156,13 +148,7 @@ internal partial class TrueTypeInterpreter
     /// </summary>
     /// <param name="instructions">The raw font program bytecode.</param>
     public void InitializeFunctionDefs(byte[] instructions)
-    {
-        this.Execute(new StackInstructionStream(instructions, 0), false, true);
-
-        // Capture the post-fpgm storage so it can be restored whenever the prep program is
-        // re-run for a new size on a reused (pooled) interpreter.
-        this.fpgmStorage = (int[])this.storage.Clone();
-    }
+        => this.Execute(new StackInstructionStream(instructions, 0), false, true);
 
     /// <summary>
     /// Scales the Control Value Table and executes the prep (CVT) program.
@@ -176,11 +162,15 @@ internal partial class TrueTypeInterpreter
     /// <param name="cvProgram">The raw prep program bytecode, or <see langword="null"/> if absent.</param>
     public void SetControlValueTable(short[]? cvt, float scale, float ppem, byte[]? cvProgram)
     {
-        if (this.scale == scale || cvt == null)
+        if (this.scale == scale)
         {
             return;
         }
-        else
+
+        // A missing CVT table must not skip the prep program: fonts may carry a prep
+        // program without control values, and prep still establishes the graphics state,
+        // storage, and twilight points that glyph programs build on.
+        if (cvt != null)
         {
             if (this.controlValueTable.Length == 0 && cvt.Length > 0)
             {
@@ -189,8 +179,19 @@ internal partial class TrueTypeInterpreter
 
             for (int i = 0; i < cvt.Length; i++)
             {
-                this.controlValueTable[i] = cvt[i] * scale;
+                // Match FreeType's tt_size_run_prep CVT scaling, which produces 26.6
+                // fixed-point pixel values (FT_MulFix rounds to the nearest 1/64).
+                // Scaling in unquantized float lets control values land on the other
+                // side of a rounding boundary, flipping prep's round-to-grid decisions
+                // for some sizes (Arial's x-height at 13 ppem rounds to 8px instead of
+                // FreeType's 7px). FreeType notes the operation is "very sensitive to
+                // rounding".
+                this.controlValueTable[i] = MathF.Round(cvt[i] * scale * 64F) / 64F;
             }
+        }
+        else
+        {
+            this.controlValueTable = [];
         }
 
         this.scale = scale;
@@ -205,16 +206,11 @@ internal partial class TrueTypeInterpreter
         // without restoring it the prep result — and therefore the hinted outline — depends on
         // the interpreter's history. That made hinting non-deterministic when a font family was
         // rendered concurrently from a shared interpreter pool (see issue #484).
+        // FreeType does the same in tt_size_run_prep (ttobjs.c): it zeroes the twilight zone
+        // and the storage area before every prep execution, deliberately discarding any
+        // storage writes made by the font program (fpgm).
         this.ResetTwilightZone();
-        if (this.storage.Length == this.fpgmStorage.Length)
-        {
-            Array.Copy(this.fpgmStorage, this.storage, this.fpgmStorage.Length);
-        }
-        else
-        {
-            this.storage = (int[])this.fpgmStorage.Clone();
-        }
-
+        Array.Clear(this.storage, 0, this.storage.Length);
         this.prepStorage = null;
         this.inGlyphProgram = false;
         this.callStackSize = 0;

--- a/src/SixLabors.Fonts/Tables/TrueType/Hinting/TrueTypeInterpreter.cs
+++ b/src/SixLabors.Fonts/Tables/TrueType/Hinting/TrueTypeInterpreter.cs
@@ -55,6 +55,13 @@ internal partial class TrueTypeInterpreter
     // (see WS instruction) so that prep state is preserved across glyphs.
     private int[] storage;
     private int[]? prepStorage;
+
+    // Snapshot of the storage area immediately after the font program (fpgm) runs. A freshly
+    // created interpreter executes fpgm once, which may seed storage locations that the prep
+    // (CVT) program later reads. When a pooled interpreter is reused for a new pixel size the
+    // prep program is re-run, so storage must be restored to this post-fpgm baseline rather
+    // than being left in its previous (glyph-modified) state.
+    private int[] fpgmStorage;
     private bool inGlyphProgram;
 
     private IReadOnlyList<ushort> contours;
@@ -131,6 +138,7 @@ internal partial class TrueTypeInterpreter
         this.twilight = new Zone(maxTwilightPoints, isTwilight: true);
         this.controlValueTable = [];
         this.baseControlValueTable = [];
+        this.fpgmStorage = [];
         this.contours = [];
     }
 
@@ -148,7 +156,13 @@ internal partial class TrueTypeInterpreter
     /// </summary>
     /// <param name="instructions">The raw font program bytecode.</param>
     public void InitializeFunctionDefs(byte[] instructions)
-        => this.Execute(new StackInstructionStream(instructions, 0), false, true);
+    {
+        this.Execute(new StackInstructionStream(instructions, 0), false, true);
+
+        // Capture the post-fpgm storage so it can be restored whenever the prep program is
+        // re-run for a new size on a reused (pooled) interpreter.
+        this.fpgmStorage = (int[])this.storage.Clone();
+    }
 
     /// <summary>
     /// Scales the Control Value Table and executes the prep (CVT) program.
@@ -181,9 +195,39 @@ internal partial class TrueTypeInterpreter
 
         this.scale = scale;
         this.ppem = (int)Math.Round(ppem);
-        this.zp0 = this.zp1 = this.zp2 = this.points;
         this.state.Reset();
         this.stack.Clear();
+
+        // Restore the interpreter to the same state a freshly created interpreter would be in
+        // immediately before running the prep program. A pooled interpreter may have been used
+        // to hint glyphs at a previous size, leaving behind storage writes, twilight points,
+        // rounding state and zone pointers. The prep program reads and builds on this state, so
+        // without restoring it the prep result — and therefore the hinted outline — depends on
+        // the interpreter's history. That made hinting non-deterministic when a font family was
+        // rendered concurrently from a shared interpreter pool (see issue #484).
+        this.ResetTwilightZone();
+        if (this.storage.Length == this.fpgmStorage.Length)
+        {
+            Array.Copy(this.fpgmStorage, this.storage, this.fpgmStorage.Length);
+        }
+        else
+        {
+            this.storage = (int[])this.fpgmStorage.Clone();
+        }
+
+        this.prepStorage = null;
+        this.inGlyphProgram = false;
+        this.callStackSize = 0;
+        this.fdotp = 0;
+        this.roundThreshold = 0;
+        this.roundPhase = 0;
+        this.roundPeriod = 0;
+        this.iupXCalled = false;
+        this.iupYCalled = false;
+        this.isComposite = false;
+        this.contours = [];
+        this.points = default;
+        this.zp0 = this.zp1 = this.zp2 = this.points;
 
         if (cvProgram != null)
         {

--- a/tests/Images/ReferenceOutput/Test_Hinting_Robustness_-Arial-.png
+++ b/tests/Images/ReferenceOutput/Test_Hinting_Robustness_-Arial-.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdb327119817df8d7bd1e7e66c6f9921d903a9e4eb573db2db9128fddd7626e6
-size 298028
+oid sha256:af456c8d093b4a30b878f6c8b5f9b0d4b03648b6b2e1a17c86c70c89c5fe1f26
+size 299643

--- a/tests/SixLabors.Fonts.Tests/HintingTests.cs
+++ b/tests/SixLabors.Fonts.Tests/HintingTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Numerics;
 using System.Text;
+using SixLabors.Fonts.Rendering;
 using SixLabors.Fonts.Unicode;
 
 namespace SixLabors.Fonts.Tests;
@@ -69,5 +71,59 @@ public class HintingTests
             text,
             options,
             properties: name);
+    }
+
+    // The TrueType bytecode interpreter is pooled and reused across renders for the same
+    // font. When a pooled interpreter is reused for a different pixel size it re-runs the
+    // font's prep (CVT) program, which must execute from the same pristine state as a freshly
+    // created interpreter. If transient interpreter state (twilight zone, storage, rounding
+    // state, zone pointers, ...) is not reset first, the prep result — and therefore the
+    // hinted glyph outline — depends on which sizes were rendered previously on that
+    // interpreter. Because interpreters are shared through a pool, that made hinting output
+    // non-deterministic when a single font family was rendered concurrently from multiple
+    // threads
+    [Fact]
+    public void Hinting_OutputIsIndependentOfPreviouslyRenderedSizes()
+    {
+        const string text = "The quick brown fox 12345";
+        const float dpi = 150F;
+        const float targetSize = 7F;
+        const float otherSize = 12F;
+
+        static List<Vector2> RenderControlPoints(string text, float size, float dpi, float? warmUpSize)
+        {
+            FontCollection collection = new();
+            FontFamily family = collection.Add(TestFonts.Arial);
+
+            if (warmUpSize is { } w)
+            {
+                RenderTo(family, text, w, dpi, new GlyphRenderer());
+            }
+
+            GlyphRenderer renderer = new();
+            RenderTo(family, text, size, dpi, renderer);
+            return renderer.ControlPoints;
+        }
+
+        static void RenderTo(FontFamily family, string text, float size, float dpi, GlyphRenderer renderer)
+        {
+            Font font = family.CreateFont(size);
+            TextOptions options = new(font)
+            {
+                Dpi = dpi,
+                HintingMode = HintingMode.Standard,
+            };
+
+            TextRenderer.RenderTextTo(renderer, text, options);
+        }
+
+        // Render the target size on a font whose interpreter has processed nothing else.
+        List<Vector2> reference = RenderControlPoints(text, targetSize, dpi, warmUpSize: null);
+
+        // Render the same target size, but on a font whose pooled interpreter has already
+        // processed a different size. With a correct per-size reset this is byte-for-byte equal.
+        List<Vector2> afterOtherSize = RenderControlPoints(text, targetSize, dpi, warmUpSize: otherSize);
+
+        Assert.Equal(reference, afterOtherSize);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Replaces #540 

@christianrondeau I couldn't push to your fork (I think because you are an org) so I replicated your commit here to ensure you have co-ownership.

This pull request improves the determinism and correctness of the TrueType hinting engine by ensuring that the interpreter's state is fully reset between renders, preventing non-deterministic output when reusing interpreters from a pool. It also improves CVT scaling precision and adds a regression test to guarantee consistent results. The most important changes are:

**TrueType Interpreter State Management:**

* Updated `SetControlValueTable` in `TrueTypeInterpreter.cs` to always run the prep program even if the CVT table is missing, and to fully reset interpreter state (twilight zone, storage, rounding, zone pointers, etc.) before each prep execution, matching FreeType's behavior and preventing history-dependent, non-deterministic hinting results. [[1]](diffhunk://#diff-c51df404cf4242837aca278f306e9b7bc5881f478fdfe20c38bff6b596564a7dL165-R173) [[2]](diffhunk://#diff-c51df404cf4242837aca278f306e9b7bc5881f478fdfe20c38bff6b596564a7dL178-R227)

**Hinting Precision:**

* Improved CVT value scaling to use 26.6 fixed-point rounding, matching FreeType and avoiding subtle rounding errors that could affect glyph rendering.

**Testing and Robustness:**

* Added a regression test `Hinting_OutputIsIndependentOfPreviouslyRenderedSizes` in `HintingTests.cs` to ensure that rendering output is independent of previously rendered sizes and interpreter reuse. [[1]](diffhunk://#diff-a9750263aa1224dac36296978b212e8ad63791ec28f142dbc6cf983744d52200R4-R6) [[2]](diffhunk://#diff-a9750263aa1224dac36296978b212e8ad63791ec28f142dbc6cf983744d52200R75-R128)
* Updated the reference output image for the hinting robustness test to reflect the corrected, deterministic rendering.

<!-- Thanks for contributing to SixLabors.Fonts! -->
