### PR TITLE
Underline should be continuous across spacing from tracking

### DIFF
--- a/src/SixLabors.Fonts/FontGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/FontGlyphMetrics.cs
@@ -313,6 +313,10 @@ public abstract class FontGlyphMetrics
     /// <param name="glyphOrigin">The origin used to render the glyph outline.</param>
     /// <param name="decorationOrigin">The origin used to render text decorations.</param>
     /// <param name="mode">The glyph layout mode to render using.</param>
+    /// <param name="layoutAdvance">
+    /// The laid-out advance for this glyph in DPI-normalized units, including any tracking applied during layout.
+    /// Used to size text decorations so they span the full space between glyphs.
+    /// </param>
     /// <param name="options">The options used to influence the rendering of this glyph.</param>
     internal abstract void RenderTo(
         IGlyphRenderer renderer,
@@ -320,6 +324,7 @@ public abstract class FontGlyphMetrics
         Vector2 glyphOrigin,
         Vector2 decorationOrigin,
         GlyphLayoutMode mode,
+        float layoutAdvance,
         TextOptions options);
 
     /// <summary>
@@ -335,6 +340,7 @@ public abstract class FontGlyphMetrics
     /// or vertical rotated).</param>
     /// <param name="transform">The transformation matrix applied to the decoration coordinates before rendering.</param>
     /// <param name="scaledPPEM">The scaled pixels-per-em value used to adjust decoration size and positioning for the current rendering context.</param>
