### PR TITLE
Add color font palette selection support

### DIFF
--- a/src/SixLabors.Fonts/FileFontMetrics.cs
+++ b/src/SixLabors.Fonts/FileFontMetrics.cs
@@ -174,8 +174,9 @@ internal sealed class FileFontMetrics : FontMetrics
         TextDecorations textDecorations,
         LayoutMode layoutMode,
         ColorFontSupport support,
+        FontPalette? palette,
         [NotNullWhen(true)] out FontGlyphMetrics? metrics)
-          => this.fontMetrics.Value.TryGetGlyphMetrics(codePoint, textAttributes, textDecorations, layoutMode, support, out metrics);
+          => this.fontMetrics.Value.TryGetGlyphMetrics(codePoint, textAttributes, textDecorations, layoutMode, support, palette, out metrics);
 
     /// <inheritdoc />
     public override bool TryGetGlyphMetrics(
@@ -184,8 +185,9 @@ internal sealed class FileFontMetrics : FontMetrics
         TextDecorations textDecorations,
         LayoutMode layoutMode,
         ColorFontSupport support,
+        FontPalette? palette,
         [NotNullWhen(true)] out FontGlyphMetrics? metrics)
-        => this.fontMetrics.Value.TryGetGlyphMetrics(glyphId, textAttributes, textDecorations, layoutMode, support, out metrics);
+        => this.fontMetrics.Value.TryGetGlyphMetrics(glyphId, textAttributes, textDecorations, layoutMode, support, palette, out metrics);
 
     /// <inheritdoc />
     internal override FontGlyphMetrics GetGlyphMetrics(
@@ -194,8 +196,9 @@ internal sealed class FileFontMetrics : FontMetrics
         TextAttributes textAttributes,
         TextDecorations textDecorations,
         LayoutMode layoutMode,
-        ColorFontSupport support)
-        => this.fontMetrics.Value.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support);
+        ColorFontSupport support,
+        FontPalette? palette)
+        => this.fontMetrics.Value.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support, palette);
 
     /// <inheritdoc />
     public override ReadOnlyMemory<CodePoint> GetAvailableCodePoints()

--- a/src/SixLabors.Fonts/Font.cs
+++ b/src/SixLabors.Fonts/Font.cs
@@ -366,12 +366,38 @@ public sealed class Font
         LayoutMode layoutMode,
         ColorFontSupport support,
         [NotNullWhen(true)] out Glyph? glyph)
+        => this.TryGetGlyph(codePoint, textAttributes, textDecorations, layoutMode, support, null, out glyph);
+
+    /// <summary>
+    /// Gets the glyph for the given codepoint.
+    /// </summary>
+    /// <param name="codePoint">The code point of the character.</param>
+    /// <param name="textAttributes">The text attributes to apply to the glyphs.</param>
+    /// <param name="textDecorations">The text decorations to apply to the glyphs.</param>
+    /// <param name="layoutMode">The layout mode to apply to the glyphs.</param>
+    /// <param name="support">Options for enabling color font support during layout and rendering.</param>
+    /// <param name="palette">The color palette selection for color fonts, or <see langword="null"/> for the font's default palette.</param>
+    /// <param name="glyph">
+    /// When this method returns, contains the glyph for the given codepoint, attributes, and color support if the glyph
+    /// is found; otherwise the default value. This parameter is passed uninitialized.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the face contains glyphs for the specified codepoint; otherwise, <see langword="false"/>.
+    /// </returns>
+    public bool TryGetGlyph(
+        CodePoint codePoint,
+        TextAttributes textAttributes,
+        TextDecorations textDecorations,
+        LayoutMode layoutMode,
+        ColorFontSupport support,
+        FontPalette? palette,
+        [NotNullWhen(true)] out Glyph? glyph)
     {
         FontMetrics fontMetrics = this.FontMetrics;
         if (fontMetrics.TryGetGlyphId(codePoint, out ushort glyphId))
         {
             TextRun textRun = new() { Start = 0, End = 1, Font = this, TextAttributes = textAttributes, TextDecorations = textDecorations };
-            FontGlyphMetrics metrics = fontMetrics.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support);
+            FontGlyphMetrics metrics = fontMetrics.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support, palette);
 
             glyph = new(metrics, this.Size, textRun, Vector2.Zero, new Vector2(metrics.AdvanceWidth, metrics.AdvanceHeight));
             return true;

--- a/src/SixLabors.Fonts/FontGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/FontGlyphMetrics.cs
@@ -232,6 +232,13 @@ public abstract class FontGlyphMetrics
     /// </summary>
     public GlyphType GlyphType { get; }
 
+    /// <summary>
+    /// Gets the color palette selection the glyph's colors were resolved with, or
+    /// <see langword="null"/> when the glyph resolves no palette colors. Painted formats
+    /// override this so renderer caches can distinguish palette variants of one glyph.
+    /// </summary>
+    internal virtual FontPalette? FontPalette => null;
+
     /// <inheritdoc cref="FontMetrics.UnitsPerEm"/>
     public ushort UnitsPerEm { get; }
 

--- a/src/SixLabors.Fonts/FontMetrics.cs
+++ b/src/SixLabors.Fonts/FontMetrics.cs
@@ -234,6 +234,7 @@ public abstract class FontMetrics
     /// <param name="textDecorations">The text decorations applied to the glyph.</param>
     /// <param name="layoutMode">The layout mode applied to the glyph.</param>
     /// <param name="support">Options for enabling color font support during layout and rendering.</param>
+    /// <param name="palette">The color palette selection for color fonts, or <see langword="null"/> for the font's default palette.</param>
     /// <param name="metrics">
     /// When this method returns, contains the metrics for the given codepoint and color support if the metrics
     /// are found; otherwise the default value. This parameter is passed uninitialized.
@@ -247,6 +248,7 @@ public abstract class FontMetrics
         TextDecorations textDecorations,
         LayoutMode layoutMode,
         ColorFontSupport support,
+        FontPalette? palette,
         [NotNullWhen(true)] out FontGlyphMetrics? metrics);
 
     /// <summary>
@@ -257,6 +259,7 @@ public abstract class FontMetrics
     /// <param name="textDecorations">The text decorations applied to the glyph.</param>
     /// <param name="layoutMode">The layout mode applied to the glyph.</param>
     /// <param name="support">Options for enabling color font support during layout and rendering.</param>
+    /// <param name="palette">The color palette selection for color fonts, or <see langword="null"/> for the font's default palette.</param>
     /// <param name="metrics">
     /// When this method returns, contains the metrics for the given glyph id and color support if the metrics
     /// are found; otherwise the default value. This parameter is passed uninitialized.
@@ -270,6 +273,7 @@ public abstract class FontMetrics
         TextDecorations textDecorations,
         LayoutMode layoutMode,
         ColorFontSupport support,
+        FontPalette? palette,
         [NotNullWhen(true)] out FontGlyphMetrics? metrics);
 
     /// <summary>
@@ -290,6 +294,7 @@ public abstract class FontMetrics
     /// <param name="textDecorations">The text decorations applied to the glyph.</param>
     /// <param name="layoutMode">The layout mode applied to the glyph.</param>
     /// <param name="colorSupport">Options for enabling color font support during layout and rendering.</param>
+    /// <param name="palette">The color palette selection for color fonts, or <see langword="null"/> for the font's default palette.</param>
     /// <returns>The font glyph metrics.</returns>
     internal abstract FontGlyphMetrics GetGlyphMetrics(
         CodePoint codePoint,
@@ -297,7 +302,8 @@ public abstract class FontMetrics
         TextAttributes textAttributes,
         TextDecorations textDecorations,
         LayoutMode layoutMode,
-        ColorFontSupport colorSupport);
+        ColorFontSupport colorSupport,
+        FontPalette? palette);
 
     /// <summary>
     /// Tries to get the GSUB table.

