### PR TITLE
Resolve emoji presentation selectors across the font chain

### DIFF
--- a/src/SixLabors.Fonts/FileFontMetrics.cs
+++ b/src/SixLabors.Fonts/FileFontMetrics.cs
@@ -201,6 +201,9 @@ internal sealed class FileFontMetrics : FontMetrics
         => this.fontMetrics.Value.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support, palette);
 
     /// <inheritdoc />
+    internal override bool HasColorTable(ColorFontSupport colorSupport) => this.fontMetrics.Value.HasColorTable(colorSupport);
+
+    /// <inheritdoc />
     public override ReadOnlyMemory<CodePoint> GetAvailableCodePoints()
         => this.fontMetrics.Value.GetAvailableCodePoints();
 

--- a/src/SixLabors.Fonts/FontMetrics.cs
+++ b/src/SixLabors.Fonts/FontMetrics.cs
@@ -306,6 +306,15 @@ public abstract class FontMetrics
         FontPalette? palette);
 
     /// <summary>
+    /// Gets a value indicating whether the font carries a color table of a kind
+    /// <paramref name="colorSupport"/> enables: COLR for COLR v0, COLR version 1 for
+    /// COLR v1, or SVG.
+    /// </summary>
+    /// <param name="colorSupport">Options for enabling color font support during layout and rendering.</param>
+    /// <returns><see langword="true"/> when the font has an enabled color table.</returns>
+    internal abstract bool HasColorTable(ColorFontSupport colorSupport);
+
+    /// <summary>
     /// Tries to get the GSUB table.
     /// </summary>
     /// <param name="gSubTable">The GSUB table.</param>

--- a/src/SixLabors.Fonts/MemoryFontMetrics.cs
+++ b/src/SixLabors.Fonts/MemoryFontMetrics.cs
@@ -195,6 +195,9 @@ internal sealed class MemoryFontMetrics : FontMetrics
         => this.fontMetrics.Value.GetGlyphMetrics(codePoint, glyphId, textAttributes, textDecorations, layoutMode, support, palette);
 
     /// <inheritdoc />
+    internal override bool HasColorTable(ColorFontSupport colorSupport) => this.fontMetrics.Value.HasColorTable(colorSupport);
+
+    /// <inheritdoc />
     public override ReadOnlyMemory<CodePoint> GetAvailableCodePoints()
         => this.fontMetrics.Value.GetAvailableCodePoints();
 

--- a/src/SixLabors.Fonts/ShapingBuffer.cs
+++ b/src/SixLabors.Fonts/ShapingBuffer.cs
@@ -129,6 +129,16 @@ internal sealed class ShapingBuffer
     private const int DottedCircleCodePoint = 0x25CC;
 
     /// <summary>
+    /// U+FE0F VARIATION SELECTOR-16, which requests emoji presentation for the preceding character.
+    /// </summary>
+    public const int EmojiPresentationSelector = 0xFE0F;
+
+    /// <summary>
+    /// U+FE0E VARIATION SELECTOR-15, which requests text presentation for the preceding character.
+    /// </summary>
+    public const int TextPresentationSelector = 0xFE0E;
+
+    /// <summary>
     /// The multiplier used by the deterministic random sequence.
     /// </summary>
     private const uint RandomMultiplier = 48271;