+    /// <param name="decorationLength">The length of the decoration line in device pixels, derived from the laid-out glyph advance so that decorations span any tracking applied between glyphs.</param>
     /// <param name="options">Additional text rendering options that may influence decoration appearance or behavior.</param>
     protected void RenderDecorationsTo(
         IGlyphRenderer renderer,
@@ -342,17 +348,13 @@ public abstract class FontGlyphMetrics
         GlyphLayoutMode mode,
         Matrix3x2 transform,
         float scaledPPEM,
+        float decorationLength,
         TextOptions options)
     {
         bool perGlyph = options.DecorationPositioningMode == DecorationPositioningMode.GlyphFont;
         FontMetrics fontMetrics = perGlyph
             ? this.FontMetrics
             : options.Font.FontMetrics;
-
-        // The scale factor for the decoration length is treated separately from other factors
-        // as it is used to scale the length of the decoration line.
-        // This must always be derived from the glyph's own scale factor to ensure correct length.
-        Vector2 lengthScaleFactor = this.ScaleFactor;
 
         // These factors determine horizontal and vertical scaling and offset for the decorations.
         // and are either per-glyph or derived from the common font metrics.
@@ -390,19 +392,19 @@ public abstract class FontGlyphMetrics
             // For vertical layout we need to draw a vertical line.
             if (isVerticalLayout)
             {
-                float length = mode == GlyphLayoutMode.VerticalRotated ? this.AdvanceWidth : this.AdvanceHeight;
+                // The decoration length is the laid-out advance (including tracking) so that
+                // the line spans the full space between glyphs rather than only the glyph advance.
+                float length = decorationLength;
                 if (length == 0)
                 {
                     return (Vector2.Zero, Vector2.Zero, 0);
                 }
 
-                Vector2 lengthScale = new Vector2(scaledPPEM) / lengthScaleFactor;
                 Vector2 scale = new Vector2(scaledPPEM) / scaleFactor;
 
                 // Undo the vertical offset applied when laying out the text.
                 Vector2 scaledOffset = (offset + new Vector2(decoratorPosition, 0)) * scale;
 
-                length *= lengthScale.Y;
                 thickness *= scale.X;
 
                 Vector2 tl = new(scaledOffset.X, scaledOffset.Y);
@@ -429,17 +431,15 @@ public abstract class FontGlyphMetrics
             }
             else
             {
-                float length = this.AdvanceWidth;
+                float length = decorationLength;
                 if (length == 0)
                 {
                     return (Vector2.Zero, Vector2.Zero, 0);
                 }
 
-                Vector2 lengthScale = new Vector2(scaledPPEM) / lengthScaleFactor;
                 Vector2 scale = new Vector2(scaledPPEM) / scaleFactor;
                 Vector2 scaledOffset = (offset + new Vector2(0, decoratorPosition)) * scale;
 
-                length *= lengthScale.X;
                 thickness *= scale.Y;
 
                 Vector2 tl = new(scaledOffset.X, scaledOffset.Y);

--- a/src/SixLabors.Fonts/Glyph.cs
+++ b/src/SixLabors.Fonts/Glyph.cs
@@ -42,6 +42,7 @@ public readonly struct Glyph
     /// <param name="glyphOrigin">The origin used to render the glyph outline.</param>
     /// <param name="decorationOrigin">The origin used to render text decorations.</param>
     /// <param name="mode">The glyph layout mode to render using.</param>
+    /// <param name="layoutAdvance">The laid-out advance for this glyph in DPI-normalized units, including any tracking, used to size text decorations.</param>
     /// <param name="options">The options to render using.</param>
     internal void RenderTo(
         IGlyphRenderer surface,
@@ -49,6 +50,7 @@ public readonly struct Glyph
         Vector2 glyphOrigin,
         Vector2 decorationOrigin,
         GlyphLayoutMode mode,
+        float layoutAdvance,
         TextOptions options)
-        => this.GlyphMetrics.RenderTo(surface, graphemeIndex, glyphOrigin, decorationOrigin, mode, options);
+        => this.GlyphMetrics.RenderTo(surface, graphemeIndex, glyphOrigin, decorationOrigin, mode, layoutAdvance, options);
 }

--- a/src/SixLabors.Fonts/PlaceholderGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/PlaceholderGlyphMetrics.cs
@@ -66,6 +66,7 @@ internal sealed class PlaceholderGlyphMetrics : FontGlyphMetrics
         Vector2 glyphOrigin,
         Vector2 decorationOrigin,
         GlyphLayoutMode mode,
+        float layoutAdvance,
         TextOptions options)
     {
         // Placeholders reserve layout space only; the caller owns the object rendering.

--- a/src/SixLabors.Fonts/Rendering/PaintedGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/Rendering/PaintedGlyphMetrics.cs
@@ -115,6 +115,7 @@ public sealed class PaintedGlyphMetrics : FontGlyphMetrics
         Vector2 glyphOrigin,
         Vector2 decorationOrigin,
         GlyphLayoutMode mode,
+        float layoutAdvance,
         TextOptions options)
     {
         if (ShouldSkipGlyphRendering(this.CodePoint))
@@ -128,6 +129,7 @@ public sealed class PaintedGlyphMetrics : FontGlyphMetrics
         // Device-space placement.
         glyphOrigin *= dpi;
         decorationOrigin *= dpi;
+        layoutAdvance *= dpi;
 
         float scaledPpem = this.GetScaledSize(pointSize, dpi);
         Vector2 scale = new Vector2(scaledPpem) / this.ScaleFactor; // uniform
@@ -159,7 +161,7 @@ public sealed class PaintedGlyphMetrics : FontGlyphMetrics
             }
 
             renderer.EndGlyph();
-            this.RenderDecorationsTo(renderer, decorationOrigin, mode, rotation, scaledPpem, options);
+            this.RenderDecorationsTo(renderer, decorationOrigin, mode, rotation, scaledPpem, layoutAdvance, options);
         }
     }
 

--- a/src/SixLabors.Fonts/Tables/Cff/CffGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/Tables/Cff/CffGlyphMetrics.cs
@@ -132,6 +132,7 @@ internal class CffGlyphMetrics : FontGlyphMetrics
         Vector2 glyphOrigin,
         Vector2 decorationOrigin,
         GlyphLayoutMode mode,