--- a/src/SixLabors.Fonts/FontPalette.cs
+++ b/src/SixLabors.Fonts/FontPalette.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.Fonts;
+
+/// <summary>
+/// Selects the CPAL color palette used to resolve COLR glyph colors and optionally replaces individual palette entries.
+/// <para/>
+/// A palette index outside the range defined by the font selects the default palette (index 0), and overrides still
+/// apply, matching the CSS <c>font-palette</c> behavior. Overrides apply in order, so a later override of the same
+/// entry replaces an earlier one, and overrides whose entry index lies outside the font's palette entry range are ignored.
+/// </summary>
+public sealed class FontPalette : IEquatable<FontPalette>
+{
+    /// <summary>
+    /// The override colors applied on top of the selected palette. Instances are immutable so
+    /// that a palette can act as a cache key; the constructor copies the caller's collection.
+    /// </summary>
+    private readonly FontPaletteOverride[] overrides;
+
+    /// <summary>
+    /// The hash code precomputed over the index and override sequence, so repeated cache
+    /// lookups do not rehash the override array.
+    /// </summary>
+    private readonly int hashCode;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FontPalette"/> class.
+    /// </summary>
+    /// <param name="index">The zero-based palette index within the font's CPAL table.</param>
+    public FontPalette(int index)
+        : this(index, Array.Empty<FontPaletteOverride>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FontPalette"/> class.
+    /// </summary>
+    /// <param name="index">The zero-based palette index within the font's CPAL table.</param>
+    /// <param name="overrides">The override colors to apply, in order, on top of the selected palette.</param>
+    public FontPalette(int index, IReadOnlyList<FontPaletteOverride> overrides)
+    {
+        Guard.MustBeGreaterThanOrEqualTo(index, 0, nameof(index));
+        Guard.NotNull(overrides, nameof(overrides));
+
+        this.Index = index;
+
+        FontPaletteOverride[] copy = new FontPaletteOverride[overrides.Count];
+        for (int i = 0; i < copy.Length; i++)
+        {
+            copy[i] = overrides[i];
+        }
+
+        this.overrides = copy;
+
+        HashCode hash = default;
+        hash.Add(index);
+        for (int i = 0; i < copy.Length; i++)
+        {
+            hash.Add(copy[i]);
+        }
+
+        this.hashCode = hash.ToHashCode();
+    }
+
+    /// <summary>
+    /// Gets the zero-based palette index within the font's CPAL table.
+    /// </summary>
+    public int Index { get; }
+
+    /// <summary>
+    /// Gets the override colors applied, in order, on top of the selected palette.
+    /// </summary>
+    public IReadOnlyList<FontPaletteOverride> Overrides => this.overrides;
+
+    /// <inheritdoc/>
+    public bool Equals(FontPalette? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        // The cached hash rejects almost every non-equal palette without touching the
+        // override array; the element loop below only confirms true matches.
+        if (this.hashCode != other.hashCode || this.Index != other.Index || this.overrides.Length != other.overrides.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < this.overrides.Length; i++)
+        {
+            if (!this.overrides[i].Equals(other.overrides[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+        => obj is FontPalette other && this.Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+        => this.hashCode;
+}

--- a/src/SixLabors.Fonts/FontPaletteOverride.cs
+++ b/src/SixLabors.Fonts/FontPaletteOverride.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.Fonts;
+
+/// <summary>
+/// Replaces the color of a single palette entry when a <see cref="FontPalette"/> is applied.
+/// An override whose <see cref="Index"/> lies outside the font's palette entry range is ignored.
+/// </summary>
+public readonly struct FontPaletteOverride : IEquatable<FontPaletteOverride>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FontPaletteOverride"/> struct.
+    /// </summary>
+    /// <param name="index">The zero-based palette entry index to replace.</param>
+    /// <param name="color">The replacement color.</param>
+    public FontPaletteOverride(int index, GlyphColor color)
+    {
+        Guard.MustBeGreaterThanOrEqualTo(index, 0, nameof(index));
+
+        this.Index = index;
+        this.Color = color;
+    }
+
+    /// <summary>
+    /// Gets the zero-based palette entry index to replace.
+    /// </summary>
+    public int Index { get; }
+
+    /// <summary>
+    /// Gets the replacement color.
+    /// </summary>
+    public GlyphColor Color { get; }
+
+    /// <summary>
+    /// Compares two <see cref="FontPaletteOverride"/> objects for equality.
+    /// </summary>
+    /// <param name="left">The <see cref="FontPaletteOverride"/> on the left side of the operand.</param>
+    /// <param name="right">The <see cref="FontPaletteOverride"/> on the right side of the operand.</param>
+    /// <returns>True if the current left is equal to the <paramref name="right"/> parameter; otherwise, false.</returns>
+    public static bool operator ==(FontPaletteOverride left, FontPaletteOverride right)
+        => left.Equals(right);
+
+    /// <summary>
+    /// Compares two <see cref="FontPaletteOverride"/> objects for inequality.
+    /// </summary>
+    /// <param name="left">The <see cref="FontPaletteOverride"/> on the left side of the operand.</param>
+    /// <param name="right">The <see cref="FontPaletteOverride"/> on the right side of the operand.</param>
+    /// <returns>True if the current left is unequal to the <paramref name="right"/> parameter; otherwise, false.</returns>
+    public static bool operator !=(FontPaletteOverride left, FontPaletteOverride right)
+        => !left.Equals(right);
+
+    /// <inheritdoc/>
+    public bool Equals(FontPaletteOverride other)
+        => this.Index == other.Index && this.Color.Equals(other.Color);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+        => obj is FontPaletteOverride other && this.Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+        => HashCode.Combine(this.Index, this.Color);
+}

--- a/src/SixLabors.Fonts/GlyphColor.cs
+++ b/src/SixLabors.Fonts/GlyphColor.cs
@@ -11,7 +11,14 @@ namespace SixLabors.Fonts;
 /// </summary>
 public readonly partial struct GlyphColor : IEquatable<GlyphColor>
 {
-    internal GlyphColor(byte red, byte green, byte blue, byte alpha)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GlyphColor"/> struct.
+    /// </summary>
+    /// <param name="red">The red component.</param>
+    /// <param name="green">The green component.</param>
+    /// <param name="blue">The blue component.</param>
+    /// <param name="alpha">The alpha component.</param>
+    public GlyphColor(byte red, byte green, byte blue, byte alpha)
     {
         this.R = red;
         this.G = green;

--- a/src/SixLabors.Fonts/GlyphOptions.cs
+++ b/src/SixLabors.Fonts/GlyphOptions.cs
@@ -47,6 +47,9 @@ public class GlyphOptions
     /// <inheritdoc cref="TextOptions.ColorFontSupport"/>
     public ColorFontSupport ColorFontSupport { get; set; } = ColorFontSupport.None;
 
+    /// <inheritdoc cref="TextOptions.FontPalette"/>
+    public FontPalette? FontPalette { get; set; }
+
     /// <inheritdoc cref="TextOptions.Origin"/>
     public Vector2 Origin { get; set; } = Vector2.Zero;
 
@@ -109,7 +112,9 @@ public class GlyphOptions
             End = this.GraphemeIndex + 1,
             Font = this.Font,
             TextAttributes = this.TextAttributes,
-            TextDecorations = this.TextDecorations
+            TextDecorations = this.TextDecorations,
+            ColorFontSupport = this.ColorFontSupport,
+            FontPalette = this.FontPalette
         };
 
     /// <summary>

--- a/src/SixLabors.Fonts/MemoryFontMetrics.cs
+++ b/src/SixLabors.Fonts/MemoryFontMetrics.cs
@@ -168,8 +168,9 @@ internal sealed class MemoryFontMetrics : FontMetrics
         TextDecorations textDecorations,
         LayoutMode layoutMode,
         ColorFontSupport support,
+        FontPalette? palette,
         [NotNullWhen(true)] out FontGlyphMetrics? metrics)
-          => this.fontMetrics.Value.TryGetGlyphMetrics(codePoint, textAttributes, textDecorations, layoutMode, support, out metrics);
+          => this.fontMetrics.Value.TryGetGlyphMetrics(codePoint, textAttributes, textDecorations, layoutMode, support, palette, out metrics);
 
     /// <inheritdoc />
     public override bool TryGetGlyphMetrics(
@@ -178,8 +179,9 @@ internal sealed class MemoryFontMetrics : FontMetrics
         TextDecorations textDecorations,
         LayoutMode layoutMode,
         ColorFontSupport support,
+        FontPalette? palette,
         [NotNullWhen(true)] out FontGlyphMetrics? metrics)
-        => this.fontMetrics.Value.TryGetGlyphMetrics(glyphId, textAttributes, textDecorations, layoutMode, support, out metrics);
+        => this.fontMetrics.Value.TryGetGlyphMetrics(glyphId, textAttributes, textDecorations, layoutMode, support, palette, out metrics);
 
     /// <inheritdoc />
     internal override FontGlyphMetrics GetGlyphMetrics(
@@ -188,8 +190,9 @@ internal sealed class MemoryFontMetrics : FontMetrics
         TextAttributes textAttributes,
         TextDecorations textDecorations,
         LayoutMode layoutMode,
-        ColorFontSupport support)
-        => this.fontMetrics.Value.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support);
+        ColorFontSupport support,
+        FontPalette? palette)
+        => this.fontMetrics.Value.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support, palette);
 
     /// <inheritdoc />
     public override ReadOnlyMemory<CodePoint> GetAvailableCodePoints()

--- a/src/SixLabors.Fonts/Rendering/GlyphRendererParameters.cs
+++ b/src/SixLabors.Fonts/Rendering/GlyphRendererParameters.cs
@@ -37,6 +37,7 @@ public readonly struct GlyphRendererParameters : IEquatable<GlyphRendererParamet
         this.LayoutMode = layoutMode;
         this.HintingMode = hintingMode;
         this.ClipBounds = clipBounds;
+        this.FontPalette = metrics.FontPalette;
     }
 
     /// <summary>
@@ -101,6 +102,14 @@ public readonly struct GlyphRendererParameters : IEquatable<GlyphRendererParamet
     public HintingMode HintingMode { get; }
 
     /// <summary>
+    /// Gets the color palette selection the glyph's colors were resolved with, or
+    /// <see langword="null"/> when the glyph resolves no palette colors. The selection
+    /// changes the emitted layer paints so it participates in identity, allowing
+    /// consumers to cache per palette variant.
+    /// </summary>
+    public FontPalette? FontPalette { get; }
+
+    /// <summary>
     /// Gets the clip bounds for the glyph, or <see langword="null"/> when the font defines
     /// none. The renderer restricts every operation the glyph emits to these bounds.
     /// The transform carries the glyph's placement, so the value is excluded from equality:
@@ -151,6 +160,7 @@ public readonly struct GlyphRendererParameters : IEquatable<GlyphRendererParamet
         && other.TextRun.TextDecorations == this.TextRun.TextDecorations
         && other.LayoutMode == this.LayoutMode
         && other.HintingMode == this.HintingMode
+        && Equals(other.FontPalette, this.FontPalette)
         && ((other.Font is null && this.Font is null)
         || (other.Font?.Equals(this.Font, StringComparison.OrdinalIgnoreCase) == true));
 
@@ -177,7 +187,8 @@ public readonly struct GlyphRendererParameters : IEquatable<GlyphRendererParamet
 
         int c = HashCode.Combine(
             this.CompositeGlyphId,
-            this.GraphemeIndex);
+            this.GraphemeIndex,
+            this.FontPalette);
 
         return HashCode.Combine(a, b, c);
     }

--- a/src/SixLabors.Fonts/Rendering/PaintedGlyphMetrics.cs
+++ b/src/SixLabors.Fonts/Rendering/PaintedGlyphMetrics.cs
@@ -22,6 +22,7 @@ public sealed class PaintedGlyphMetrics : FontGlyphMetrics
     /// <param name="glyphId">The glyph identifier.</param>
     /// <param name="codePoint">The code point.</param>
     /// <param name="source">The painted glyph source.</param>
+    /// <param name="palette">The color palette selection the source resolves colors with, or null for the font's default palette.</param>
     /// <param name="bounds">The design-space bounds for the glyph.</param>
     /// <param name="advanceWidth">The advance width.</param>
     /// <param name="advanceHeight">The advance height.</param>
@@ -35,6 +36,7 @@ public sealed class PaintedGlyphMetrics : FontGlyphMetrics
         ushort glyphId,
         CodePoint codePoint,
         IPaintedGlyphSource source,
+        FontPalette? palette,
         Bounds bounds,
         ushort advanceWidth,
         ushort advanceHeight,
@@ -56,7 +58,17 @@ public sealed class PaintedGlyphMetrics : FontGlyphMetrics
               textAttributes,
               textDecorations,
               GlyphType.Painted)
-        => this.source = source;
+    {
+        this.source = source;
+        this.FontPalette = palette;
+    }
+
+    /// <summary>
+    /// Gets the color palette selection the glyph's colors were resolved with, or
+    /// <see langword="null"/> for the font's default palette. Participates in renderer
+    /// cache identity through <see cref="GlyphRendererParameters"/>.
+    /// </summary>
+    internal override FontPalette? FontPalette { get; }
 
     /// <inheritdoc/>
     internal override Bounds GetDesignBounds()

--- a/src/SixLabors.Fonts/Rendering/TextRenderer.cs
+++ b/src/SixLabors.Fonts/Rendering/TextRenderer.cs
@@ -111,6 +111,7 @@ public class TextRenderer
             options.TextDecorations,
             options.LayoutMode,
             options.ColorFontSupport,