@@ -338,6 +348,13 @@ internal sealed class ShapingBuffer
     /// hide-ignorables stage can skip plain text without a scan.
     /// </summary>
     public bool HasDefaultIgnorables { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a record's base character was mapped but
+    /// the presentation its selector asks for was not, so the cluster is missing for
+    /// that font. When no font answers it, the fonts run again with selectors ignored.
+    /// </summary>
+    public bool HasUnmatchedVariationSequences { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether any record carries the fraction
@@ -554,7 +571,8 @@ internal sealed class ShapingBuffer
 
             FontGlyphMetrics glyphMetrics = this.GetGlyphMetrics(fontMetrics, codePoint, slot.GlyphId, textAttributes, textDecorations, layoutMode, textRun.ColorFontSupport ?? colorFontSupport, textRun.FontPalette ?? fontPalette);
 
-            if (glyphMetrics.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
+            // A default ignorable without a glyph is hidden later, never missing.
+            if (glyphMetrics.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint) && !slot.IsDefaultIgnorable)
             {
                 hasFallBacks = true;
             }
@@ -623,6 +641,7 @@ internal sealed class ShapingBuffer
         this.LigatureId = 1;
         this.EnabledFeatureMaskUnion = ShapePlanFeatures.GlobalFeatureMask;
         this.HasDefaultIgnorables = false;
+        this.HasUnmatchedVariationSequences = false;
         this.HasFractionSlash = false;
         this.HasVowelConstraintCandidates = false;
         this.placeholderBidiRuns.Clear();
@@ -1551,6 +1570,7 @@ internal sealed class ShapingBuffer
         // The hide-ignorables stage runs against this buffer, so the workspace's
         // knowledge of default ignorables must travel with its records.
         this.HasDefaultIgnorables |= workspace.HasDefaultIgnorables;
+        this.HasUnmatchedVariationSequences |= workspace.HasUnmatchedVariationSequences;
         this.HasFractionSlash |= workspace.HasFractionSlash;
         this.HasVowelConstraintCandidates |= workspace.HasVowelConstraintCandidates;
 
@@ -1593,7 +1613,8 @@ internal sealed class ShapingBuffer
 
             FontGlyphMetrics glyphMetrics = this.GetGlyphMetrics(fontMetrics, codePoint, id, textAttributes, textDecorations, layoutMode, sourceRun.ColorFontSupport ?? colorFontSupport, sourceRun.FontPalette ?? fontPalette);
 
-            if (glyphMetrics.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint))
+            // A default ignorable without a glyph is hidden later, never missing.
+            if (glyphMetrics.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(codePoint) && !source.IsDefaultIgnorable)
             {
                 hasFallBacks = true;
             }
@@ -1638,6 +1659,7 @@ internal sealed class ShapingBuffer
         // The hide-ignorables stage runs against this buffer, so the workspace's
         // knowledge of default ignorables must travel with its records.
         this.HasDefaultIgnorables |= workspace.HasDefaultIgnorables;
+        this.HasUnmatchedVariationSequences |= workspace.HasUnmatchedVariationSequences;
         this.HasFractionSlash |= workspace.HasFractionSlash;
         this.HasVowelConstraintCandidates |= workspace.HasVowelConstraintCandidates;
 
@@ -1645,10 +1667,11 @@ internal sealed class ShapingBuffer
 
         for (int i = 0; i < this.Count;)
         {
-            if (this.metrics[i].Metrics.GlyphType != GlyphType.Fallback)
+            if (this.metrics[i].Metrics.GlyphType != GlyphType.Fallback || this.data[i].IsDefaultIgnorable)
             {
                 // A primary or earlier fallback font already resolved this record.
-                // Later fallback passes must not replace a successful choice.
+                // Later fallback passes must not replace a successful choice. A
+                // default ignorable without a glyph is hidden later, never missing.
                 i++;
                 continue;
             }
@@ -1712,7 +1735,7 @@ internal sealed class ShapingBuffer
                     shapeRun.ColorFontSupport ?? colorFontSupport,
                     shapeRun.FontPalette ?? fontPalette);
 
-                if (glyphMetrics.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(shape.CodePoint))
+                if (glyphMetrics.GlyphType == GlyphType.Fallback && !CodePoint.IsControl(shape.CodePoint) && !shape.IsDefaultIgnorable)
                 {
                     replacementsComplete = false;
                     break;
@@ -1993,7 +2016,7 @@ internal sealed class ShapingBuffer
         for (int i = 0; i < this.Count; i++)
         {
             ref GlyphShapingData slot = ref this.data[i];
-            if (slot.IsPlaceholder || CodePoint.IsControl(slot.CodePoint))
+            if (slot.IsPlaceholder || CodePoint.IsControl(slot.CodePoint) || slot.IsDefaultIgnorable)
             {
                 continue;
             }

--- a/src/SixLabors.Fonts/StreamFontMetrics.cs
+++ b/src/SixLabors.Fonts/StreamFontMetrics.cs
@@ -10,6 +10,7 @@ using SixLabors.Fonts.Tables.AdvancedTypographic;
 using SixLabors.Fonts.Tables.AdvancedTypographic.Variations;
 using SixLabors.Fonts.Tables.Cff;
 using SixLabors.Fonts.Tables.General;
+using SixLabors.Fonts.Tables.General.Colr;
 using SixLabors.Fonts.Tables.General.Kern;
 using SixLabors.Fonts.Tables.General.Post;
 using SixLabors.Fonts.Tables.General.Svg;
@@ -431,6 +432,19 @@ internal partial class StreamFontMetrics : FontMetrics
                 key.IsVerticalLayout,
                 key.Palette),
             (textDecorations, codePoint, this));
+
+    /// <inheritdoc/>
+    internal override bool HasColorTable(ColorFontSupport colorSupport)
+    {
+        ColrTable? colr = this.trueTypeFontTables?.Colr ?? this.compactFontTables?.Colr;
+        if (colr is not null && ((colorSupport & ColorFontSupport.ColrV0) == ColorFontSupport.ColrV0 || ((colorSupport & ColorFontSupport.ColrV1) == ColorFontSupport.ColrV1 && colr.Version >= 1)))
+        {
+            return true;
+        }
+
+        SvgTable? svg = this.trueTypeFontTables?.Svg ?? this.compactFontTables?.Svg;
+        return svg is not null && (colorSupport & ColorFontSupport.Svg) == ColorFontSupport.Svg;
+    }
 
     /// <inheritdoc />
     public override ReadOnlyMemory<CodePoint> GetAvailableCodePoints()

--- a/src/SixLabors.Fonts/Tables/AdvancedTypographic/SkippingGlyphIterator.cs
+++ b/src/SixLabors.Fonts/Tables/AdvancedTypographic/SkippingGlyphIterator.cs
@@ -378,15 +378,17 @@ internal struct SkippingGlyphIterator
 
     /// <summary>
     /// Determines whether the record is transparent to the current matcher: a
-    /// default ignorable whose joiner bits the matcher ignores. Transparent
-    /// records are stepped over during matching unless they match the sequence
-    /// position themselves.
+    /// default ignorable that no lookup has substituted and whose joiner bits the
+    /// matcher ignores. A substituted record is an ordinary glyph whatever
+    /// codepoint it came from. Transparent records are stepped over during
+    /// matching unless they match the sequence position themselves.
     /// </summary>
     /// <param name="data">The record to test.</param>
     /// <returns><see langword="true"/> when the record may be stepped over.</returns>
     public readonly bool IsTransparent(ref GlyphShapingData data)
         => (this.matchFlags & TransparencyActiveFlag) != 0
         && data.IsDefaultIgnorable
+        && !data.IsSubstituted
         && ((this.matchFlags & IgnoreZwnjFlag) != 0 || !data.IsZwnj)
         && ((this.matchFlags & IgnoreZwjFlag) != 0 || !data.IsZwj)
         && ((this.matchFlags & IgnoreHiddenFlag) != 0 || !data.IsHiddenIgnorable);

--- a/src/SixLabors.Fonts/Tables/General/CMap/Format14SubTable.cs
+++ b/src/SixLabors.Fonts/Tables/General/CMap/Format14SubTable.cs
@@ -192,11 +192,11 @@ internal sealed class Format14SubTable : CMapSubTable
                 }
             }
 
-            // At this point we are neither a non-default UVS nor a default UVS,
-            // but we know the nextCodepoint is a variation selector. Unicode says
-            // this glyph should be invisible: "no visible rendering for the VS"
-            // (http://unicode.org/faq/unsup_char.html#4)
-            return defaultGlyphIndex;
+            // The selector has a record but the base character is in neither its
+            // default nor its non-default mappings, so the pair is not a variation
+            // sequence of this font. Both characters continue separately; the
+            // selector renders invisibly through its own glyph.
+            return 0;
         }
 
         // In all other cases, return 0

--- a/src/SixLabors.Fonts/TextShaper.Pipeline.cs
+++ b/src/SixLabors.Fonts/TextShaper.Pipeline.cs
@@ -283,13 +283,14 @@ public static partial class TextShaper
 
         // Single-run fast path: shape and seed one buffer in place and flip it to the
         // positioning role, so no record is copied between buffers. When fallback