+        float layoutAdvance,
         TextOptions options)
     {
         // https://www.unicode.org/faq/unsup_char.html
@@ -145,6 +146,7 @@ internal class CffGlyphMetrics : FontGlyphMetrics
 
         glyphOrigin *= dpi;
         decorationOrigin *= dpi;
+        layoutAdvance *= dpi;
         float scaledPPEM = this.GetScaledSize(pointSize, dpi);
 
         Matrix3x2 rotation = GetRotationMatrix(mode);
@@ -171,7 +173,7 @@ internal class CffGlyphMetrics : FontGlyphMetrics
             }
 
             renderer.EndGlyph();
-            this.RenderDecorationsTo(renderer, decorationOrigin, mode, rotation, scaledPPEM, options);
+            this.RenderDecorationsTo(renderer, decorationOrigin, mode, rotation, scaledPPEM, layoutAdvance, options);
         }
     }
 }

--- a/src/SixLabors.Fonts/Tables/TrueType/TrueTypeGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/Tables/TrueType/TrueTypeGlyphMetrics.cs
@@ -138,6 +138,7 @@ public partial class TrueTypeGlyphMetrics : FontGlyphMetrics
         Vector2 glyphOrigin,
         Vector2 decorationOrigin,
         GlyphLayoutMode mode,
+        float layoutAdvance,
         TextOptions options)
     {
         // https://www.unicode.org/faq/unsup_char.html
@@ -151,6 +152,7 @@ public partial class TrueTypeGlyphMetrics : FontGlyphMetrics
 
         glyphOrigin *= dpi;
         decorationOrigin *= dpi;
+        layoutAdvance *= dpi;
         float scaledPPEM = this.GetScaledSize(pointSize, dpi);
 
         Matrix3x2 rotation = GetRotationMatrix(mode);
@@ -253,7 +255,7 @@ public partial class TrueTypeGlyphMetrics : FontGlyphMetrics
             }
 
             renderer.EndGlyph();
-            this.RenderDecorationsTo(renderer, decorationOrigin, mode, rotation, scaledPPEM, options);
+            this.RenderDecorationsTo(renderer, decorationOrigin, mode, rotation, scaledPPEM, layoutAdvance, options);
         }
     }
 }

--- a/src/SixLabors.Fonts/TextBlock.Visitors.cs
+++ b/src/SixLabors.Fonts/TextBlock.Visitors.cs
@@ -802,7 +802,8 @@ public sealed partial class TextBlock
                 return;
             }
 
-            glyph.Glyph.RenderTo(this.renderer, glyph.GraphemeIndex, glyph.GlyphOrigin, glyph.DecorationOrigin, glyph.LayoutMode, this.options);
+            float layoutAdvance = glyph.LayoutMode == GlyphLayoutMode.Horizontal ? glyph.AdvanceX : glyph.AdvanceY;
+            glyph.Glyph.RenderTo(this.renderer, glyph.GraphemeIndex, glyph.GlyphOrigin, glyph.DecorationOrigin, glyph.LayoutMode, layoutAdvance, this.options);
         }
 
         /// <inheritdoc/>

--- a/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
@@ -48,7 +48,7 @@ public class FontLoaderTests
         Assert.True(font.TryGetGlyphs(new CodePoint('A'), ColorFontSupport.None, out Glyph? glyph));
 
         GlyphRenderer r = new();
-        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
+        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, 0, new TextOptions(font));
 
         Assert.Equal(37, r.ControlPoints.Count);
         Assert.Single(r.GlyphKeys);
@@ -62,7 +62,7 @@ public class FontLoaderTests
 
         Assert.True(font.TryGetGlyphs(new CodePoint('A'), ColorFontSupport.None, out Glyph? glyph));
         GlyphRenderer r = new();
-        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
+        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, 0, new TextOptions(font));
 
         Assert.Equal(37, r.ControlPoints.Count);
         Assert.Single(r.GlyphKeys);
@@ -94,7 +94,7 @@ public class FontLoaderTests
 
         Assert.True(font.TryGetGlyphs(new CodePoint('A'), ColorFontSupport.None, out Glyph? glyph));
         GlyphRenderer r = new();
-        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
+        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, 0, new TextOptions(font));
 
         Assert.Equal(37, r.ControlPoints.Count);
         Assert.Single(r.GlyphKeys);