+            options.FontPalette,
             out FontGlyphMetrics? metrics))
         {
             return;

--- a/src/SixLabors.Fonts/ShapingBuffer.cs
+++ b/src/SixLabors.Fonts/ShapingBuffer.cs
@@ -76,6 +76,13 @@ internal sealed class ShapingBuffer
     private FontMetrics? metricsCacheOwner;
 
     /// <summary>
+    /// The palette selection the cache entries belong to. The palette is a reference the
+    /// packed tag cannot encode, and a pooled buffer can be reset with new options while
+    /// keeping the same font, so a selection change clears the cache before use.
+    /// </summary>
+    private FontPalette? metricsCachePalette;
+
+    /// <summary>
     /// The bit offset of the encoded following codepoint in a glyph id cache entry.
     /// </summary>
     private const int GlyphIdCacheNextShift = 21;
@@ -529,6 +536,7 @@ internal sealed class ShapingBuffer
         FontMetrics fontMetrics = font.FontMetrics;
         LayoutMode layoutMode = this.TextOptions.LayoutMode;
         ColorFontSupport colorFontSupport = this.TextOptions.ColorFontSupport;
+        FontPalette? fontPalette = this.TextOptions.FontPalette;
 
         uint verticalMask = ShapePlanFeatures.VerticalFeatureMask;
 
@@ -544,7 +552,7 @@ internal sealed class ShapingBuffer
             bool isVertical = AdvancedTypographicUtils.IsVerticalGlyph(codePoint, layoutMode)
                 || (slot.AppliedFeatureMask & verticalMask) != 0;
 
-            FontGlyphMetrics glyphMetrics = this.GetGlyphMetrics(fontMetrics, codePoint, slot.GlyphId, textAttributes, textDecorations, layoutMode, colorFontSupport);
+            FontGlyphMetrics glyphMetrics = this.GetGlyphMetrics(fontMetrics, codePoint, slot.GlyphId, textAttributes, textDecorations, layoutMode, textRun.ColorFontSupport ?? colorFontSupport, textRun.FontPalette ?? fontPalette);
 
             if (glyphMetrics.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
             {
@@ -1538,6 +1546,7 @@ internal sealed class ShapingBuffer
         FontMetrics fontMetrics = font.FontMetrics;
         LayoutMode layoutMode = this.TextOptions.LayoutMode;
         ColorFontSupport colorFontSupport = this.TextOptions.ColorFontSupport;
+        FontPalette? fontPalette = this.TextOptions.FontPalette;
 
         // The hide-ignorables stage runs against this buffer, so the workspace's
         // knowledge of default ignorables must travel with its records.
@@ -1582,7 +1591,7 @@ internal sealed class ShapingBuffer
             bool isVertical = AdvancedTypographicUtils.IsVerticalGlyph(codePoint, layoutMode)
                 || (source.AppliedFeatureMask & verticalMask) != 0;
 
-            FontGlyphMetrics glyphMetrics = this.GetGlyphMetrics(fontMetrics, codePoint, id, textAttributes, textDecorations, layoutMode, colorFontSupport);
+            FontGlyphMetrics glyphMetrics = this.GetGlyphMetrics(fontMetrics, codePoint, id, textAttributes, textDecorations, layoutMode, sourceRun.ColorFontSupport ?? colorFontSupport, sourceRun.FontPalette ?? fontPalette);
 
             if (glyphMetrics.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
             {
@@ -1623,6 +1632,7 @@ internal sealed class ShapingBuffer
         FontMetrics fontMetrics = font.FontMetrics;
         LayoutMode layoutMode = this.TextOptions.LayoutMode;
         ColorFontSupport colorFontSupport = this.TextOptions.ColorFontSupport;
+        FontPalette? fontPalette = this.TextOptions.FontPalette;
         bool hasFallBacks = false;
 
         // The hide-ignorables stage runs against this buffer, so the workspace's
@@ -1699,7 +1709,8 @@ internal sealed class ShapingBuffer
                     shapeRun.TextAttributes,
                     shapeRun.TextDecorations,
                     layoutMode,
-                    colorFontSupport);
+                    shapeRun.ColorFontSupport ?? colorFontSupport,
+                    shapeRun.FontPalette ?? fontPalette);
 
                 if (glyphMetrics.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(shape.CodePoint))
                 {
@@ -1757,7 +1768,8 @@ internal sealed class ShapingBuffer
                     shapeRun.TextAttributes,
                     shapeRun.TextDecorations,
                     layoutMode,
-                    colorFontSupport);
+                    shapeRun.ColorFontSupport ?? colorFontSupport,
+                    shapeRun.FontPalette ?? fontPalette);
 
                 bool isVertical = AdvancedTypographicUtils.IsVerticalGlyph(codePoint, layoutMode)
                     || (shape.AppliedFeatureMask & verticalMask) != 0;
@@ -1931,6 +1943,7 @@ internal sealed class ShapingBuffer
     /// <param name="textDecorations">The text decorations applied to the glyph.</param>
     /// <param name="layoutMode">The layout mode.</param>
     /// <param name="colorFontSupport">The color font support level.</param>
+    /// <param name="palette">The color palette selection, or null for the font's default palette.</param>
     /// <returns>The resolved <see cref="FontGlyphMetrics"/>.</returns>
     private FontGlyphMetrics GetGlyphMetrics(
         FontMetrics fontMetrics,
@@ -1939,12 +1952,14 @@ internal sealed class ShapingBuffer
         TextAttributes textAttributes,
         TextDecorations textDecorations,
         LayoutMode layoutMode,
-        ColorFontSupport colorFontSupport)
+        ColorFontSupport colorFontSupport,
+        FontPalette? palette)
     {
-        if (!ReferenceEquals(this.metricsCacheOwner, fontMetrics))
+        if (!ReferenceEquals(this.metricsCacheOwner, fontMetrics) || !ReferenceEquals(this.metricsCachePalette, palette))
         {
             Array.Clear(this.metricsCacheTags);
             this.metricsCacheOwner = fontMetrics;
+            this.metricsCachePalette = palette;
         }
 
         bool isVertical = AdvancedTypographicUtils.IsVerticalGlyph(codePoint, layoutMode);
@@ -1961,7 +1976,7 @@ internal sealed class ShapingBuffer
             return this.metricsCacheValues[slot]!;
         }
 
-        FontGlyphMetrics glyphMetrics = fontMetrics.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, colorFontSupport);
+        FontGlyphMetrics glyphMetrics = fontMetrics.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, colorFontSupport, palette);
         this.metricsCacheTags[slot] = tag;
         this.metricsCacheValues[slot] = glyphMetrics;
         return glyphMetrics;

--- a/src/SixLabors.Fonts/StreamFontMetrics.Cff.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.Cff.cs
@@ -108,9 +108,8 @@ internal partial class StreamFontMetrics
         TextDecorations textDecorations,
         ColorFontSupport colorSupport,
         bool isVerticalLayout,
-        ushort paletteIndex = 0)
+        FontPalette? palette)
     {
-        // TODO: When do we require and how do we use the palette index?
         CompactFontTables tables = this.compactFontTables!;
         ICffTable cff = tables.Cff;
         HorizontalMetricsTable htmx = tables.Htmx;
@@ -167,6 +166,7 @@ internal partial class StreamFontMetrics
                 glyphId,
                 codePoint,
                 this.GetOrCreateSvgGlyphSource(svg),
+                null,
                 bounds,
                 advanceWidth,
                 advancedHeight,

--- a/src/SixLabors.Fonts/StreamFontMetrics.TrueType.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.TrueType.cs
@@ -266,9 +266,8 @@ internal partial class StreamFontMetrics
         TextDecorations textDecorations,
         ColorFontSupport colorSupport,
         bool isVerticalLayout,
-        ushort paletteIndex = 0)
+        FontPalette? palette)
     {
-        // TODO: When do we require and how do we use the palette index?
         TrueTypeFontTables tables = this.trueTypeFontTables!;
         GlyphTable glyf = tables.Glyf;
         HorizontalMetricsTable htmx = tables.Htmx;
@@ -316,13 +315,14 @@ internal partial class StreamFontMetrics
         if ((colorSupport & ColorFontSupport.ColrV1) == ColorFontSupport.ColrV1 && colr?.ContainsColorV1Glyph(glyphId) == true)
         {
             CpalTable? cpal = tables.Cpal;
-            ColrV1GlyphSource glyphSource = new(colr, cpal, i => glyf.GetGlyph(i), this.GlyphVariationProcessor);
+            ColrV1GlyphSource glyphSource = new(colr, cpal, palette, i => glyf.GetGlyph(i), this.GlyphVariationProcessor);
 
             return new PaintedGlyphMetrics(
                 this,
                 glyphId,
                 codePoint,
                 glyphSource,
+                palette,
                 bounds,
                 advanceWidth,
                 advancedHeight,
@@ -336,13 +336,14 @@ internal partial class StreamFontMetrics
         if ((colorSupport & ColorFontSupport.ColrV0) == ColorFontSupport.ColrV0 && colr?.ContainsColorV0Glyph(glyphId) == true)
         {
             CpalTable? cpal = tables.Cpal;
-            ColrV0GlyphSource glyphSource = new(colr, cpal, i => glyf.GetGlyph(i));
+            ColrV0GlyphSource glyphSource = new(colr, cpal, palette, i => glyf.GetGlyph(i));
 
             return new PaintedGlyphMetrics(
                 this,
                 glyphId,
                 codePoint,
                 glyphSource,
+                palette,
                 bounds,
                 advanceWidth,
                 advancedHeight,
@@ -361,6 +362,7 @@ internal partial class StreamFontMetrics
                 glyphId,
                 codePoint,
                 this.GetOrCreateSvgGlyphSource(svg),
+                null,
                 bounds,
                 advanceWidth,
                 advancedHeight,

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -32,7 +32,7 @@ internal partial class StreamFontMetrics : FontMetrics
     private readonly OutlineType outlineType;
 
     // https://docs.microsoft.com/en-us/typography/opentype/spec/otff#font-tables
-    private readonly ConcurrentDictionary<(int CodePoint, ushort Id, TextAttributes Attributes, ColorFontSupport ColorSupport, bool IsVerticalLayout), FontGlyphMetrics> glyphCache;
+    private readonly ConcurrentDictionary<(int CodePoint, ushort Id, TextAttributes Attributes, ColorFontSupport ColorSupport, bool IsVerticalLayout, FontPalette? Palette), FontGlyphMetrics> glyphCache;
     private readonly ConcurrentDictionary<(int CodePoint, int NextCodePoint), (bool Success, ushort GlyphId, bool SkipNextCodePoint)> glyphIdCache;
     private readonly ConcurrentDictionary<ushort, (bool Success, CodePoint CodePoint)> codePointCache;
     private readonly FontSource source;
@@ -362,11 +362,12 @@ internal partial class StreamFontMetrics : FontMetrics
         TextDecorations textDecorations,
         LayoutMode layoutMode,
         ColorFontSupport support,
+        FontPalette? palette,
         [NotNullWhen(true)] out FontGlyphMetrics? metrics)
     {
         // We return metrics for the special glyph representing a missing character, commonly known as .notdef.
         this.TryGetGlyphId(codePoint, out ushort glyphId);
-        metrics = this.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support);
+        metrics = this.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support, palette);
         return true;
     }
 
@@ -377,6 +378,7 @@ internal partial class StreamFontMetrics : FontMetrics
         TextDecorations textDecorations,
         LayoutMode layoutMode,
         ColorFontSupport support,
+        FontPalette? palette,
         [NotNullWhen(true)] out FontGlyphMetrics? metrics)
     {
         ushort glyphCount = this.outlineType == OutlineType.TrueType
@@ -394,7 +396,7 @@ internal partial class StreamFontMetrics : FontMetrics
         // bailing here would drop them entirely. Recover the codepoint when possible (it only feeds the
         // skip/whitespace heuristics and GlyphRendererParameters.CodePoint); otherwise fall back to default.
         _ = this.TryGetCodePoint(glyphId, out CodePoint codePoint);
-        metrics = this.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support);
+        metrics = this.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support, palette);
         return true;
     }
 