-        // glyphs remain and fallback fonts exist, fall through to the general
-        // cross-buffer seed so the fallback passes can merge into the accumulator.
+        // glyphs remain and fallback fonts exist, or a selector cluster went unmatched
+        // and the pass that ignores selectors must run, fall through to the general
+        // cross-buffer seed so those passes can merge into the accumulator.
         ShapingBuffer shaped = positionings;
         if (textRuns.Count == 1 && !textRuns[0].Placeholder.HasValue)
         {
             TextRun onlyRun = textRuns[0];
-            int graphemeEnd = PopulateAndSubstitute(text, onlyRun.Start, textRuns, ref textRunIndex, ref codePointIndex, ref stringIndex, ref bidiRunIndex, onlyRun.ResolvedFont, bidiRuns, bidiMap, substitutions);
+            int graphemeEnd = PopulateAndSubstitute(text, onlyRun.Start, textRuns, ref textRunIndex, ref codePointIndex, ref stringIndex, ref bidiRunIndex, onlyRun.ResolvedFont, bidiRuns, bidiMap, substitutions, false);
 
             if (usesDefaultTextRun)
             {
@@ -300,7 +301,7 @@ public static partial class TextShaper
 
             complete = substitutions.SeedMetricsInPlace(onlyRun.ResolvedFont);
 
-            if (complete || (fallbackFonts.Length == 0 && options.FontFallbackResolver is null))
+            if (complete || (fallbackFonts.Length == 0 && options.FontFallbackResolver is null && !substitutions.HasUnmatchedVariationSequences))
             {
                 substitutions.SetRole(ShapingBufferRole.Positioning);
                 shaped = substitutions;
@@ -361,7 +362,8 @@ public static partial class TextShaper
                 bidiRuns,
                 bidiMap,
                 substitutions,
-                positionings))
+                positionings,
+                false))
             {
                 complete = false;
             }
@@ -391,7 +393,8 @@ public static partial class TextShaper
                     bidiRuns,
                     bidiMap,
                     substitutions,
-                    positionings))
+                    positionings,
+                    false))
                 {
                     complete = true;
                     break;
@@ -430,7 +433,48 @@ public static partial class TextShaper
                     bidiRuns,
                     bidiMap,
                     substitutions,
-                    positionings);
+                    positionings,
+                    false);
+            }
+        }
+
+        // A selector cluster no font answered in its requested presentation takes the
+        // base glyph from the first font that maps it, so the fonts run again with the
+        // selectors ignored. A cluster no font maps at all stays missing.
+        if (!complete && positionings.HasUnmatchedVariationSequences)
+        {
+            Font? previous = null;
+            for (int i = 0; i < textRuns.Count && !complete; i++)
+            {
+                Font font = textRuns[i].ResolvedFont;
+                if (font != previous)
+                {
+                    previous = font;
+                    complete = ShapeIgnoringSelectors(text, textRuns, font, bidiRuns, bidiMap, substitutions, positionings);
+                }
+            }
+
+            foreach (Font font in fallbackFonts)
+            {
+                if (complete)
+                {
+                    break;
+                }
+
+                complete = ShapeIgnoringSelectors(text, textRuns, font, bidiRuns, bidiMap, substitutions, positionings);
+            }
+
+            if (resolverFonts is not null)
+            {
+                foreach (Font font in resolverFonts)
+                {
+                    if (complete)
+                    {
+                        break;
+                    }
+
+                    complete = ShapeIgnoringSelectors(text, textRuns, font, bidiRuns, bidiMap, substitutions, positionings);
+                }
             }
         }
 
@@ -478,6 +522,28 @@ public static partial class TextShaper
         HideDefaultIgnorables(shaped);
 
         return shaped;
+    }
+
+    /// <summary>
+    /// Shapes the whole text with <paramref name="font"/> as a fallback pass that ignores
+    /// presentation selectors, so a selector cluster no font answered takes the base
+    /// glyph from the first font that maps it.
+    /// </summary>
+    /// <param name="text">The text to process.</param>
+    /// <param name="textRuns">The ordered list of resolved text runs.</param>
+    /// <param name="font">The font to shape with.</param>
+    /// <param name="bidiRuns">The resolved bidi runs covering the whole input.</param>
+    /// <param name="bidiMap">A codepoint → bidi-run mapping accumulated across shaping passes.</param>
+    /// <param name="substitutions">The GSUB substitution buffer to write into.</param>
+    /// <param name="positionings">The GPOS positioning buffer to write into.</param>
+    /// <returns><see langword="true"/> if every codepoint mapped successfully.</returns>
+    private static bool ShapeIgnoringSelectors(ReadOnlySpan<char> text, IReadOnlyList<TextRun> textRuns, Font font, BidiRun[] bidiRuns, int[] bidiMap, ShapingBuffer substitutions, ShapingBuffer positionings)
+    {
+        int textRunIndex = 0;
+        int codePointIndex = 0;
+        int stringIndex = 0;
+        int bidiRunIndex = 0;
+        return DoFontRun(text, 0, textRuns, ref textRunIndex, ref codePointIndex, ref stringIndex, ref bidiRunIndex, true, font, bidiRuns, bidiMap, substitutions, positionings, true);
     }
 
     /// <summary>
@@ -812,6 +878,10 @@ public static partial class TextShaper
     /// <param name="bidiMap">A codepoint → bidi-run mapping accumulated across shaping passes.</param>
     /// <param name="substitutions">The GSUB substitution buffer to write into.</param>
     /// <param name="positionings">The GPOS positioning buffer to write into.</param>
+    /// <param name="ignoreVariationSelectors">
+    /// <see langword="true"/> to map a base character without regard to the presentation
+    /// its selector asks for, once no font has answered it.
+    /// </param>
     /// <returns>
     /// <see langword="true"/> if every codepoint mapped successfully; <see langword="false"/> if any
     /// codepoint remains unmapped (so a fallback-font pass is needed).
@@ -829,9 +899,10 @@ public static partial class TextShaper
         BidiRun[] bidiRuns,
         int[] bidiMap,
         ShapingBuffer substitutions,