@@ -111,7 +111,7 @@ public class FontLoaderTests
 
         Assert.True(font.TryGetGlyphs(new CodePoint('a'), ColorFontSupport.None, out Glyph? glyph));
         GlyphRenderer r = new();
-        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
+        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, 0, new TextOptions(font));
 
         // the test font only has characters .notdef, 'a' & 'b' defined
         Assert.Equal(6, r.ControlPoints.Distinct().Count());
@@ -127,7 +127,7 @@ public class FontLoaderTests
 
         Assert.True(font.TryGetGlyphs(new CodePoint('a'), ColorFontSupport.None, out Glyph? glyph));
         GlyphRenderer r = new();
-        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
+        glyph.Value.RenderTo(r, 0, Vector2.Zero, Vector2.Zero, GlyphLayoutMode.Horizontal, 0, new TextOptions(font));
 
         // the test font only has characters .notdef, 'a' & 'b' defined
         Assert.Equal(6, r.ControlPoints.Distinct().Count());

--- a/tests/SixLabors.Fonts.Tests/GlyphRenderer.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphRenderer.cs
@@ -81,7 +81,7 @@ public class GlyphRenderer : IGlyphRenderer
     public TextDecorations EnabledDecorations()
         => this.parameters.TextRun.TextDecorations;
 
-    public void SetDecoration(TextDecorations textDecorations, Vector2 start, Vector2 end, float thickness)
+    public virtual void SetDecoration(TextDecorations textDecorations, Vector2 start, Vector2 end, float thickness)
     {
     }
 

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -48,7 +48,7 @@ public class GlyphTests
         Glyph glyph = new(glyphMetrics.CloneForRendering(textRun), font.Size);
 
         Vector2 locationInFontSpace = new Vector2(99, 99) / 72; // glyph ends up 10px over due to offset in fake glyph