@@ -405,7 +407,8 @@ internal partial class StreamFontMetrics : FontMetrics
         TextAttributes textAttributes,
         TextDecorations textDecorations,
         LayoutMode layoutMode,
-        ColorFontSupport support)
+        ColorFontSupport support,
+        FontPalette? palette)
 
         // We overwrite the cache entry for this type should the attributes change.
         => this.glyphCache.GetOrAdd(
@@ -414,7 +417,8 @@ internal partial class StreamFontMetrics : FontMetrics
                 glyphId,
                 textAttributes,
                 support,
-                AdvancedTypographicUtils.IsVerticalGlyph(codePoint, layoutMode)),
+                AdvancedTypographicUtils.IsVerticalGlyph(codePoint, layoutMode),
+                palette),
             static (key, arg) =>
 
             arg.Item3.CreateGlyphMetrics(
@@ -424,7 +428,8 @@ internal partial class StreamFontMetrics : FontMetrics
                 key.Attributes,
                 arg.textDecorations,
                 key.ColorSupport,
-                key.IsVerticalLayout),
+                key.IsVerticalLayout,
+                key.Palette),
             (textDecorations, codePoint, this));
 
     /// <inheritdoc />
@@ -890,13 +895,14 @@ internal partial class StreamFontMetrics : FontMetrics
         this.underlineThickness += (short)MathF.Round(processor.GetMVarDelta(MVarTag.UnderlineThickness));
     }
 
-    private static (int CodePoint, ushort Id, TextAttributes Attributes, ColorFontSupport ColorSupport, bool IsVerticalLayout) CreateCacheKey(
+    private static (int CodePoint, ushort Id, TextAttributes Attributes, ColorFontSupport ColorSupport, bool IsVerticalLayout, FontPalette? Palette) CreateCacheKey(
         in CodePoint codePoint,
         ushort glyphId,
         TextAttributes textAttributes,
         ColorFontSupport colorSupport,
-        bool isVerticalLayout)
-        => (codePoint.Value, glyphId, textAttributes, colorSupport, isVerticalLayout);
+        bool isVerticalLayout,
+        FontPalette? palette)
+        => (codePoint.Value, glyphId, textAttributes, colorSupport, isVerticalLayout, palette);
 
     private FontGlyphMetrics CreateGlyphMetrics(
         in CodePoint codePoint,
@@ -906,11 +912,11 @@ internal partial class StreamFontMetrics : FontMetrics
         TextDecorations textDecorations,
         ColorFontSupport colorSupport,
         bool isVerticalLayout,
-        ushort paletteIndex = 0)
+        FontPalette? palette)
         => this.outlineType switch
         {
-            OutlineType.TrueType => this.CreateTrueTypeGlyphMetrics(in codePoint, glyphId, glyphType, textAttributes, textDecorations, colorSupport, isVerticalLayout, paletteIndex),
-            OutlineType.CFF => this.CreateCffGlyphMetrics(in codePoint, glyphId, glyphType, textAttributes, textDecorations, colorSupport, isVerticalLayout, paletteIndex),
+            OutlineType.TrueType => this.CreateTrueTypeGlyphMetrics(in codePoint, glyphId, glyphType, textAttributes, textDecorations, colorSupport, isVerticalLayout, palette),
+            OutlineType.CFF => this.CreateCffGlyphMetrics(in codePoint, glyphId, glyphType, textAttributes, textDecorations, colorSupport, isVerticalLayout, palette),
             _ => throw new NotSupportedException(),
         };
 

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/AnchorTable.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/GPos/AnchorTable.cs
@@ -160,8 +160,9 @@ internal abstract class AnchorTable
                 TextAttributes textAttributes = textRun.TextAttributes;
                 TextDecorations textDecorations = textRun.TextDecorations;
                 LayoutMode layoutMode = buffer.TextOptions.LayoutMode;