-        ShapingBuffer positionings)
+        ShapingBuffer positionings,
+        bool ignoreVariationSelectors)
     {
-        _ = PopulateAndSubstitute(text, start, textRuns, ref textRunIndex, ref codePointIndex, ref stringIndex, ref bidiRunIndex, font, bidiRuns, bidiMap, substitutions);
+        _ = PopulateAndSubstitute(text, start, textRuns, ref textRunIndex, ref codePointIndex, ref stringIndex, ref bidiRunIndex, font, bidiRuns, bidiMap, substitutions, ignoreVariationSelectors);
 
         bool result = !isFallbackRun
             ? positionings.TryAdd(font, substitutions)
@@ -855,8 +926,12 @@ public static partial class TextShaper
     /// <param name="bidiRuns">The resolved bidi runs covering the whole input.</param>
     /// <param name="bidiMap">A codepoint → bidi-run mapping accumulated across shaping passes.</param>
     /// <param name="substitutions">The GSUB substitution buffer to write into.</param>
+    /// <param name="ignoreVariationSelectors">
+    /// <see langword="true"/> to map a base character without regard to the presentation
+    /// its selector asks for, once no font has answered it.
+    /// </param>
     /// <returns>The exclusive grapheme index reached after consuming the text.</returns>
-    private static int PopulateAndSubstitute(ReadOnlySpan<char> text, int start, IReadOnlyList<TextRun> textRuns, ref int textRunIndex, ref int codePointIndex, ref int stringIndex, ref int bidiRunIndex, Font font, BidiRun[] bidiRuns, int[] bidiMap, ShapingBuffer substitutions)
+    private static int PopulateAndSubstitute(ReadOnlySpan<char> text, int start, IReadOnlyList<TextRun> textRuns, ref int textRunIndex, ref int codePointIndex, ref int stringIndex, ref int bidiRunIndex, Font font, BidiRun[] bidiRuns, int[] bidiMap, ShapingBuffer substitutions, bool ignoreVariationSelectors)
     {
         // For each run we start with a fresh substitution buffer to avoid
         // overwriting the glyph ids.
@@ -878,7 +953,6 @@ public static partial class TextShaper
         while (graphemeEnumerator.MoveNext())
         {
             ReadOnlySpan<char> grapheme = graphemeEnumerator.CurrentSpan;
-            int graphemeMax = grapheme.Length - 1;
             int graphemeCodePointIndex = 0;
             int charIndex = 0;
 
@@ -958,6 +1032,10 @@ public static partial class TextShaper
 
                 if (skipNextCodePoint)
                 {
+                    // The preceding codepoint consumed this variation selector as a
+                    // Unicode Variation Sequence, so it produces no record of its own.
+                    skipNextCodePoint = false;
+                    charIndex += current.Utf16SequenceLength;
                     codePointIndex++;
                     graphemeCodePointIndex++;
                     continue;
@@ -965,19 +1043,38 @@ public static partial class TextShaper
 
                 bidiMap[codePointIndex] = bidiRunIndex;
 
-                int charsConsumed = 0;
+                // Peek at the codepoint that follows so the cmap can resolve a Unicode
+                // Variation Sequence, and so a presentation selector can judge the base.
+                // The peek does not move the position; the loop reaches that codepoint on
+                // its next iteration.
                 charIndex += current.Utf16SequenceLength;
-                CodePoint? next = hasVariationSequences && graphemeCodePointIndex < graphemeMax
-                    ? CodePoint.DecodeFromUtf16At(grapheme, charIndex, out charsConsumed)
+                char following = charIndex < grapheme.Length ? grapheme[charIndex] : '\0';
+                bool followedByPresentationSelector = following is (char)ShapingBuffer.TextPresentationSelector or (char)ShapingBuffer.EmojiPresentationSelector;
+                CodePoint? next = (hasVariationSequences || followedByPresentationSelector) && charIndex < grapheme.Length
+                    ? CodePoint.DecodeFromUtf16At(grapheme, charIndex, out _)
                     : null;
-
-                charIndex += charsConsumed;
 
                 // Get the glyph id for the codepoint and add to the buffer. Every
                 // codepoint enters the buffer, including unmapped default
                 // ignorables as the missing glyph: sequence matching treats them
                 // as transparent and the hide stage replaces them at the end.
                 _ = substitutions.TryGetGlyphId(font.FontMetrics, current, next, out ushort glyphId, out skipNextCodePoint);
+
+                // A base character mapped without its selector's sequence answers the
+                // selector through the font as a whole: a font with an enabled color
+                // table has the emoji presentation, a font without one the text
+                // presentation. A font with the other presentation does not have the
+                // sequence, so the cluster is missing for it and the selector goes with it.
+                if (followedByPresentationSelector && !ignoreVariationSelectors && !skipNextCodePoint && glyphId != 0)
+                {
+                    ColorFontSupport colorFontSupport = textRuns[textRunIndex].ColorFontSupport ?? substitutions.TextOptions.ColorFontSupport;
+                    if (font.FontMetrics.HasColorTable(colorFontSupport) == (following == (char)ShapingBuffer.TextPresentationSelector))
+                    {
+                        glyphId = 0;
+                        skipNextCodePoint = true;
+                        substitutions.HasUnmatchedVariationSequences = true;
+                    }
+                }
 
                 // Capture all three source coordinates while the input enumerators
                 // provide them. Later substitutions move, duplicate, or combine the

--- a/tests/Browser/EmojiPresentation.html
+++ b/tests/Browser/EmojiPresentation.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Emoji presentation browser comparison</title>
+  <style>
+    @font-face {
+      font-family: "Presentation DejaVu Sans";
+      src: url("../Fonts/DejaVuSans.ttf") format("truetype");
+      font-style: normal;
+      font-weight: 400;
+    }
+
+    @font-face {
+      font-family: "Presentation Noto Color Emoji";
+      src: url("../Fonts/NotoColorEmoji-Regular.ttf") format("truetype");
+      font-style: normal;
+      font-weight: 400;
+    }
+
+    @font-face {
+      font-family: "Presentation Arial";
+      src: url("../Fonts/arial.ttf") format("truetype");
+      font-style: normal;
+      font-weight: 400;
+    }
+
+    @font-face {
+      font-family: "Presentation Segoe UI Emoji";
+      src: url("../Fonts/seguiemj-win11.ttf") format("truetype");
+      font-style: normal;
+      font-weight: 400;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      color: #111;
+      background: #fff;
+      font-family: Arial, sans-serif;
+    }
+
+    header,
+    section {
+      padding: 16px 20px;
+      border-bottom: 1px solid #ccc;
+    }
+
+    h1,
+    h2 {
+      margin: 0 0 12px;
+      font-size: 16px;
+      font-weight: 600;
+    }
+
+    .sample {
+      margin: 0;
+      color: #000;
+      background: #fff;
+      font-size: 30pt;
+      font-kerning: normal;
+      line-height: 1.4;
+      white-space: pre;
+    }
+
+    .comparison {
+      display: grid;
+      grid-template-columns: max-content max-content;
+      gap: 24px;
+      align-items: start;
+      overflow-x: auto;
+    }
+
+    figure {
+      margin: 0;
+    }
+
+    figcaption {
+      margin-bottom: 8px;
+      color: #555;
+      font-size: 13px;
+    }
+
+    .actual-output {
+      display: block;
+      max-width: none;
+    }
+
+    .dejavu-noto {
+      font-family: "Presentation DejaVu Sans", "Presentation Noto Color Emoji";
+    }
+
+    .noto-dejavu {
+      font-family: "Presentation Noto Color Emoji", "Presentation DejaVu Sans";
+    }
+
+    .arial-segoe-dejavu {
+      font-family: "Presentation Arial", "Presentation Segoe UI Emoji", "Presentation DejaVu Sans";
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Browser emoji presentation comparison</h1>
+  </header>
+
+  <section>
+    <h2>DejaVu Sans, then Noto Color Emoji, 30pt</h2>
+    <div class="comparison">
+      <figure>
+        <figcaption>Browser</figcaption>
+        <p class="sample dejavu-noto">☀︎ ☀️ ☀ ☺︎ ☺️ ☺
+🤷🏽‍♀️ 🤷🏽 👨‍👩‍👧‍👦 ❤️‍🔥
+1️⃣ 🇯🇵 👍🏽 😀</p>
+      </figure>
+      <figure>
+        <figcaption>SixLabors.Fonts actual output</figcaption>
+        <img class="actual-output" src="../Images/ActualOutput/EmojiPresentation_BrowserComparison_DejaVuSans-NotoColorEmoji.png" alt="SixLabors.Fonts DejaVu Sans then Noto Color Emoji output">
+      </figure>
+    </div>
+  </section>
+
+  <section>
+    <h2>Noto Color Emoji, then DejaVu Sans, 30pt</h2>
+    <div class="comparison">
+      <figure>
+        <figcaption>Browser</figcaption>
+        <p class="sample noto-dejavu">☀︎ ☀️ ☀ ☺︎ ☺️ ☺
+🤷🏽‍♀️ 🤷🏽 👨‍👩‍👧‍👦 ❤️‍🔥
+1️⃣ 🇯🇵 👍🏽 😀</p>
+      </figure>
+      <figure>
+        <figcaption>SixLabors.Fonts actual output</figcaption>
+        <img class="actual-output" src="../Images/ActualOutput/EmojiPresentation_BrowserComparison_NotoColorEmoji-DejaVuSans.png" alt="SixLabors.Fonts Noto Color Emoji then DejaVu Sans output">
+      </figure>
+    </div>
+  </section>
+
+  <section>
+    <h2>Arial, then Segoe UI Emoji, then DejaVu Sans, 30pt</h2>
+    <div class="comparison">
+      <figure>
+        <figcaption>Browser</figcaption>
+        <p class="sample arial-segoe-dejavu">☀︎ ☀️ ☀ ☺︎ ☺️ ☺
+🤷🏽‍♀️ 🤷🏽 👨‍👩‍👧‍👦 ❤️‍🔥
+1️⃣ 🇯🇵 👍🏽 😀</p>
+      </figure>
+      <figure>
+        <figcaption>SixLabors.Fonts actual output</figcaption>
+        <img class="actual-output" src="../Images/ActualOutput/EmojiPresentation_BrowserComparison_Arial-SegoeUIEmoji-DejaVuSans.png" alt="SixLabors.Fonts Arial then Segoe UI Emoji then DejaVu Sans output">
+      </figure>
+    </div>
+  </section>
+</body>
+</html>

--- a/tests/Images/ReferenceOutput/EmojiPresentation_BrowserComparison_Arial-SegoeUIEmoji-DejaVuSans.png
+++ b/tests/Images/ReferenceOutput/EmojiPresentation_BrowserComparison_Arial-SegoeUIEmoji-DejaVuSans.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fb89c48143cc1c256357e7187db24b60492148395df1c6d8a4e1f017bc57c1a
+size 13897

--- a/tests/Images/ReferenceOutput/EmojiPresentation_BrowserComparison_DejaVuSans-NotoColorEmoji.png
+++ b/tests/Images/ReferenceOutput/EmojiPresentation_BrowserComparison_DejaVuSans-NotoColorEmoji.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e445a6fc37cdadf0d1e667f1d0331275321473656231a4fbaf13ad31ed6b77c
+size 20202

--- a/tests/Images/ReferenceOutput/EmojiPresentation_BrowserComparison_NotoColorEmoji-DejaVuSans.png
+++ b/tests/Images/ReferenceOutput/EmojiPresentation_BrowserComparison_NotoColorEmoji-DejaVuSans.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd7a328bb61e65f70ae3a09dba340b52d8e0314ba6ef76f4667f67007132c91a
+size 24264

--- a/tests/SixLabors.Fonts.Tests/EmojiPresentationFallbackTests.cs
+++ b/tests/SixLabors.Fonts.Tests/EmojiPresentationFallbackTests.cs
@@ -1,0 +1,404 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using HarfBuzzSharp;
+using HBFace = HarfBuzzSharp.Face;
+using HBFont = HarfBuzzSharp.Font;
+using SixLabors.Fonts.Rendering;
+using SixLabors.Fonts.Unicode;
+
+namespace SixLabors.Fonts.Tests;
+
+/// <summary>
+/// Font fallback with a text font and a color emoji font: a presentation selector decides which
+/// font owns the cluster, and an emoji sequence stays in one font as one glyph.
+/// </summary>
+public class EmojiPresentationFallbackTests
+{
+    // The sun has text presentation by default. U+FE0E asks for the text glyph, U+FE0F for the emoji glyph.
+    private const string Suns = "☀︎ ☀️ ☀";
+
+    // The shrug with a skin tone joined to the female sign with emoji presentation, then the plain shrug.
+    private const string Shrugs = "🤷🏽‍♀️ 🤷🏽";
+
+    // The text that tests/Browser/EmojiPresentation.html renders: text presentation, emoji presentation and
+    // no selector for two symbols, then joiner, modifier, keycap and flag sequences, and a face that
+    // DejaVu Sans maps without a selector.
+    private const string ComparisonText = "☀︎ ☀️ ☀ ☺︎ ☺️ ☺\n🤷🏽‍♀️ 🤷🏽 👨‍👩‍👧‍👦 ❤️‍🔥\n1️⃣ 🇯🇵 👍🏽 😀";
+
+    private static readonly CodePoint Sun = new(0x2600);
+
+    private static readonly CodePoint SmilingFace = new(0x263A);
+
+    private const int TextPresentationSelector = 0xFE0E;
+
+    /// <summary>
+    /// Gets the color emoji fonts in the test set: COLR v1, COLR v0 with a cmap format 14, and COLR v0.
+    /// </summary>
+    public static TheoryData<string> ColorEmojiFonts { get; } = new()
+    {
+        TestFonts.NotoColorEmojiRegular,
+        TestFonts.SegoeuiEmojiFile,
+        TestFonts.TwemojiMozillaFile
+    };
+
+    /// <summary>
+    /// Gets the sequences a text font maps only in part, paired with every color emoji font. DejaVu Sans
+    /// maps the digit, the heart, the joiner and the selectors but none of the emoji, so each
+    /// cluster must move to the emoji font as a whole.
+    /// </summary>
+    public static TheoryData<string, string> SequencesAndColorEmojiFonts { get; } = BuildSequenceCases();
+
+    /// <summary>
+    /// Gets the font chains that tests/Browser/EmojiPresentation.html renders beside the output, with the index
+    /// of the chain font that owns each cluster of <see cref="ComparisonText"/>, whitespace excluded. A text
+    /// selector takes the first font whose glyph is not painted, an emoji selector the first font whose glyph
+    /// is painted, and a cluster without a selector the first font that maps all of it.
+    /// </summary>
+    public static TheoryData<string, string[], int[]> BrowserComparisonChains { get; } = new()
+    {
+        {
+            "DejaVuSans-NotoColorEmoji",
+            [TestFonts.Anchor2FontFile, TestFonts.NotoColorEmojiRegular],
+            [0, 1, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0]
+        },
+        {
+            "NotoColorEmoji-DejaVuSans",
+            [TestFonts.NotoColorEmojiRegular, TestFonts.Anchor2FontFile],
+            [1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        },
+        {
+            "Arial-SegoeUIEmoji-DejaVuSans",
+            [TestFonts.Arial, TestFonts.SegoeuiEmojiFile, TestFonts.Anchor2FontFile],
+            [2, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1]
+        }
+    };
+
+    [Fact]
+    public void TextFontFirst_SelectorsChooseTheFont()
+    {
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily emoji = TestFonts.GetFontFamily(TestFonts.NotoColorEmojiRegular);
+
+        GlyphRendererParameters[] suns = RenderSuns(text, emoji);
+
+        Assert.Equal(3, suns.Length);
+        AssertFont(text, suns[0]);
+        AssertFont(emoji, suns[1]);
+        AssertFont(text, suns[2]);
+        Assert.Equal(GlyphType.Painted, suns[1].GlyphType);
+    }
+
+    [Fact]
+    public void EmojiFontFirst_SelectorsChooseTheFont()
+    {
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily emoji = TestFonts.GetFontFamily(TestFonts.NotoColorEmojiRegular);
+
+        GlyphRendererParameters[] suns = RenderSuns(emoji, text);
+
+        Assert.Equal(3, suns.Length);
+        AssertFont(text, suns[0]);
+        AssertFont(emoji, suns[1]);
+        AssertFont(emoji, suns[2]);
+    }
+
+    [Fact]
+    public void NoColorFont_EmojiSelectorTakesTheBaseGlyph()
+    {
+        // Neither font has a color table, so no font answers ☀️ and the pass that ignores
+        // the selector takes the base glyph from the first font that maps it.
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily other = TestFonts.GetFontFamily(TestFonts.OpenSansFile);
+
+        GlyphRendererParameters[] suns = RenderSuns(text, other);
+
+        Assert.Equal(3, suns.Length);
+        Assert.All(suns, sun => AssertFont(text, sun));
+        Assert.All(suns, sun => Assert.Equal(GlyphType.Standard, sun.GlyphType));
+    }
+
+    [Fact]
+    public void TextFontFirst_ZwjSequenceStaysInTheEmojiFont()
+    {
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily emoji = TestFonts.GetFontFamily(TestFonts.NotoColorEmojiRegular);
+        TextOptions options = new(text.CreateFont(48))
+        {
+            FallbackFontFamilies = [emoji]
+        };
+
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, Shrugs, options);
+        string textFont = text.Name.ToUpperInvariant();
+
+        // Both clusters render as one painted glyph each from the emoji font. The text font
+        // keeps only the space; it must not keep the female sign out of the first cluster.
+        GlyphRendererParameters[] painted = renderer.GlyphKeys.Where(k => k.GlyphType == GlyphType.Painted).ToArray();
+        Assert.Equal(2, painted.Length);
+        Assert.All(painted, glyph => AssertFont(emoji, glyph));
+        Assert.NotEqual(painted[0].GlyphId, painted[1].GlyphId);
+        Assert.DoesNotContain(renderer.GlyphKeys, k => k.Font == textFont && k.CodePoint.Value != 0x20);
+        Assert.DoesNotContain(renderer.GlyphKeys, k => k.GlyphType == GlyphType.Fallback);
+    }
+
+    [Theory]
+    [MemberData(nameof(ColorEmojiFonts))]
+    public void TextFontFirst_SelectorsChooseTheFont_ForEveryColorFont(string emojiFile)
+    {
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily emoji = TestFonts.GetFontFamily(emojiFile);
+
+        GlyphRendererParameters[] suns = RenderSuns(text, emoji);
+
+        Assert.Equal(3, suns.Length);
+        AssertFont(text, suns[0]);
+        AssertFont(emoji, suns[1]);
+        AssertFont(text, suns[2]);
+        Assert.Equal(GlyphType.Painted, suns[1].GlyphType);
+    }
+
+    [Theory]
+    [MemberData(nameof(ColorEmojiFonts))]
+    public void EmojiFontFirst_SelectorsChooseTheFont_ForEveryColorFont(string emojiFile)
+    {
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily emoji = TestFonts.GetFontFamily(emojiFile);
+
+        GlyphRendererParameters[] suns = RenderSuns(emoji, text);
+
+        Assert.Equal(3, suns.Length);
+        AssertFont(text, suns[0]);
+        AssertFont(emoji, suns[1]);
+        AssertFont(emoji, suns[2]);
+    }
+
+    [Fact]
+    public void ArialThenSegoeUIEmoji_TextSelectorWithoutAPlainSunTakesTheBaseGlyph()
+    {
+        // Arial has no sun and Segoe UI Emoji has a color table, so no font answers ☀︎ and
+        // the pass that ignores the selector takes the base glyph from Segoe UI Emoji.
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Arial);
+        FontFamily emoji = TestFonts.GetFontFamily(TestFonts.SegoeuiEmojiFile);
+
+        GlyphRendererParameters[] suns = RenderSuns(text, emoji);
+
+        Assert.Equal(3, suns.Length);
+        Assert.All(suns, sun => AssertFont(emoji, sun));
+        Assert.All(suns, sun => Assert.Equal(GlyphType.Painted, sun.GlyphType));
+        Assert.Equal(suns[2].GlyphId, suns[0].GlyphId);
+    }
+
+    [Theory]
+    [MemberData(nameof(ColorEmojiFonts))]
+    public void ColorFontAlone_TextSelectorTakesTheBaseGlyph(string emojiFile)
+    {
+        // None of the color fonts declares the sun's text selector sequence, and each has a
+        // color table, so none answers ☀︎ and the pass that ignores the selector takes the base glyph.
+        Assert.False(TryGetVariationGlyph(emojiFile, TextPresentationSelector, out _));
+
+        FontFamily emoji = TestFonts.GetFontFamily(emojiFile);
+        TextOptions options = new(emoji.CreateFont(48));
+
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, Suns, options);
+        GlyphRendererParameters[] suns = renderer.GlyphKeys.Where(k => k.CodePoint == Sun).ToArray();
+
+        Assert.Equal(3, suns.Length);
+        Assert.All(suns, sun => AssertFont(emoji, sun));
+        Assert.All(suns, sun => Assert.Equal(GlyphType.Painted, sun.GlyphType));
+        Assert.Equal(suns[2].GlyphId, suns[0].GlyphId);
+    }
+
+    [Fact]
+    public void ColorSupportNone_EmojiSelectorTakesTheFirstFontsBaseGlyph()
+    {
+        // With no color format enabled no font counts as a color font, so no font answers
+        // ☀️ and the pass that ignores the selector takes the base glyph from the first font.
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily emoji = TestFonts.GetFontFamily(TestFonts.NotoColorEmojiRegular);
+        TextOptions options = new(text.CreateFont(48))
+        {
+            ColorFontSupport = ColorFontSupport.None,
+            FallbackFontFamilies = [emoji]
+        };
+
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, Suns, options);
+        GlyphRendererParameters[] suns = renderer.GlyphKeys.Where(k => k.CodePoint == Sun).ToArray();
+
+        Assert.Equal(3, suns.Length);
+        Assert.All(suns, sun => AssertFont(text, sun));
+        Assert.All(suns, sun => Assert.Equal(GlyphType.Standard, sun.GlyphType));
+    }
+
+    [Fact]
+    public void ArialThenSegoeUIEmoji_SmilingFaceSelectorsChooseTheFont()
+    {
+        // Arial maps the smiling face, and Segoe UI Emoji declares the emoji sequence in its cmap.
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Arial);
+        FontFamily emoji = TestFonts.GetFontFamily(TestFonts.SegoeuiEmojiFile);
+        TextOptions options = new(text.CreateFont(48))
+        {
+            FallbackFontFamilies = [emoji]
+        };
+
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, "☺︎ ☺️ ☺", options);
+        GlyphRendererParameters[] faces = renderer.GlyphKeys.Where(k => k.CodePoint == SmilingFace).ToArray();
+
+        Assert.Equal(3, faces.Length);
+        AssertFont(text, faces[0]);
+        AssertFont(emoji, faces[1]);
+        AssertFont(text, faces[2]);
+        Assert.Equal(GlyphType.Painted, faces[1].GlyphType);
+    }
+
+    [Fact]
+    public void MonochromeEmojiFont_EmojiSelectorTakesTheBaseGlyph()
+    {
+        // Neither font has a color table, so no font answers ☀️ and the pass that ignores
+        // the selector takes the base glyph from the first font that maps it.
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily monochrome = TestFonts.GetFontFamily(TestFonts.NotoEmojiVariableFont);
+
+        GlyphRendererParameters[] suns = RenderSuns(text, monochrome);
+
+        Assert.Equal(3, suns.Length);
+        Assert.All(suns, sun => AssertFont(text, sun));
+        Assert.All(suns, sun => Assert.Equal(GlyphType.Standard, sun.GlyphType));
+    }
+
+    [Fact]
+    public void MonochromeEmojiFont_ReplacesAClusterTheTextFontCannotMap()
+    {
+        // Noto Emoji maps both shrugs as plain glyphs. No font answers the U+FE0F of the
+        // first, so the pass that ignores the selector takes Noto Emoji's glyphs for it too.
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily monochrome = TestFonts.GetFontFamily(TestFonts.NotoEmojiVariableFont);
+        TextOptions options = new(text.CreateFont(48))
+        {
+            FallbackFontFamilies = [monochrome]
+        };
+
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, Shrugs, options);
+        string textFont = text.Name.ToUpperInvariant();
+
+        Assert.DoesNotContain(renderer.GlyphKeys, k => k.GlyphType == GlyphType.Fallback);
+        Assert.DoesNotContain(renderer.GlyphKeys, k => k.Font == textFont && k.CodePoint.Value != 0x20);
+        Assert.Contains(renderer.GlyphKeys, k => k.Font != textFont && k.GlyphId != 0 && k.GlyphType == GlyphType.Standard);
+    }
+
+    [Theory]
+    [MemberData(nameof(SequencesAndColorEmojiFonts))]
+    public void TextFontFirst_SequenceStaysInTheEmojiFont(string sequence, string emojiFile)
+    {
+        FontFamily text = TestFonts.GetFontFamily(TestFonts.Anchor2FontFile);
+        FontFamily emoji = TestFonts.GetFontFamily(emojiFile);
+        TextOptions options = new(text.CreateFont(48))
+        {
+            FallbackFontFamilies = [emoji]
+        };
+
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, sequence, options);
+        string textFont = text.Name.ToUpperInvariant();
+
+        // Every visible glyph is a painted glyph of the emoji font. Segoe UI Emoji builds
+        // the family from several positioned glyphs, so the count is not fixed.
+        Assert.DoesNotContain(renderer.GlyphKeys, k => k.GlyphType == GlyphType.Fallback);
+        Assert.DoesNotContain(renderer.GlyphKeys, k => k.Font == textFont);
+        Assert.Contains(renderer.GlyphKeys, k => k.GlyphType == GlyphType.Painted);
+        Assert.All(renderer.GlyphKeys.Where(k => k.GlyphType == GlyphType.Painted), glyph => AssertFont(emoji, glyph));
+    }
+
+    [Theory]
+    [MemberData(nameof(BrowserComparisonChains))]
+    public void EmojiPresentation_BrowserComparison(string chainName, string[] fontFiles, int[] fontIndexes)
+    {
+        FontCollection collection = new();
+        FontFamily[] chain = Array.ConvertAll(fontFiles, file => TestFonts.GetFontFamily(collection, file));
+        TextOptions options = new(chain[0].CreateFont(30))
+        {
+            Dpi = 96F,
+            LineSpacing = 1.4F,
+            FallbackFontFamilies = chain[1..]
+        };
+
+        // Selectors and joiners are default ignorable and render nothing, so they are left out.
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, ComparisonText, options);
+        IGrouping<int, GlyphRendererParameters>[] clusters = renderer.GlyphKeys
+            .Where(k => !CodePoint.IsWhiteSpace(k.CodePoint))
+            .GroupBy(k => k.GraphemeIndex)
+            .OrderBy(g => g.Key)
+            .ToArray();
+
+        Assert.Equal(fontIndexes.Length, clusters.Length);
+        for (int i = 0; i < clusters.Length; i++)
+        {
+            FontFamily expected = chain[fontIndexes[i]];
+            GlyphRendererParameters[] visible = clusters[i].Where(k => !CodePoint.IsVariationSelector(k.CodePoint) && !CodePoint.IsZeroWidthJoiner(k.CodePoint)).ToArray();
+            Assert.NotEmpty(visible);
+            Assert.All(visible, glyph =>
+            {
+                AssertFont(expected, glyph);
+                Assert.NotEqual((ushort)0, glyph.GlyphId);
+                Assert.NotEqual(GlyphType.Fallback, glyph.GlyphType);
+            });
+        }
+
+        // A string property is decorated in the file name. The formattable string keeps the chain name plain.
+        FormattableString name = $"{chainName}";
+        TextLayoutTestUtilities.TestLayout(ComparisonText, options, properties: [name]);
+    }
+
+    private static TheoryData<string, string> BuildSequenceCases()
+    {
+        // Keycap, flag, joiner with a selector inside, modifier, and the family joiner sequence.
+        // Segoe UI Emoji draws no country flags; a regional indicator pair renders as two
+        // outline letters there, so the flag is paired with the other two fonts only.
+        const string flag = "🇯🇵";
+        string[] sequences = ["1️⃣", flag, "❤️‍🔥", "👍🏽", "👨‍👩‍👧‍👦"];
+        string[] fonts = [TestFonts.NotoColorEmojiRegular, TestFonts.SegoeuiEmojiFile, TestFonts.TwemojiMozillaFile];
+        TheoryData<string, string> cases = [];
+        foreach (string sequence in sequences)
+        {
+            foreach (string font in fonts)
+            {
+                if (sequence == flag && font == TestFonts.SegoeuiEmojiFile)
+                {
+                    continue;
+                }
+
+                cases.Add(sequence, font);
+            }
+        }
+
+        return cases;
+    }
+
+    private static GlyphRendererParameters[] RenderSuns(FontFamily primary, FontFamily fallback)
+    {
+        TextOptions options = new(primary.CreateFont(48))
+        {
+            FallbackFontFamilies = [fallback]
+        };
+
+        GlyphRenderer renderer = new();
+        TextRenderer.RenderTo(renderer, Suns, options);
+        return renderer.GlyphKeys.Where(k => k.CodePoint == Sun).ToArray();
+    }
+
+    private static void AssertFont(FontFamily expected, GlyphRendererParameters glyph)
+        => Assert.Equal(expected.Name.ToUpperInvariant(), glyph.Font);
+
+    private static bool TryGetVariationGlyph(string fontFile, int selector, out uint glyph)
+    {
+        using Blob blob = Blob.FromFile(fontFile);
+        using HBFace face = new(blob, 0);
+        using HBFont font = new(face);
+        return font.TryGetVariationGlyph((uint)Sun.Value, (uint)selector, out glyph);
+    }
+}