-        glyph.RenderTo(this.renderer, 0, locationInFontSpace, Vector2.Zero, GlyphLayoutMode.Horizontal, new TextOptions(font));
+        glyph.RenderTo(this.renderer, 0, locationInFontSpace, Vector2.Zero, GlyphLayoutMode.Horizontal, 0, new TextOptions(font));
 
         Assert.Equal(new FontRectangle(99, 89, 0, 0), this.renderer.GlyphRects.Single());
     }

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_405.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_405.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Numerics;
+using SixLabors.Fonts.Rendering;
+using SixLabors.Fonts.Unicode;
+
+namespace SixLabors.Fonts.Tests.Issues;
+
+public class Issues_405
+{
+    private static List<DecorationSegment> RenderDecorations(
+        string text,
+        float tracking,
+        TextDecorations decorations,
+        LayoutMode layoutMode = LayoutMode.HorizontalTopBottom)
+    {
+        Font font = TestFonts.GetFont(TestFonts.OpenSansFile, 64);
+        TextOptions options = new(font)
+        {
+            Dpi = 72,
+            Tracking = tracking,
+            LayoutMode = layoutMode,
+            TextRuns =
+            [
+                new()
+                {
+                    Start = 0,
+                    End = text.GetGraphemeCount(),
+                    TextDecorations = decorations
+                }
+            ]
+        };
+
+        DecorationRecordingRenderer renderer = new();
+        TextRenderer.RenderTextTo(renderer, text, options);
+        return renderer.Decorations;
+    }
+
+    [Fact]
+    public void Underline_WithTracking_IsContinuousAcrossGlyphs()
+    {
+        List<DecorationSegment> segments = RenderDecorations("AB", 2, TextDecorations.Underline);
+
+        Assert.Equal(2, segments.Count);
+        Assert.All(segments, s => Assert.Equal(TextDecorations.Underline, s.Decoration));
+
+        // The underline beneath the first glyph must extend all the way to the start of the
+        // underline beneath the second glyph so that no gap appears across the tracking space.
+        Assert.Equal(segments[0].End.X, segments[1].Start.X, 0.5F);
+    }
+
+    [Fact]
+    public void Underline_WithoutTracking_IsContinuousAcrossGlyphs()
+    {
+        List<DecorationSegment> segments = RenderDecorations("AB", 0, TextDecorations.Underline);
+
+        Assert.Equal(2, segments.Count);
+        Assert.Equal(segments[0].End.X, segments[1].Start.X, 0.5F);
+    }
+
+    [Fact]
+    public void Underline_TrackingExtendsDecorationByTrackingAdvance()
+    {
+        const float tracking = 2;
+        List<DecorationSegment> withoutTracking = RenderDecorations("AB", 0, TextDecorations.Underline);
+        List<DecorationSegment> withTracking = RenderDecorations("AB", tracking, TextDecorations.Underline);
+
+        float lengthWithout = withoutTracking[0].End.X - withoutTracking[0].Start.X;
+        float lengthWith = withTracking[0].End.X - withTracking[0].Start.X;
+
+        // Tracking adds (tracking * pointSize * dpi / 72) device pixels of advance to each glyph.
+        // With a DPI of 72 this equals tracking * pointSize.
+        const float expectedExtra = tracking * 64;
+        Assert.Equal(expectedExtra, lengthWith - lengthWithout, 1F);
+    }
+
+    [Fact]
+    public void StrikeoutAndOverline_WithTracking_AreContinuousAcrossGlyphs()
+    {
+        List<DecorationSegment> segments = RenderDecorations(
+            "AB",
+            2,
+            TextDecorations.Strikeout | TextDecorations.Overline);
+
+        List<DecorationSegment> strikeout = segments.FindAll(s => s.Decoration == TextDecorations.Strikeout);
+        List<DecorationSegment> overline = segments.FindAll(s => s.Decoration == TextDecorations.Overline);
+
+        Assert.Equal(2, strikeout.Count);
+        Assert.Equal(2, overline.Count);
+        Assert.Equal(strikeout[0].End.X, strikeout[1].Start.X, 0.5F);
+        Assert.Equal(overline[0].End.X, overline[1].Start.X, 0.5F);
+    }
+
+    [Fact]
+    public void Decorations_WithTracking_AreContinuousInVerticalLayout()
+    {
+        List<DecorationSegment> segments = RenderDecorations(
+            "AB",
+            2,
+            TextDecorations.Underline | TextDecorations.Strikeout | TextDecorations.Overline,
+            LayoutMode.VerticalLeftRight);
+
+        // Vertical decorations run along the Y axis; each type must reach the next glyph without a gap.
+        foreach (TextDecorations decoration in new[] { TextDecorations.Underline, TextDecorations.Strikeout, TextDecorations.Overline })
+        {
+            List<DecorationSegment> ofType = segments.FindAll(s => s.Decoration == decoration);
+            Assert.Equal(2, ofType.Count);
+            Assert.Equal(ofType[0].End.Y, ofType[1].Start.Y, 0.5F);
+        }
+    }
+
+    private readonly record struct DecorationSegment(
+        TextDecorations Decoration,
+        Vector2 Start,
+        Vector2 End,
+        float Thickness);
+
+    private sealed class DecorationRecordingRenderer : GlyphRenderer
+    {
+        public List<DecorationSegment> Decorations { get; } = [];
+
+        public override void SetDecoration(TextDecorations textDecorations, Vector2 start, Vector2 end, float thickness)
+            => this.Decorations.Add(new DecorationSegment(textDecorations, start, end, thickness));
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Fixes https://github.com/SixLabors/ImageSharp.Drawing/issues/405

The issue being that the underline (decoration) length did not take into account the actual advance, but instead only considered the font's advance.

<img width="4910" height="555" alt="image" src="https://github.com/user-attachments/assets/b6d266e5-4902-49b2-a576-cac061e1764b" />

Disclaimer: this code was written using AI (Copilot with Claude Opus 4.8), and reviewed by me.

Note that there is a big difference between Chrome's underline and ImageSharp's, but from my understanding, ImageSharp's the correct one because it's based on the post table metrics, and Chrome ignores it. This PR only solves the tracking issue and does not change the underline behavior in other ways.