-                ColorFontSupport colorFontSupport = buffer.TextOptions.ColorFontSupport;
-                if (fontMetrics.TryGetGlyphMetrics(data.CodePoint, textAttributes, textDecorations, layoutMode, colorFontSupport, out FontGlyphMetrics? metrics))
+                ColorFontSupport colorFontSupport = textRun.ColorFontSupport ?? buffer.TextOptions.ColorFontSupport;
+                FontPalette? fontPalette = textRun.FontPalette ?? buffer.TextOptions.FontPalette;
+                if (fontMetrics.TryGetGlyphMetrics(data.CodePoint, textAttributes, textDecorations, layoutMode, colorFontSupport, fontPalette, out FontGlyphMetrics? metrics))
                 {
                     if (metrics is TrueTypeGlyphMetrics ttmetric)
                     {

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/Shapers/HangulShaper.cs
@@ -544,8 +544,9 @@ internal sealed class HangulShaper : DefaultShaper
         TextAttributes textAttributes = textRun.TextAttributes;
         TextDecorations textDecorations = textRun.TextDecorations;
         LayoutMode layoutMode = buffer.TextOptions.LayoutMode;
-        ColorFontSupport colorFontSupport = buffer.TextOptions.ColorFontSupport;
-        if (fontMetrics.TryGetGlyphMetrics(data.CodePoint, textAttributes, textDecorations, layoutMode, colorFontSupport, out FontGlyphMetrics? metrics)
+        ColorFontSupport colorFontSupport = textRun.ColorFontSupport ?? buffer.TextOptions.ColorFontSupport;
+        FontPalette? fontPalette = textRun.FontPalette ?? buffer.TextOptions.FontPalette;
+        if (fontMetrics.TryGetGlyphMetrics(data.CodePoint, textAttributes, textDecorations, layoutMode, colorFontSupport, fontPalette, out FontGlyphMetrics? metrics)
             && metrics.AdvanceWidth == 0)
         {
             return;
@@ -578,8 +579,9 @@ internal sealed class HangulShaper : DefaultShaper
             TextAttributes textAttributes = textRun.TextAttributes;
             TextDecorations textDecorations = textRun.TextDecorations;
             LayoutMode layoutMode = buffer.TextOptions.LayoutMode;
-            ColorFontSupport colorFontSupport = buffer.TextOptions.ColorFontSupport;
-            if (fontMetrics.TryGetGlyphMetrics(data.CodePoint, textAttributes, textDecorations, layoutMode, colorFontSupport, out FontGlyphMetrics? metrics)
+            ColorFontSupport colorFontSupport = textRun.ColorFontSupport ?? buffer.TextOptions.ColorFontSupport;
+            FontPalette? fontPalette = textRun.FontPalette ?? buffer.TextOptions.FontPalette;
+            if (fontMetrics.TryGetGlyphMetrics(data.CodePoint, textAttributes, textDecorations, layoutMode, colorFontSupport, fontPalette, out FontGlyphMetrics? metrics)
                 && metrics.AdvanceWidth != 0)
             {
                 after = true;

--- a/src/SixLabors.Fonts/Tables/General/Colr/ColrGlyphSourceBase.cs
+++ b/src/SixLabors.Fonts/Tables/General/Colr/ColrGlyphSourceBase.cs
@@ -19,11 +19,12 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
     /// </summary>
     /// <param name="colr">The COLR table.</param>
     /// <param name="cpal">The CPAL table, or null if not present.</param>
+    /// <param name="palette">The palette selection, or null for the font's default palette.</param>
     /// <param name="glyphLoader">Delegate that loads a glyph outline for the given glyph id.</param>
-    public ColrGlyphSourceBase(ColrTable colr, CpalTable? cpal, Func<ushort, GlyphVector?> glyphLoader)
+    public ColrGlyphSourceBase(ColrTable colr, CpalTable? cpal, FontPalette? palette, Func<ushort, GlyphVector?> glyphLoader)
     {
         this.Colr = colr;
-        this.Cpal = cpal;
+        this.PaletteColors = cpal?.GetPaletteColors(palette);
         this.GlyphLoader = glyphLoader;
     }
 
@@ -33,9 +34,11 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
     protected ColrTable Colr { get; }
 
     /// <summary>
-    /// Gets the CPAL table, or null if not present.
+    /// Gets the effective palette colors resolved from the CPAL table and the palette
+    /// selection, or null when the font has no CPAL table. The array is owned and shared
+    /// by the CPAL table across glyph sources and must never be mutated.
     /// </summary>
-    protected CpalTable? Cpal { get; }
+    protected GlyphColor[]? PaletteColors { get; }
 
     /// <summary>
     /// Gets the glyph loader delegate.
@@ -56,7 +59,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
     /// <param name="node">The COLR paint node.</param>
     /// <param name="transform">The affine matrix in document space.</param>
     /// <param name="mode">The active composite mode to apply to leaf paints, or null for default.</param>
-    /// <param name="cpal">Optional CPAL palette for color resolution.</param>
+    /// <param name="palette">Optional effective palette colors for color resolution.</param>
     /// <param name="colr">The COLR table for variation delta resolution.</param>
     /// <param name="processor">The glyph variation processor, or null for non-variable fonts.</param>
     /// <param name="outLeaves">Collector for emitted leaf paints.</param>
@@ -64,7 +67,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
         Paint node,
         Matrix3x2 transform,
         CompositeMode mode,
-        CpalTable? cpal,
+        GlyphColor[]? palette,
         ColrTable colr,
         GlyphVariationProcessor? processor,
         List<Rendering.Paint> outLeaves)
@@ -89,7 +92,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
                     return;
                 }
 
-                GlyphColor color = ResolveColor(cpal, ps.PaletteIndex, ps.Alpha);
+                GlyphColor color = ResolveColor(palette, ps.PaletteIndex, ps.Alpha);
                 outLeaves.Add(new SolidPaint
                 {
                     Color = color,
@@ -116,7 +119,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
                     return;
                 }
 
-                GlyphColor color = ResolveColor(cpal, pvs.PaletteIndex, alpha);
+                GlyphColor color = ResolveColor(palette, pvs.PaletteIndex, alpha);
                 outLeaves.Add(new SolidPaint
                 {
                     Color = color,
@@ -129,7 +132,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
 
             case PaintLinearGradient pl:
             {
-                GradientStop[] stops = ResolveStops(pl.ColorLine, cpal);
+                GradientStop[] stops = ResolveStops(pl.ColorLine, palette);
                 outLeaves.Add(new LinearGradientPaint
                 {
                     Units = GradientUnits.UserSpaceOnUse,
@@ -148,7 +151,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
             case PaintVarLinearGradient vpl:
             {
                 uint vib = vpl.VarIndexBase;
-                GradientStop[] stops = ResolveStops(vpl.ColorLine, cpal, colr, processor);
+                GradientStop[] stops = ResolveStops(vpl.ColorLine, palette, colr, processor);
                 outLeaves.Add(new LinearGradientPaint
                 {
                     Units = GradientUnits.UserSpaceOnUse,
@@ -166,7 +169,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
 
             case PaintRadialGradient pr:
             {
-                GradientStop[] stops = ResolveStops(pr.ColorLine, cpal);
+                GradientStop[] stops = ResolveStops(pr.ColorLine, palette);
                 outLeaves.Add(new RadialGradientPaint
                 {
                     Units = GradientUnits.UserSpaceOnUse,
@@ -186,7 +189,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
             case PaintVarRadialGradient vpr:
             {
                 uint vib = vpr.VarIndexBase;
-                GradientStop[] stops = ResolveStops(vpr.ColorLine, cpal, colr, processor);
+                GradientStop[] stops = ResolveStops(vpr.ColorLine, palette, colr, processor);
                 outLeaves.Add(new RadialGradientPaint
                 {
                     Units = GradientUnits.UserSpaceOnUse,
@@ -205,7 +208,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
 
             case PaintSweepGradient sw:
             {
-                GradientStop[] stops = ResolveStops(sw.ColorLine, cpal);
+                GradientStop[] stops = ResolveStops(sw.ColorLine, palette);
                 outLeaves.Add(new SweepGradientPaint
                 {
                     Units = GradientUnits.UserSpaceOnUse,
@@ -226,7 +229,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
             case PaintVarSweepGradient vsw:
             {
                 uint vib = vsw.VarIndexBase;
-                GradientStop[] stops = ResolveStops(vsw.ColorLine, cpal, colr, processor);
+                GradientStop[] stops = ResolveStops(vsw.ColorLine, palette, colr, processor);
                 float startAngle = vsw.StartAngle + colr.ResolveDelta(processor, vib + 2u);
                 float endAngle = vsw.EndAngle + colr.ResolveDelta(processor, vib + 3u);
                 outLeaves.Add(new SweepGradientPaint
@@ -356,10 +359,10 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
     /// 0xFFFF palette indices are treated as transparent here (foreground color handled by text color elsewhere).
     /// </summary>
     /// <param name="line">The color line.</param>
-    /// <param name="cpal">The CPAL table, or null if not present.</param>
+    /// <param name="palette">The effective palette colors, or null if the font has no CPAL table.</param>
     /// <returns>The resolved gradient stops.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static GradientStop[] ResolveStops(ColorLine line, CpalTable? cpal)
+    private static GradientStop[] ResolveStops(ColorLine line, GlyphColor[]? palette)
     {
         ColorStop[] src = line.Stops;
         GradientStop[] stops = new GradientStop[src.Length];
@@ -370,7 +373,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
 
             GlyphColor c = s.PaletteIndex == 0xFFFF
                 ? new GlyphColor(0, 0, 0, 0) // transparent placeholder; renderer can blend with foreground
-                : ResolveColor(cpal, s.PaletteIndex, s.Alpha);
+                : ResolveColor(palette, s.PaletteIndex, s.Alpha);
 
             float offset = Math.Clamp(s.StopOffset, 0F, 1F);
 
@@ -386,12 +389,12 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
     /// 0xFFFF palette indices are treated as transparent here (foreground color handled by text color elsewhere).
     /// </summary>
     /// <param name="line">The variable color line.</param>
-    /// <param name="cpal">The CPAL table, or null if not present.</param>
+    /// <param name="palette">The effective palette colors, or null if the font has no CPAL table.</param>
     /// <param name="colr">The COLR table for delta resolution.</param>
     /// <param name="processor">The glyph variation processor, or null.</param>
     /// <returns>The resolved gradient stops.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static GradientStop[] ResolveStops(VarColorLine line, CpalTable? cpal, ColrTable colr, GlyphVariationProcessor? processor)
+    private static GradientStop[] ResolveStops(VarColorLine line, GlyphColor[]? palette, ColrTable colr, GlyphVariationProcessor? processor)
     {
         VarColorStop[] src = line.Stops;
         GradientStop[] stops = new GradientStop[src.Length];
@@ -406,7 +409,7 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
 
             GlyphColor c = s.PaletteIndex == 0xFFFF
                 ? new GlyphColor(0, 0, 0, 0) // transparent placeholder; renderer can blend with foreground
-                : ResolveColor(cpal, s.PaletteIndex, alpha);
+                : ResolveColor(palette, s.PaletteIndex, alpha);
 
             float offset = Math.Clamp(stopOffset, 0F, 1F);
 
@@ -417,17 +420,20 @@ internal abstract class ColrGlyphSourceBase : IPaintedGlyphSource
     }
 
     /// <summary>
-    /// Resolves a CPAL palette entry with an alpha multiplier.
+    /// Resolves an entry of the effective palette with an alpha multiplier.
     /// </summary>
-    /// <param name="cpal">The CPAL table, or null if not present.</param>
+    /// <param name="palette">The effective palette colors, or null if the font has no CPAL table.</param>
     /// <param name="paletteEntryIndex">The palette entry index.</param>
     /// <param name="alphaMul">The alpha multiplier.</param>
     /// <returns>The resolved color.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static GlyphColor ResolveColor(CpalTable? cpal, int paletteEntryIndex, float alphaMul)
+    private static GlyphColor ResolveColor(GlyphColor[]? palette, int paletteEntryIndex, float alphaMul)
     {
-        // Palette index 0 selection. If you later expose palette selection, thread it here.
-        GlyphColor baseColor = cpal is null ? new GlyphColor(0, 0, 0, 0) : cpal.GetGlyphColor(0, paletteEntryIndex);
+        // An entry index outside the effective palette resolves as transparent, the same
+        // fallback used when the font carries no CPAL table at all.
+        GlyphColor baseColor = palette is null || (uint)paletteEntryIndex >= (uint)palette.Length
+            ? new GlyphColor(0, 0, 0, 0)
+            : palette[paletteEntryIndex];
 
         byte a = (byte)Math.Clamp((int)MathF.Round(baseColor.A * alphaMul), 0, 255);
         return new GlyphColor(baseColor.R, baseColor.G, baseColor.B, a);

--- a/src/SixLabors.Fonts/Tables/General/Colr/ColrV0GlyphSource.cs
+++ b/src/SixLabors.Fonts/Tables/General/Colr/ColrV0GlyphSource.cs
@@ -24,9 +24,10 @@ internal sealed class ColrV0GlyphSource : ColrGlyphSourceBase
     /// </summary>
     /// <param name="colr">The COLR table.</param>
     /// <param name="cpal">The CPAL table, or null if not present.</param>
+    /// <param name="palette">The palette selection, or null for the font's default palette.</param>
     /// <param name="glyphLoader">Delegate that loads a glyph outline for the given glyph id.</param>
-    public ColrV0GlyphSource(ColrTable colr, CpalTable? cpal, Func<ushort, GlyphVector?> glyphLoader)
-        : base(colr, cpal, glyphLoader)
+    public ColrV0GlyphSource(ColrTable colr, CpalTable? cpal, FontPalette? palette, Func<ushort, GlyphVector?> glyphLoader)
+        : base(colr, cpal, palette, glyphLoader)
     {
     }
 
@@ -53,7 +54,7 @@ internal sealed class ColrV0GlyphSource : ColrGlyphSourceBase
                     // Flatten paint graph: attach composite mode to leaves.
                     List<Rendering.Paint> leafPaints = [];
                     PaintSolid paint = new() { PaletteIndex = rl.PaletteIndex, Alpha = 1, Format = 2 };
-                    FlattenPaint(paint, Matrix3x2.Identity, CompositeMode.SrcOver, this.Cpal, this.Colr, null, leafPaints);
+                    FlattenPaint(paint, Matrix3x2.Identity, CompositeMode.SrcOver, this.PaletteColors, this.Colr, null, leafPaints);
 
                     // Emit one layer per leaf paint.
                     for (int p = 0; p < leafPaints.Count; p++)

--- a/src/SixLabors.Fonts/Tables/General/Colr/ColrV1GlyphSource.cs
+++ b/src/SixLabors.Fonts/Tables/General/Colr/ColrV1GlyphSource.cs
@@ -31,10 +31,11 @@ internal sealed class ColrV1GlyphSource : ColrGlyphSourceBase
     /// </summary>
     /// <param name="colr">The COLR table.</param>
     /// <param name="cpal">The CPAL table, or null if not present.</param>
+    /// <param name="palette">The palette selection, or null for the font's default palette.</param>
     /// <param name="glyphLoader">Delegate that loads a glyph outline for the given glyph id.</param>
     /// <param name="processor">The glyph variation processor for variable fonts, or null.</param>
-    public ColrV1GlyphSource(ColrTable colr, CpalTable? cpal, Func<ushort, GlyphVector?> glyphLoader, GlyphVariationProcessor? processor = null)
-        : base(colr, cpal, glyphLoader)
+    public ColrV1GlyphSource(ColrTable colr, CpalTable? cpal, FontPalette? palette, Func<ushort, GlyphVector?> glyphLoader, GlyphVariationProcessor? processor)
+        : base(colr, cpal, palette, glyphLoader)
         => this.processor = processor;
 
     /// <inheritdoc/>
@@ -87,7 +88,7 @@ internal sealed class ColrV1GlyphSource : ColrGlyphSourceBase
 
                     // Composite modes belong to the group commands; ordinary leaf application is SrcOver.
                     List<Rendering.Paint> leafPaints = [];
-                    FlattenPaint(rl.Paint, rl.PaintTransform, CompositeMode.SrcOver, this.Cpal, this.Colr, this.processor, leafPaints);
+                    FlattenPaint(rl.Paint, rl.PaintTransform, CompositeMode.SrcOver, this.PaletteColors, this.Colr, this.processor, leafPaints);
 
                     // Emit one layer per leaf paint.
                     for (int p = 0; p < leafPaints.Count; p++)

--- a/src/SixLabors.Fonts/Tables/General/CpalTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CpalTable.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Collections.Concurrent;
+
 namespace SixLabors.Fonts.Tables.General;
 
 /// <summary>
@@ -16,6 +18,11 @@ internal class CpalTable : Table
     internal const string TableName = "CPAL";
 
     /// <summary>
+    /// The number of palette entries in each palette.
+    /// </summary>
+    private readonly ushort paletteEntryCount;
+
+    /// <summary>
     /// The offsets into the palette entries array for each palette.
     /// </summary>
     private readonly ushort[] paletteOffsets;
@@ -26,12 +33,29 @@ internal class CpalTable : Table
     private readonly GlyphColor[] paletteEntries;
 
     /// <summary>
+    /// The effective colors of the default palette, built on first use and shared by every
+    /// glyph source that renders with the default selection. The unsynchronized build race
+    /// is benign: both threads produce identical content.
+    /// </summary>
+    private GlyphColor[]? defaultPaletteColors;
+
+    /// <summary>
+    /// The effective colors per custom palette selection, created on the first custom
+    /// selection. Keyed by the value equality of <see cref="FontPalette"/> so each selection
+    /// in use materializes once per font; a lost creation race rebuilds into the surviving
+    /// dictionary.
+    /// </summary>
+    private ConcurrentDictionary<FontPalette, GlyphColor[]>? selectedPaletteColors;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CpalTable"/> class.
     /// </summary>
+    /// <param name="paletteEntryCount">The number of palette entries in each palette.</param>
     /// <param name="paletteOffsets">The index of each palette's first color record.</param>
     /// <param name="paletteEntries">The combined color records for all palettes.</param>
-    public CpalTable(ushort[] paletteOffsets, GlyphColor[] paletteEntries)
+    public CpalTable(ushort paletteEntryCount, ushort[] paletteOffsets, GlyphColor[] paletteEntries)
     {
+        this.paletteEntryCount = paletteEntryCount;
         this.paletteEntries = paletteEntries;
         this.paletteOffsets = paletteOffsets;
     }
@@ -44,6 +68,63 @@ internal class CpalTable : Table
     /// <returns>The <see cref="GlyphColor"/>.</returns>
     public GlyphColor GetGlyphColor(int paletteIndex, int paletteEntryIndex)
         => this.paletteEntries[this.paletteOffsets[paletteIndex] + paletteEntryIndex];
+
+    /// <summary>
+    /// Gets the effective color array for the given palette selection: the colors of the
+    /// selected palette with the selection's overrides applied in order.
+    /// A palette index outside the range defined by the font selects the default palette (index 0)
+    /// and overrides still apply, matching the CSS <c>font-palette</c> behavior. Overrides whose
+    /// entry index lies outside the palette entry range are ignored.
+    /// The returned array is cached per distinct selection and shared across every glyph
+    /// source in the font; callers must treat it as read-only.
+    /// </summary>
+    /// <param name="palette">The palette selection, or <see langword="null"/> for the default palette.</param>
+    /// <returns>The effective palette colors.</returns>
+    public GlyphColor[] GetPaletteColors(FontPalette? palette)
+    {
+        // The common case shares one array per font: no selection, and the explicit default
+        // selection, both resolve to palette 0 with no overrides.
+        if (palette is null || (palette.Index == 0 && palette.Overrides.Count == 0))
+        {
+            return this.defaultPaletteColors ??= this.BuildPaletteColors(null);
+        }
+
+        ConcurrentDictionary<FontPalette, GlyphColor[]> cache = this.selectedPaletteColors ??= new();
+        return cache.GetOrAdd(palette, static (key, table) => table.BuildPaletteColors(key), this);
+    }
+
+    /// <summary>
+    /// Builds the effective color array for the given palette selection. Runs once per
+    /// distinct selection; <see cref="GetPaletteColors"/> caches and shares the result.
+    /// </summary>
+    /// <param name="palette">The palette selection, or <see langword="null"/> for the default palette.</param>
+    /// <returns>The effective palette colors.</returns>
+    private GlyphColor[] BuildPaletteColors(FontPalette? palette)
+    {
+        int paletteIndex = 0;
+        if (palette is not null && palette.Index < this.paletteOffsets.Length)
+        {
+            paletteIndex = palette.Index;
+        }
+
+        GlyphColor[] colors = new GlyphColor[this.paletteEntryCount];
+        Array.Copy(this.paletteEntries, this.paletteOffsets[paletteIndex], colors, 0, colors.Length);
+
+        if (palette is not null)
+        {
+            IReadOnlyList<FontPaletteOverride> overrides = palette.Overrides;
+            for (int i = 0; i < overrides.Count; i++)
+            {
+                FontPaletteOverride paletteOverride = overrides[i];
+                if (paletteOverride.Index < colors.Length)
+                {
+                    colors[paletteOverride.Index] = paletteOverride.Color;
+                }
+            }
+        }
+
+        return colors;
+    }
 
     /// <summary>
     /// Loads the <see cref="CpalTable"/> from the specified font reader.
@@ -114,6 +195,6 @@ internal class CpalTable : Table
             palettes[n] = new GlyphColor(red, green, blue, alpha);
         }
 
-        return new CpalTable(colorRecordIndices, palettes);
+        return new CpalTable(numPaletteEntries, colorRecordIndices, palettes);
     }
 }

--- a/src/SixLabors.Fonts/TextLayout.LineBreaking.cs
+++ b/src/SixLabors.Fonts/TextLayout.LineBreaking.cs
@@ -93,7 +93,8 @@ internal static partial class TextLayout
                 run.TextRun.TextAttributes,
                 run.TextRun.TextDecorations,
                 shapedText.LayoutMode,
-                options.ColorFontSupport);
+                run.TextRun.ColorFontSupport ?? options.ColorFontSupport,
+                run.TextRun.FontPalette ?? options.FontPalette);
 
             // Full hinting substitutes whole pixel hinted advances on the flow axis only, so
             // the pen accumulates on the pixel grid exactly as the classic rasterizer's does
@@ -308,7 +309,8 @@ internal static partial class TextLayout
                                       glyph.TextAttributes,
                                       glyph.TextDecorations,
                                       shapedText.LayoutMode,
-                                      options.ColorFontSupport);
+                                      metricsSpan[0].TextRun.ColorFontSupport ?? options.ColorFontSupport,
+                                      metricsSpan[0].TextRun.FontPalette ?? options.FontPalette);
 
                                 // The tab advance lives only in the positioned snapshot;
                                 // the metrics instance is shared and must not be mutated.
@@ -663,7 +665,8 @@ internal static partial class TextLayout
             anchorMetric.TextAttributes,
             anchorMetric.TextDecorations,
             layoutMode,
-            options.ColorFontSupport);
+            anchor.TextRun.ColorFontSupport ?? options.ColorFontSupport,
+            anchor.TextRun.FontPalette ?? options.FontPalette);
 
         bool isHorizontalLayout = layoutMode.IsHorizontal();
         bool isVerticalLayout = layoutMode.IsVertical();

--- a/src/SixLabors.Fonts/TextMeasurer.cs
+++ b/src/SixLabors.Fonts/TextMeasurer.cs
@@ -833,6 +833,7 @@ public static class TextMeasurer
                 options.TextDecorations,
                 options.LayoutMode,
                 options.ColorFontSupport,
+                options.FontPalette,
                 out metrics)
             || FontGlyphMetrics.ShouldSkipGlyphRendering(metrics.CodePoint))
         {

--- a/src/SixLabors.Fonts/TextOptions.cs
+++ b/src/SixLabors.Fonts/TextOptions.cs
@@ -60,6 +60,7 @@ public class TextOptions
         this.KerningMode = options.KerningMode;
         this.Tracking = options.Tracking;
         this.ColorFontSupport = options.ColorFontSupport;
+        this.FontPalette = options.FontPalette;
         this.FeatureTags = new List<Tag>(options.FeatureTags);
         this.Culture = options.Culture;
         this.TextRuns = new List<TextRun>(options.TextRuns);
@@ -296,7 +297,21 @@ public class TextOptions
     /// <summary>
     /// Gets or sets the color font support options.
     /// </summary>
+    /// <remarks>
+    /// A text run with a non-null <see cref="TextRun.ColorFontSupport"/> value
+    /// replaces this value over that run.
+    /// </remarks>
     public ColorFontSupport ColorFontSupport { get; set; } = ColorFontSupport.ColrV1 | ColorFontSupport.ColrV0 | ColorFontSupport.Svg;
+
+    /// <summary>
+    /// Gets or sets the color palette selection used to resolve COLR glyph colors, or
+    /// <see langword="null"/> to use the font's default palette.
+    /// </summary>
+    /// <remarks>
+    /// A text run with a non-null <see cref="TextRun.FontPalette"/> value
+    /// replaces this value over that run.
+    /// </remarks>
+    public FontPalette? FontPalette { get; set; }
 
     /// <summary>
     /// Gets or sets the collection of additional feature tags to apply during glyph shaping.

--- a/src/SixLabors.Fonts/TextRun.cs
+++ b/src/SixLabors.Fonts/TextRun.cs
@@ -57,6 +57,18 @@ public class TextRun
     public IReadOnlyList<Tag>? FeatureTags { get; set; }
 
     /// <summary>
+    /// Gets or sets the color font support options for this run, or <see langword="null"/>
+    /// to use those supplied by the owning text options.
+    /// </summary>
+    public ColorFontSupport? ColorFontSupport { get; set; }
+
+    /// <summary>
+    /// Gets or sets the color palette selection used to resolve COLR glyph colors for this run,
+    /// or <see langword="null"/> to use the palette supplied by the owning text options.
+    /// </summary>
+    public FontPalette? FontPalette { get; set; }
+
+    /// <summary>
     /// Gets or sets the text attributes applied to this run.
     /// </summary>
     public TextAttributes TextAttributes { get; set; }

--- a/src/SixLabors.Fonts/TextShaper.Pipeline.cs
+++ b/src/SixLabors.Fonts/TextShaper.Pipeline.cs
@@ -641,6 +641,7 @@ public static partial class TextShaper
         CodePoint space = new(0x0020);
         LayoutMode layoutMode = shaped.TextOptions.LayoutMode;
         ColorFontSupport colorFontSupport = shaped.TextOptions.ColorFontSupport;
+        FontPalette? fontPalette = shaped.TextOptions.FontPalette;
         bool isVertical = layoutMode.IsVertical();
         Font? invisibleFont = null;
         ushort invisible = 0;
@@ -686,7 +687,7 @@ public static partial class TextShaper
             // The projection reads the glyph id and default advance from the
             // metrics entry, so the invisible glyph's metrics replace it.
             TextRun textRun = shaped.TextRuns[data.TextRunIndex];
-            entry.Metrics = font.FontMetrics.GetGlyphMetrics(space, invisible, textRun.TextAttributes, textRun.TextDecorations, layoutMode, colorFontSupport);
+            entry.Metrics = font.FontMetrics.GetGlyphMetrics(space, invisible, textRun.TextAttributes, textRun.TextDecorations, layoutMode, textRun.ColorFontSupport ?? colorFontSupport, textRun.FontPalette ?? fontPalette);
             shaped.SetGlyphId(i, invisible);
             data.IsHidden = true;
         }

--- a/tests/Images/ReferenceOutput/RenderColrEmojiWithInvertedPalette-.png
+++ b/tests/Images/ReferenceOutput/RenderColrEmojiWithInvertedPalette-.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40618bd1c212e77bec7efcea676286e8a8fdb816e5e6db23d89464a2ac0da91f
+size 7355

--- a/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontLoaderTests.cs
@@ -19,6 +19,7 @@ public class FontLoaderTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics _));
     }
 

--- a/tests/SixLabors.Fonts.Tests/FontMetricsTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontMetricsTests.cs
@@ -150,6 +150,7 @@ public class FontMetricsTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics metrics));
 
         Assert.Equal(codePoint, metrics.CodePoint);
@@ -179,6 +180,7 @@ public class FontMetricsTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics metrics));
 
         Assert.Equal(codePoint, metrics.CodePoint);
@@ -208,6 +210,7 @@ public class FontMetricsTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics metrics));
 
         Assert.Equal(codePoint, metrics.CodePoint);
@@ -237,6 +240,7 @@ public class FontMetricsTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics metrics));
 
         // Position 0.

--- a/tests/SixLabors.Fonts.Tests/FontPaletteTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontPaletteTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.Fonts.Rendering;
+using SixLabors.Fonts.Tables.General;
+using SixLabors.Fonts.Unicode;
+
+using System.Numerics;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Processing;
+
+namespace SixLabors.Fonts.Tests;
+
+public class FontPaletteTests
+{
+    /// <summary>
+    /// Reads the effective default palette straight from the font's CPAL table so tests
+    /// derive override lists from the real entry count instead of a guessed size.
+    /// </summary>
+    private static GlyphColor[] GetDefaultPaletteColors()
+    {
+        using Stream stream = TestFonts.TwemojiMozillaData();
+        using FontReader reader = new(stream);
+        return reader.GetTable<CpalTable>().GetPaletteColors(null);
+    }
+
+    /// <summary>
+    /// Overrides every palette entry of the font with one color, so assertions do not
+    /// depend on which CPAL entries the tested glyph references.
+    /// </summary>
+    private static FontPalette CreateUniformOverride(GlyphColor color)
+    {
+        GlyphColor[] palette = GetDefaultPaletteColors();
+        FontPaletteOverride[] overrides = new FontPaletteOverride[palette.Length];
+        for (int i = 0; i < overrides.Length; i++)
+        {
+            overrides[i] = new FontPaletteOverride(i, color);
+        }
+
+        return new FontPalette(0, overrides);
+    }
+
+    /// <summary>
+    /// Overrides every palette entry with its RGB complement, keeping alpha.
+    /// </summary>
+    private static FontPalette CreateInvertedPalette()
+    {
+        GlyphColor[] palette = GetDefaultPaletteColors();
+        FontPaletteOverride[] overrides = new FontPaletteOverride[palette.Length];
+        for (int i = 0; i < overrides.Length; i++)
+        {
+            GlyphColor c = palette[i];
+            overrides[i] = new FontPaletteOverride(i, new GlyphColor((byte)(255 - c.R), (byte)(255 - c.G), (byte)(255 - c.B), c.A));
+        }
+
+        return new FontPalette(0, overrides);
+    }
+
+    [Fact]
+    public void RenderColrGlyph_PaletteOverrideReplacesColors()
+    {
+        Font font = TestFonts.GetFont(TestFonts.TwemojiMozillaFile, 12);
+
+        ColorGlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, "😀", new TextOptions(font)
+        {
+            ColorFontSupport = ColorFontSupport.ColrV0,
+            FontPalette = CreateUniformOverride(GlyphColor.Red)
+        });
+
+        Assert.Equal(3, renderer.Colors.Count);
+        Assert.All(renderer.Colors, c => Assert.Equal(GlyphColor.Red, c));
+    }
+
+    [Fact]
+    public void RenderColrGlyph_OutOfRangePaletteIndexUsesDefaultPalette()
+    {
+        Font font = TestFonts.GetFont(TestFonts.TwemojiMozillaFile, 12);
+
+        ColorGlyphRenderer defaultRenderer = new();
+        TextRenderer.RenderTo(defaultRenderer, "😀", new TextOptions(font)
+        {
+            ColorFontSupport = ColorFontSupport.ColrV0
+        });
+
+        ColorGlyphRenderer selectedRenderer = new();
+        TextRenderer.RenderTo(selectedRenderer, "😀", new TextOptions(font)
+        {
+            ColorFontSupport = ColorFontSupport.ColrV0,
+            FontPalette = new FontPalette(9999)
+        });
+
+        Assert.Equal(defaultRenderer.Colors, selectedRenderer.Colors);
+    }
+
+    [Fact]
+    public void RenderColrGlyph_TextRunPaletteOverridesOptionsPalette()
+    {
+        Font font = TestFonts.GetFont(TestFonts.TwemojiMozillaFile, 12);
+
+        ColorGlyphRenderer defaultRenderer = new();
+        TextRenderer.RenderTo(defaultRenderer, "😀", new TextOptions(font)
+        {
+            ColorFontSupport = ColorFontSupport.ColrV0
+        });
+
+        // The run covers the first emoji only; the second renders with the options palette.
+        ColorGlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, "😀😀", new TextOptions(font)
+        {
+            ColorFontSupport = ColorFontSupport.ColrV0,
+            TextRuns = [new TextRun { Start = 0, End = 1, FontPalette = CreateUniformOverride(GlyphColor.Red) }]
+        });
+
+        Assert.Equal(6, renderer.Colors.Count);
+        Assert.All(renderer.Colors.Take(3), c => Assert.Equal(GlyphColor.Red, c));
+        Assert.Equal(defaultRenderer.Colors, renderer.Colors.Skip(3).ToList());
+    }
+
+    [Fact]
+    public void RenderGlyphById_UsesGlyphOptionsPalette()
+    {
+        Font font = TestFonts.GetFont(TestFonts.TwemojiMozillaFile, 12);
+        Assert.True(font.TryGetGlyphId(new CodePoint(0x1F600), out ushort glyphId));
+
+        ColorGlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, glyphId, new GlyphOptions
+        {
+            Font = font,
+            ColorFontSupport = ColorFontSupport.ColrV0,
+            FontPalette = CreateUniformOverride(GlyphColor.Blue)
+        });
+
+        Assert.Equal(3, renderer.Colors.Count);
+        Assert.All(renderer.Colors, c => Assert.Equal(GlyphColor.Blue, c));
+    }
+
+    [Fact]
+    public void RenderColrEmojiWithInvertedPalette()
+    {
+        Font font = TestFonts.GetFont(TestFonts.TwemojiMozillaFile, 128);
+
+        FontRectangle advance = TextMeasurer.MeasureAdvance("😀", new TextOptions(font));
+        int width = (int)Math.Ceiling(advance.Width);
+        int height = (int)Math.Ceiling(advance.Height);
+
+        // Two large emoji on one canvas: the left renders with the font's default palette,
+        // the right renders with a palette that inverts every CPAL entry. One canvas also
+        // exercises the renderer glyph cache, which must treat the palette variants of one
+        // glyph as distinct entries.
+        TextLayoutTestUtilities.TestImage(
+            width * 2,
+            height,
+            img => img.Mutate(ctx => ctx.Paint(canvas =>
+            {
+                canvas.DrawText(
+                    new RichTextOptions(font) { ColorFontSupport = ColorFontSupport.ColrV0 },
+                    "😀",
+                    Brushes.Solid(Color.Black),
+                    pen: null);
+
+                canvas.DrawText(
+                    new RichTextOptions(font) { ColorFontSupport = ColorFontSupport.ColrV0, FontPalette = CreateInvertedPalette(), Origin = new Vector2(width, 0) },
+                    "😀",
+                    Brushes.Solid(Color.Black),
+                    pen: null);
+            })));
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/FontSynthesisTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontSynthesisTests.cs
@@ -165,6 +165,7 @@ public class FontSynthesisTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics metrics));
 
         Assert.Equal(0F, metrics.GetObliqueSkew(null));
@@ -400,6 +401,7 @@ public class FontSynthesisTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics metrics));
 
         Assert.False(metrics.ShouldSynthesizeBold(null));