--- a/tests/SixLabors.Fonts.Tests/HarfBuzzDifferentialTests.cs
+++ b/tests/SixLabors.Fonts.Tests/HarfBuzzDifferentialTests.cs
@@ -41,6 +41,20 @@ public class HarfBuzzDifferentialTests
             { TestFonts.NotoColorEmojiRegular, "\u2764\uFE0F\u200D\U0001F525", false },
             { TestFonts.NotoColorEmojiRegular, "\u2764\uFE0F\u200D\U0001FA79", false },
 
+            // Emoji sequences from ImageSharp.Drawing discussion 418: the family joiner sequence,
+            // the shrug with a skin tone modifier with and without the female sign and its
+            // emoji presentation selector, and the sun with text and emoji presentation selectors.
+            // The shaping API returns what HarfBuzz returns for a selector the font cannot
+            // answer; the layout applies the request. Twemoji Mozilla has no space glyph, so
+            // its hidden selectors are deleted rather than replaced by a zero-advance space.
+            { TestFonts.SegoeuiEmojiFile, "👨‍👩‍👧‍👦", false },
+            { TestFonts.SegoeuiEmojiFile, "🤷🏽‍♀️ 🤷🏽", false },
+            { TestFonts.SegoeuiEmojiFile, "☀︎ ☀️", false },
+            { TestFonts.NotoColorEmojiRegular, "👨‍👩‍👧‍👦", false },
+            { TestFonts.NotoColorEmojiRegular, "🤷🏽‍♀️ 🤷🏽", false },
+            { TestFonts.NotoColorEmojiRegular, "☀︎ ☀️", false },
+            { TestFonts.TwemojiMozillaFile, "☀︎ ☀️", false },
+
             // Joiners inside shaping contexts: the joiner must steer the shaping
             // (ligature suppression/formation, joining forms, half forms) and then
             // render invisibly at zero advance.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/Fonts/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Map a base character followed by U+FE0E or U+FE0F the way Chromium does: the cmap format 14 pair first, then the font as a whole decides the presentation. A font with a color table the options enable answers U+FE0F and a font without one answers U+FE0E; the other way round the cluster is missing for that font and the next font is asked. When no font answers, the fonts run once more with the selectors ignored so the first font that maps the base glyph supplies it.

A selector a font does not declare passes through as a hidden ignorable, as HarfBuzz keeps it, and a substituted ignorable is no longer transparent to sequence matching. Default ignorables without a glyph are hidden, not missing.

Add EmojiPresentationFallbackTests with the per-cluster font assertions for the three browser comparison chains, the rendered references, and tests/Browser/EmojiPresentation.html to place the browser rendering beside the output. Add the [discussion 418](https://github.com/SixLabors/ImageSharp.Drawing/discussions/418) sequences to the HarfBuzz differential suite.

<!-- Thanks for contributing to SixLabors.Fonts! -->