--- a/tests/SixLabors.Fonts.Tests/FontWeightTests.cs
+++ b/tests/SixLabors.Fonts.Tests/FontWeightTests.cs
@@ -106,6 +106,7 @@ public class FontWeightTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics metrics));
 
         float strength = metrics.GetSyntheticBoldStrength(pointSize * 72F, textRun);
@@ -147,6 +148,7 @@ public class FontWeightTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.ColrV0,
+            null,
             out FontGlyphMetrics metrics));
 
         Assert.Equal(GlyphType.Painted, metrics.GlyphType);
@@ -178,6 +180,7 @@ public class FontWeightTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics metrics));
 
         Assert.False(metrics.ShouldSynthesizeBold(textRun));
@@ -216,6 +219,7 @@ public class FontWeightTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics metrics));
 
         Assert.False(metrics.ShouldSynthesizeBold(textRun));

--- a/tests/SixLabors.Fonts.Tests/GdiOutlineProbe.cs
+++ b/tests/SixLabors.Fonts.Tests/GdiOutlineProbe.cs
@@ -56,7 +56,7 @@ public class GdiOutlineProbe
 
             foreach (char c in chars)
             {
-                font.FontMetrics.TryGetGlyphMetrics(new SixLabors.Fonts.Unicode.CodePoint(c), TextAttributes.None, TextDecorations.None, LayoutMode.HorizontalTopBottom, ColorFontSupport.None, out FontGlyphMetrics? metrics);
+                font.FontMetrics.TryGetGlyphMetrics(new SixLabors.Fonts.Unicode.CodePoint(c), TextAttributes.None, TextDecorations.None, LayoutMode.HorizontalTopBottom, ColorFontSupport.None, null, out FontGlyphMetrics? metrics);
                 if (metrics is not TrueTypeGlyphMetrics tt)
                 {
                     continue;

--- a/tests/SixLabors.Fonts.Tests/GlyphTests.cs
+++ b/tests/SixLabors.Fonts.Tests/GlyphTests.cs
@@ -123,6 +123,24 @@ public class GlyphTests
     }
 
     [Fact]
+    public void RenderColrGlyphTextRunColorFontSupportOverridesOptions()
+    {
+        Font font = TestFonts.GetFont(TestFonts.TwemojiMozillaFile, 12);
+
+        // The run disables color for the first emoji only; the second keeps the
+        // options value and contributes the three COLR v0 layer colors.
+        ColorGlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, "😀😀", new TextOptions(font)
+        {
+            ColorFontSupport = ColorFontSupport.ColrV0,
+            TextRuns = [new TextRun { Start = 0, End = 1, ColorFontSupport = ColorFontSupport.None }]
+        });
+
+        Assert.Equal(2, renderer.GlyphKeys.Count);
+        Assert.Equal(3, renderer.Colors.Count);
+    }
+
+    [Fact]
     public void RenderColrGlyphWithVariationSelector()
     {
         Font font = TestFonts.GetFont(TestFonts.TwemojiMozillaFile, 72);

--- a/tests/SixLabors.Fonts.Tests/HintingTests.cs
+++ b/tests/SixLabors.Fonts.Tests/HintingTests.cs
@@ -335,7 +335,7 @@ public class HintingTests
         FontFamily family = collection.Add(TestFonts.Arial);
         Font font = family.CreateFont(12);
 
-        Assert.True(font.FontMetrics.TryGetGlyphMetrics(new CodePoint('H'), TextAttributes.None, TextDecorations.None, LayoutMode.HorizontalTopBottom, ColorFontSupport.None, out FontGlyphMetrics metrics));
+        Assert.True(font.FontMetrics.TryGetGlyphMetrics(new CodePoint('H'), TextAttributes.None, TextDecorations.None, LayoutMode.HorizontalTopBottom, ColorFontSupport.None, null, out FontGlyphMetrics metrics));
 
         TrueTypeGlyphMetrics ttMetrics = Assert.IsType<TrueTypeGlyphMetrics>(metrics);
         StreamFontMetrics streamMetrics = Assert.IsType<StreamFontMetrics>(ttMetrics.FontMetrics);
@@ -435,7 +435,7 @@ public class HintingTests
         FontFamily family = collection.Add(TestFonts.PlantinStdRegularFile);
         Font font = family.CreateFont(12);
 
-        Assert.True(font.FontMetrics.TryGetGlyphMetrics(new CodePoint('H'), TextAttributes.None, TextDecorations.None, LayoutMode.VerticalLeftRight, ColorFontSupport.None, out FontGlyphMetrics metrics));
+        Assert.True(font.FontMetrics.TryGetGlyphMetrics(new CodePoint('H'), TextAttributes.None, TextDecorations.None, LayoutMode.VerticalLeftRight, ColorFontSupport.None, null, out FontGlyphMetrics metrics));
 
         float scaledPPEM = metrics.GetScaledSize(12F, 72F, HintingMode.Full);
         Assert.True(metrics.TryGetFittedOutlinePlacement(scaledPPEM, HintingMode.Full, true, out FontGlyphMetrics.FittedOutlinePlacement placement));

--- a/tests/SixLabors.Fonts.Tests/Issues/Issues_400.cs
+++ b/tests/SixLabors.Fonts.Tests/Issues/Issues_400.cs
@@ -2,14 +2,11 @@
 // Licensed under the Six Labors Split License.
 
 using System.Text;
-
-#if SUPPORTS_DRAWING
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-#endif
 
 namespace SixLabors.Fonts.Tests.Issues;
 
@@ -33,17 +30,12 @@ public class Issues_400
         int lineCount = TextMeasurer.CountLines(text, options);
         Assert.Equal(4, lineCount);
 
-#if SUPPORTS_DRAWING
         TextLayoutTestUtilities.TestLayout(
             text,
             options,
             afterAction: image => DrawBoundsOverlay(image, text, options));
-#else
-        TextLayoutTestUtilities.TestLayout(text, options);
-#endif
     }
 
-#if SUPPORTS_DRAWING
     private static void DrawBoundsOverlay(Image<Rgba32> image, string text, TextOptions options)
     {
         FontRectangle advance = TextMeasurer.MeasureAdvance(text, options);
@@ -77,5 +69,4 @@ public class Issues_400
             Pens.Solid(color, thickness),
             new RectanglePolygon(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height));
     }
-#endif
 }

--- a/tests/SixLabors.Fonts.Tests/Tables/General/CpalTableTests.cs
+++ b/tests/SixLabors.Fonts.Tests/Tables/General/CpalTableTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.Fonts.Tables.General;
+
+namespace SixLabors.Fonts.Tests.Tables.General;
+
+public class CpalTableTests
+{
+    private static CpalTable CreateTwoPaletteTable()
+        => new(
+            2,
+            [0, 2],
+            [
+                new GlyphColor(10, 11, 12, 255),
+                new GlyphColor(20, 21, 22, 255),
+                new GlyphColor(30, 31, 32, 255),
+                new GlyphColor(40, 41, 42, 255)
+            ]);
+
+    [Fact]
+    public void GetPaletteColors_NullSelection_ReturnsDefaultPalette()
+    {
+        CpalTable table = CreateTwoPaletteTable();
+
+        GlyphColor[] colors = table.GetPaletteColors(null);
+
+        Assert.Equal(2, colors.Length);
+        Assert.Equal(new GlyphColor(10, 11, 12, 255), colors[0]);
+        Assert.Equal(new GlyphColor(20, 21, 22, 255), colors[1]);
+    }
+
+    [Fact]
+    public void GetPaletteColors_SelectsPaletteByIndex()
+    {
+        CpalTable table = CreateTwoPaletteTable();
+
+        GlyphColor[] colors = table.GetPaletteColors(new FontPalette(1));
+
+        Assert.Equal(2, colors.Length);
+        Assert.Equal(new GlyphColor(30, 31, 32, 255), colors[0]);
+        Assert.Equal(new GlyphColor(40, 41, 42, 255), colors[1]);
+    }
+
+    [Fact]
+    public void GetPaletteColors_OutOfRangeIndex_FallsBackToDefaultAndAppliesOverrides()
+    {
+        CpalTable table = CreateTwoPaletteTable();
+
+        GlyphColor[] colors = table.GetPaletteColors(new FontPalette(9, [new FontPaletteOverride(1, GlyphColor.Red)]));
+
+        Assert.Equal(new GlyphColor(10, 11, 12, 255), colors[0]);
+        Assert.Equal(GlyphColor.Red, colors[1]);
+    }
+
+    [Fact]
+    public void GetPaletteColors_LaterOverrideWins_AndOutOfRangeOverrideIsIgnored()
+    {
+        CpalTable table = CreateTwoPaletteTable();
+
+        GlyphColor[] colors = table.GetPaletteColors(new FontPalette(0,
+        [
+            new FontPaletteOverride(0, GlyphColor.Blue),
+            new FontPaletteOverride(0, GlyphColor.Lime),
+            new FontPaletteOverride(5, GlyphColor.Red)
+        ]));
+
+        Assert.Equal(GlyphColor.Lime, colors[0]);
+        Assert.Equal(new GlyphColor(20, 21, 22, 255), colors[1]);
+    }
+
+    [Fact]
+    public void GetPaletteColors_SharesOneArrayPerSelection()
+    {
+        CpalTable table = CreateTwoPaletteTable();
+
+        // The default selection and the explicit default selection share one array.
+        Assert.Same(table.GetPaletteColors(null), table.GetPaletteColors(null));
+        Assert.Same(table.GetPaletteColors(null), table.GetPaletteColors(new FontPalette(0)));
+
+        // Value-equal custom selections share one array even across distinct instances.
+        FontPalette a = new(1, [new FontPaletteOverride(0, GlyphColor.Red)]);
+        FontPalette b = new(1, [new FontPaletteOverride(0, GlyphColor.Red)]);
+        Assert.Same(table.GetPaletteColors(a), table.GetPaletteColors(b));
+    }
+
+    [Fact]
+    public void FontPalette_ValueEquality()
+    {
+        FontPalette a = new(1, [new FontPaletteOverride(0, GlyphColor.Red), new FontPaletteOverride(1, GlyphColor.Blue)]);
+        FontPalette b = new(1, [new FontPaletteOverride(0, GlyphColor.Red), new FontPaletteOverride(1, GlyphColor.Blue)]);
+        FontPalette reordered = new(1, [new FontPaletteOverride(1, GlyphColor.Blue), new FontPaletteOverride(0, GlyphColor.Red)]);
+        FontPalette differentIndex = new(2, [new FontPaletteOverride(0, GlyphColor.Red), new FontPaletteOverride(1, GlyphColor.Blue)]);
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+
+        // Overrides apply in order and a later override wins, so order participates in equality.
+        Assert.False(a.Equals(reordered));
+        Assert.False(a.Equals(differentIndex));
+        Assert.False(a.Equals(null));
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/TextAlignmentTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextAlignmentTests.cs
@@ -12,7 +12,6 @@ using SixLabors.ImageSharp.Processing;
 
 namespace SixLabors.Fonts.Tests;
 
-#if SUPPORTS_DRAWING
 public class TextAlignmentTests
 {
     private const int Padding = 20;
@@ -234,4 +233,3 @@ public class TextAlignmentTests
         }
     }
 }
-#endif

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTestUtilities.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTestUtilities.cs
@@ -192,6 +192,7 @@ internal static class TextLayoutTestUtilities
             DecorationPositioningMode = options.DecorationPositioningMode,
             Tracking = options.Tracking,
             ColorFontSupport = options.ColorFontSupport,
+            FontPalette = options.FontPalette,
             FeatureTags = new List<Tag>(options.FeatureTags),
             Culture = options.Culture,
         };
@@ -212,6 +213,8 @@ internal static class TextLayoutTestUtilities
                     FeatureTags = run.FeatureTags is null ? null : new List<Tag>(run.FeatureTags),
                     TextAttributes = run.TextAttributes,
                     TextDecorations = run.TextDecorations,
+                    ColorFontSupport = run.ColorFontSupport,
+                    FontPalette = run.FontPalette,
                 };
 
                 if (customDecorations && run.TextDecorations != TextDecorations.None)

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -1255,7 +1255,6 @@ public class TextLayoutTests
             ]
         };
 
-        IReadOnlyList<GlyphPathCollection> glyphs = TextBuilder.GenerateGlyphs(text, options);
         TextMetrics metrics = TextMeasurer.Measure(text, options);
 
         LineMetrics line = metrics.LineMetrics[0];
@@ -1283,6 +1282,10 @@ public class TextLayoutTests
             180,
             image => image.Mutate(x => x.Paint(canvas =>
             {
+                // Must stay inside the deferred action so the test is a no-op when
+                // SUPPORTS_DRAWING is off.
+                IReadOnlyList<GlyphPathCollection> glyphs = TextBuilder.GenerateGlyphs(text, options);
+
                 RectanglePolygon lineBox = new(
                     0,
                     line.Start.Y,
@@ -1362,7 +1365,6 @@ public class TextLayoutTests
             ]
         };
 
-        IReadOnlyList<GlyphPathCollection> glyphs = TextBuilder.GenerateGlyphs(text, options);
         TextMetrics metrics = TextMeasurer.Measure(text, options);
 
         LineMetrics line = metrics.LineMetrics[0];
@@ -1389,6 +1391,10 @@ public class TextLayoutTests
             260,
             image => image.Mutate(x => x.Paint(canvas =>
             {
+                // Must stay inside the deferred action so the test is a no-op when
+                // SUPPORTS_DRAWING is off.
+                IReadOnlyList<GlyphPathCollection> glyphs = TextBuilder.GenerateGlyphs(text, options);
+
                 RectanglePolygon lineBox = new(
                     0,
                     line.Start.Y,

--- a/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextLayoutTests.cs
@@ -1223,7 +1223,6 @@ public class TextLayoutTests
         Assert.Throws<ArgumentException>(() => TextMeasurer.MeasureAdvance(text, options));
     }
 
-#if SUPPORTS_DRAWING
     [Theory]
     [InlineData(TextPlaceholderAlignment.Baseline)]
     [InlineData(TextPlaceholderAlignment.AboveBaseline)]
@@ -1330,9 +1329,7 @@ public class TextLayoutTests
         // also exposes one object-replacement glyph at the insertion point.
         Assert.Equal(1, CountGlyphs(metrics.GetGlyphMetrics().Span, CodePoint.ObjectReplacementChar));
     }
-#endif
 
-#if SUPPORTS_DRAWING
     [Theory]
     [InlineData(TextPlaceholderAlignment.Baseline)]
     [InlineData(TextPlaceholderAlignment.AboveBaseline)]
@@ -1438,7 +1435,6 @@ public class TextLayoutTests
         // The oversized visual still represents one atomic inline object.
         Assert.Equal(1, CountGlyphs(metrics.GetGlyphMetrics().Span, CodePoint.ObjectReplacementChar));
     }
-#endif
 
     /// <summary>
     /// Verifies that mixed vertical page orientation does not disable Arabic joining substitutions.

--- a/tests/SixLabors.Fonts.Tests/TextRendererGlyphIdTests.cs
+++ b/tests/SixLabors.Fonts.Tests/TextRendererGlyphIdTests.cs
@@ -24,6 +24,7 @@ public class TextRendererGlyphIdTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics codePointMetrics));
 
         Assert.True(font.FontMetrics.TryGetGlyphMetrics(
@@ -32,6 +33,7 @@ public class TextRendererGlyphIdTests
             TextDecorations.None,
             LayoutMode.HorizontalTopBottom,
             ColorFontSupport.None,
+            null,
             out FontGlyphMetrics glyphIdMetrics));
 
         Assert.Equal(codePointMetrics.GlyphId, glyphIdMetrics.GlyphId);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Introduce `FontPalette` and `FontPaletteOverride`, expose palette selection on text and glyph options, and thread it through glyph metrics, shaping, COLR rendering, and renderer cache keys so palette variants render correctly. The change also adds CPAL palette caching/override behavior tests, glyph rendering coverage, and a reference image for inverted emoji palettes.

<!-- Thanks for contributing to SixLabors.Fonts! -->
